### PR TITLE
feat: enhance /q/ page with content type selection and focus display

### DIFF
--- a/tasks/apps/tree/forms.py
+++ b/tasks/apps/tree/forms.py
@@ -32,6 +32,35 @@ class QuickNoteForm(forms.ModelForm):
             "note"
         ]
 
+class QuickContentForm(forms.Form):
+    CONTENT_TYPE_CHOICES = [
+        ('quick_note', 'Quick Note'),
+        ('task', 'Task to Do'),
+        ('plan_focus', 'Plan Focus'),
+    ]
+    
+    content_type = forms.ChoiceField(
+        choices=CONTENT_TYPE_CHOICES,
+        initial='quick_note',
+        widget=forms.Select(attrs={'id': 'content-type-selector'})
+    )
+    
+    content = forms.CharField(
+        widget=forms.Textarea(attrs={'rows': 3, 'placeholder': 'Enter your content...'}),
+        max_length=1000
+    )
+    
+    focus_timeframe = forms.ChoiceField(
+        choices=[
+            ('today', 'Today'),
+            ('tomorrow', 'Tomorrow'),
+            ('this_week', 'This Week'),
+        ],
+        initial='today',
+        required=False,
+        widget=forms.Select(attrs={'id': 'focus-timeframe'})
+    )
+
 class SingleHabitTrackedForm(forms.Form):
     text = forms.CharField(max_length=255)
     

--- a/tasks/templates/tree/quick_note.html
+++ b/tasks/templates/tree/quick_note.html
@@ -26,6 +26,30 @@
             </div>
         {% endfor %}
     </div>
+
+    <!-- Current Plans -->
+    <div class="current-plans">
+        {% if daily_plan and daily_plan.focus %}
+            <div class="plan-focus daily">
+                <h4>Daily Focus</h4>
+                <div class="focus-content">{{ daily_plan.focus|linebreaks }}</div>
+            </div>
+        {% endif %}
+        
+        {% if weekly_plan and weekly_plan.focus %}
+            <div class="plan-focus weekly">
+                <h4>Weekly Focus</h4>
+                <div class="focus-content">{{ weekly_plan.focus|linebreaks }}</div>
+            </div>
+        {% endif %}
+        
+        {% if big_picture_plan and big_picture_plan.focus %}
+            <div class="plan-focus big-picture">
+                <h4>Big Picture Focus</h4>
+                <div class="focus-content">{{ big_picture_plan.focus|linebreaks }}</div>
+            </div>
+        {% endif %}
+    </div>
 </section>
 
 {% endblock %}

--- a/tasks/templates/tree/quick_note/form.html
+++ b/tasks/templates/tree/quick_note/form.html
@@ -1,7 +1,34 @@
-{{ form.as_p }}
+{{ form.content.label_tag }}
+{{ form.content }}
+
+{{ form.content_type.label_tag }}
+{{ form.content_type }}
+
+<div id="focus-timeframe-container" style="display:none;">
+    {{ form.focus_timeframe.label_tag }}
+    {{ form.focus_timeframe }}
+</div>
 
 {% csrf_token %}
 
 <div class="">
     <button type="submit">Add</button>
 </div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const contentTypeSelect = document.getElementById('content-type-selector');
+    const focusTimeframeContainer = document.getElementById('focus-timeframe-container');
+    
+    function toggleFocusTimeframe() {
+        if (contentTypeSelect.value === 'plan_focus') {
+            focusTimeframeContainer.style.display = 'block';
+        } else {
+            focusTimeframeContainer.style.display = 'none';
+        }
+    }
+    
+    contentTypeSelect.addEventListener('change', toggleFocusTimeframe);
+    toggleFocusTimeframe(); // Initial check
+});
+</script>


### PR DESCRIPTION
## Summary
- Enhanced the /q/ page with a select field to choose between 3 content types: quick note, task, and plan focus
- Added display of current focuses from Daily, Weekly, and big-picture plans
- Refactored task creation logic to eliminate code duplication

## Changes
- **New QuickContentForm**: Replaces simple QuickNoteForm with content type selection and conditional timeframe field
- **Task Management**: Tasks now added to Inbox thread, with shared helper function `_add_task_to_board()`
- **Plan Focus**: Appends to existing plan focus content rather than replacing it
- **Focus Display**: Shows current Daily/Weekly/big-picture focuses on /q/ page when present
- **Dynamic UI**: JavaScript toggles timeframe selector visibility based on content type

## Test plan
- [x] Verify /q/ page loads with new form layout
- [x] Test adding quick notes (default behavior preserved)
- [x] Test adding tasks to Inbox board
- [x] Test adding plan focus for today/tomorrow/this week
- [x] Verify focus timeframe field shows/hides correctly
- [x] Confirm existing plan focus content gets appended to, not replaced
- [x] Check that Daily/Weekly/big-picture focuses display when present

🤖 Generated with [Claude Code](https://claude.ai/code)