### PR TITLE
Split workflows into separate test and deploy jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to specific server
+name: Deploy to production
 
 on:
   push:
@@ -7,79 +7,10 @@ on:
     paths-ignore:
       - 'docker/**'
       - '**.md'
-  pull_request:
-    branches:
-      - main
-    paths-ignore:
-      - 'docker/**'
-      - '**.md'
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:13
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: tasks_test
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      - name: Cache pip dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/test.txt', 'requirements/base.txt', 'requirements/dist.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Cache node modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Install backend packages
-        run: pip install -r requirements/test.txt
-
-      - name: Install frontend packages
-        run: npm ci
-
-      - name: Build assets for testing
-        run: npm run build
-
-      - name: Run Django tests
-        env:
-          DJANGO_SETTINGS_MODULE: tasks.settings.local
-          DB_NAME: tasks_test
-          DB_USER: postgres
-          DB_PASSWORD: postgres
-          DB_HOST: localhost
-          DB_PORT: 5432
-          DB_TEST_NAME: tasks_test
-        run: python manage.py test --noinput
-
   deploy:
-    needs: test
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4
@@ -122,7 +53,7 @@ jobs:
           remote_port: ${{ secrets.DEPLOY_PORT }}
           remote_user: ${{ secrets.DEPLOY_USER }}
           remote_key: ${{ secrets.DEPLOY_KEY }}
-      - name: Clear cache and run migrations 
+      - name: Clear cache and run migrations
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.DEPLOY_HOST }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,71 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'docker/**'
+      - '**.md'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: tasks_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/test.txt', 'requirements/base.txt', 'requirements/dist.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install backend packages
+        run: pip install -r requirements/test.txt
+
+      - name: Install frontend packages
+        run: npm ci
+
+      - name: Build assets for testing
+        run: npm run build
+
+      - name: Run Django tests
+        env:
+          DJANGO_SETTINGS_MODULE: tasks.settings.local
+          DB_NAME: tasks_test
+          DB_USER: postgres
+          DB_PASSWORD: postgres
+          DB_HOST: localhost
+          DB_PORT: 5432
+          DB_TEST_NAME: tasks_test
+        run: python manage.py test --noinput


### PR DESCRIPTION
## Summary
- Create `test.yml` workflow that runs only on pull requests
- Update `deploy.yml` to run only on push to main
- Remove test job dependency from deploy workflow

This separates concerns and prevents running tests on every merge to main, since PRs will already have tests run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)