### PR TITLE
feat: add Lessons endpoint for observation approaches

### DIFF
--- a/tasks/apps/tree/urls.py
+++ b/tasks/apps/tree/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
     re_path(r'^observations/(?P<observation_id>[a-f0-9\-]+)/$', views.observation_edit, name='public-observation-edit'),
     path('observations/', views.ObservationListView.as_view(), name='public-observation-list'),
     path('observations/closed/', views.ObservationClosedListView.as_view(), name='public-observation-list-closed'),
+    path('lessons/', views.LessonsListView.as_view(), name='public-lessons-list'),
     path('observations/<int:observation_id>/journalize/', views.migrate_observation_updates_to_journal, name='public-observation-journalize'),
     path('diary/<int:year>/<int:month>/', views.JournalArchiveMonthView.as_view(month_format="%m"), name='public-diary-archive-month'),
     path('diary/', views.JournalCurrentMonthArchiveView.as_view(month_format="%m"), name='public-diary-archive-current-month'),

--- a/tasks/apps/tree/views.py
+++ b/tasks/apps/tree/views.py
@@ -619,6 +619,27 @@ class ObservationClosedListView(ListView):
 
         return context
 
+class LessonsListView(ListView):
+    model = ObservationClosed
+    template_name = 'tree/lessons_list.html'
+    paginate_by = 100
+
+    def get_queryset(self):
+        return ObservationClosed.objects \
+            .select_related('thread', 'type') \
+            .exclude(approach__isnull=True) \
+            .exclude(approach__exact='') \
+            .exclude(approach__exact='?') \
+            .order_by('-published')
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        context['open_count'] = Observation.objects.count()
+        context['closed_count'] = ObservationClosed.objects.count()
+
+        return context
+
 def observation_closed_detail(request, event_stream_id):
     observation_closed = get_object_or_404(ObservationClosed, event_stream_id=event_stream_id)
     

--- a/tasks/assets/styles/tree.scss
+++ b/tasks/assets/styles/tree.scss
@@ -525,3 +525,10 @@
   }
 }
 
+.situation-italic {
+  font-style: italic;
+  font-size: 0.9em;
+  color: #666;
+  margin-top: 0.5em;
+}
+

--- a/tasks/templates/tree/lessons_list.html
+++ b/tasks/templates/tree/lessons_list.html
@@ -3,7 +3,7 @@
 
 {% block body_class %}page-daily{% endblock %}
 
-{% block title %}Closed Observations | Tasks Collector{% endblock %}
+{% block title %}Lessons | Tasks Collector{% endblock %}
 {% block content %}
 <!-- Vue entry-point -->
 
@@ -27,14 +27,13 @@
                 <span class="thread">{{ observation.thread }}</span> 
                 <a href="{% url 'public-observation-closed-detail' observation.event_stream_id %}">$</a>)
             </div>
-            <div class="strong">{{ observation.situation|linebreaks }}</div>
+            <div class="strong">{{ observation.approach|linebreaks }}</div>
+            <div class="situation-italic">{{ observation.situation|linebreaks }}</div>
 
             <div class="expand">
-            <div class="label">How you saw it, what you felt?</div>
-            <div>{{ observation.interpretation|linebreaks }}</div>
-            <div class="label">How should you approach it in the future?</div>
-            <div>{{ observation.approach|linebreaks }}</div>
-            </div>
+                <div class="label">How you saw it, what you felt?</div>
+                <div>{{ observation.interpretation|linebreaks }}</div>
+            </div>            
         </article>
 
         {% empty %}
@@ -43,10 +42,8 @@
         </div>
         {% endfor %}
 </div>
-
 {% endblock %}
 
 <!-- Load Vue app -->
 {% block extrajs %}
 {% endblock %}
-

--- a/tasks/templates/tree/observation_list.html
+++ b/tasks/templates/tree/observation_list.html
@@ -16,6 +16,7 @@
         <p class="menu observation with-badges">
             <a href="/observations/">Open <span class="badge">{{ open_count }}</span></a>
             <a href="/observations/closed/">Closed <span class="badge">{{ closed_count }}</span></a>
+            <a href="/lessons/">Lessons</a>
         </p>
     </div>
         {% for observation in object_list %}


### PR DESCRIPTION
## Summary
- Add new `/lessons/` endpoint that displays closed observations with focus on the approach field
- Show approach field prominently first and situation field smaller in italic font
- Filter out observations with empty, null, or '?' approach values to show only meaningful lessons
- Add "Lessons" navigation link to both observations and closed observations pages

## Test plan
- [x] Visit `/lessons/` endpoint and verify it displays observations with approach field first
- [x] Verify situation field appears smaller and in italic
- [x] Confirm observations with empty/null/'?' approach values are filtered out
- [x] Check navigation links work from `/observations/` and `/observations/closed/` pages
- [x] Verify styling and layout match design requirements

🤖 Generated with [Claude Code](https://claude.ai/code)