### PR TITLE
feat: add weekly and monthly summary indicators to calendar

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -125,7 +125,7 @@
   - [x] Mark 4 with two violet dots and 5 with one violet dot
   - [x] Remove task on 5 (~1.25 month)
   - [x] Made progress resets
-- [ ] Add markings if weekly summary and monthy summary has been added for this period
+- [x] Add markings if weekly summary and monthy summary has been added for this period
 - [ ] How about I do the AREAS for life?
   - [ ] To mark then reflection templates (weekly monthly)
 - [x] If it has leaves, don't progress marks on the category – set to 0

--- a/tasks/assets/styles/example.scss
+++ b/tasks/assets/styles/example.scss
@@ -1242,18 +1242,22 @@ body.quick-notes {
 
 .calendar {
     display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-start;
     flex-direction: column;
     gap: 2px;
     padding: 2px;
     background-color: #f0f0f0;
     border-radius: 4px;
-    align-content: flex-start;
     margin: 0 auto;
     width: fit-content;
 
-    height: 86px;
+    .calendar-daily-row {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-start;
+        flex-direction: column;
+        gap: 2px;
+        height: 84px; // Original height for daily events
+    }
 
     .event-day {
         width: 10px;
@@ -1264,6 +1268,46 @@ body.quick-notes {
 
         &[data-count="0"] {
             opacity: 0.5;
+        }
+    }
+
+    .calendar-row {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-start;
+        flex-direction: column;
+        gap: 2px;
+        height: 12px; // Height for summary rows
+    }
+
+    .summary-day {
+        width: 10px;
+        height: 10px;
+        aspect-ratio: 1 / 1;
+        border-radius: 2px;
+
+        &[data-has-summary="0"] {
+            opacity: 0.3;
+        }
+
+        &[data-has-summary="1"] {
+            opacity: 1;
+        }
+    }
+
+    .weekly-summary {
+        background-color: #4a90e2; // Blue color for weekly summaries
+
+        &[data-has-summary="0"] {
+            background-color: #4a90e2;
+        }
+    }
+
+    .monthly-summary {
+        background-color: #f5d842; // Yellow color for monthly summaries
+
+        &[data-has-summary="0"] {
+            background-color: #f5d842;
         }
     }
 }

--- a/tasks/templates/tree/calendar.html
+++ b/tasks/templates/tree/calendar.html
@@ -1,11 +1,35 @@
 
 
+<div class="calendar-daily-row">
 {% for event in event_calendar %}
-    <div 
-        title="{{ event.count }} contribution{{ event.count|pluralize }} on {{ event.date|date:"Y-m-d" }}" 
-        class="event-day" 
-        data-count="{{ event.count }}" 
+    <div
+        title="{{ event.count }} contribution{{ event.count|pluralize }} on {{ event.date|date:"Y-m-d" }}"
+        class="event-day"
+        data-count="{{ event.count }}"
         data-date="{{ event.date|date:"Y-m-d" }}"
     ></div>
 {% endfor %}
+</div>
+
+<div class="calendar-row weekly-summary-row">
+    {% for event in weekly_summary_calendar %}
+        <div
+            title="{% if event.count %}Weekly summary available{% else %}No weekly summary{% endif %} for week ending {{ event.date|date:"M d, Y" }}"
+            class="summary-day weekly-summary"
+            data-has-summary="{{ event.count }}"
+            data-date="{{ event.date|date:"Y-m-d" }}"
+        ></div>
+    {% endfor %}
+</div>
+
+<div class="calendar-row monthly-summary-row">
+    {% for event in monthly_summary_calendar %}
+        <div
+            title="{% if event.count %}Monthly summary available{% else %}No monthly summary{% endif %} for {{ event.date|date:"F Y" }}"
+            class="summary-day monthly-summary"
+            data-has-summary="{{ event.count }}"
+            data-date="{{ event.date|date:"Y-m-d" }}"
+        ></div>
+    {% endfor %}
+</div>
 


### PR DESCRIPTION
## Summary
- Added blue row for weekly summary indicators (one indicator per week)
- Added yellow row for monthly summary indicators (spans entire months with summaries)
- Calendar now displays three rows: daily events (green), weekly summaries (blue), monthly summaries (yellow)

## Implementation Details
- Created flexible period-based calendar system using (start, end) tuples as Counter keys
- Added helper functions for week/month period calculation: `get_week_period()`, `get_month_period()`
- Implemented `get_summary_calendar()` generic function for any period type
- Updated calendar layout to display summary rows below daily events
- Weekly indicators appear on weeks containing Weekly thread reflections
- Monthly indicators highlight all weeks within months that have big-picture reflections

## Visual Changes
- Blue boxes appear for weeks with weekly summaries (Sundays)
- Yellow blocks span entire months with monthly summaries (last day of month)
- Semi-transparent boxes indicate periods without summaries
- Proper vertical alignment with daily event calendar

## Test Plan
- [x] Verify weekly summaries appear on correct weeks
- [x] Verify monthly summaries span full months
- [x] Check alignment between daily, weekly, and monthly rows
- [x] Confirm tooltips display correct information
- [x] Test with existing Weekly and big-picture reflections

🤖 Generated with [Claude Code](https://claude.ai/code)