### PR TITLE
Refactor template blocks for better separation

### DIFF
--- a/tasks/templates/base.html
+++ b/tasks/templates/base.html
@@ -9,8 +9,11 @@
         <title>{% block title %}Tasks Collector{% endblock %}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-        {% block extracss %}
+        {% block cssmount %}
             {% render_css 'app' %}
+        {% endblock %}
+
+        {% block extracss %}
         {% endblock %}
 
         <script 
@@ -25,8 +28,11 @@
     <body class="{% block body_class %}{% endblock %}">
         {% block content %} {% endblock %}
 
-        {% block extrajs %}
+        {% block jsmount %}
             {% render_js 'app' %}
+        {% endblock %}
+
+        {% block extrajs %}
         {% endblock %}
     </body>
 </html>

--- a/tasks/templates/quests/quest_list.html
+++ b/tasks/templates/quests/quest_list.html
@@ -33,7 +33,3 @@
 
 {% endblock %}
 
-<!-- Load Vue app -->
-{% block extrajs %}
-{% endblock %}
-

--- a/tasks/templates/summary.html
+++ b/tasks/templates/summary.html
@@ -71,8 +71,3 @@
 
 {% endblock %}
 
-
-<!-- Load Vue app -->
-{% block extrajs %}
-{% endblock %}
-

--- a/tasks/templates/today.html
+++ b/tasks/templates/today.html
@@ -149,7 +149,3 @@
 
 {% endblock %}
 
-<!-- Load Vue app -->
-{% block extrajs %}
-{% endblock %}
-

--- a/tasks/templates/tree/breakthrough.html
+++ b/tasks/templates/tree/breakthrough.html
@@ -133,6 +133,3 @@
     </form>
 </div>
 {% endblock %}
-
-{% block extrajs %}
-{% endblock %}

--- a/tasks/templates/tree/lessons_list.html
+++ b/tasks/templates/tree/lessons_list.html
@@ -44,7 +44,3 @@
         {% endfor %}
 </div>
 {% endblock %}
-
-<!-- Load Vue app -->
-{% block extrajs %}
-{% endblock %}

--- a/tasks/templates/tree/observationclosed_detail.html
+++ b/tasks/templates/tree/observationclosed_detail.html
@@ -60,8 +60,3 @@
 
 </div>
 {% endblock %}
-
-<!-- Load Vue app -->
-{% block extrajs %}
-{% endblock %}
-

--- a/tasks/templates/tree/observationclosed_list.html
+++ b/tasks/templates/tree/observationclosed_list.html
@@ -46,8 +46,3 @@
 </div>
 
 {% endblock %}
-
-<!-- Load Vue app -->
-{% block extrajs %}
-{% endblock %}
-

--- a/tasks/templates/tree/quick_note.html
+++ b/tasks/templates/tree/quick_note.html
@@ -54,7 +54,3 @@
 
 {% endblock %}
 
-
-{% block extrajs %}
-{% endblock %}
-

--- a/tasks/templates/tree/tasks.html
+++ b/tasks/templates/tree/tasks.html
@@ -16,11 +16,11 @@
 {% endblock %}
 
 <!-- Load Vue app -->
-{% block extrajs %}
+{% block jsmount %}
 {% render_js 'hello_world_mount' %}
 {% endblock %}
 
-{% block extracss %}
+{% block cssmount %}
 {% render_css 'hello_world_mount' %}
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- Rename `extracss`/`extrajs` blocks to `cssmount`/`jsmount` for app loading
- Add new `extracss`/`extrajs` blocks for additional customization
- Remove empty `extrajs` blocks from templates that don't need them
- Update `tasks.html` to use new block names for `hello_world_mount`

## Rationale
This change provides better separation between:
- Required app mounts (cssmount/jsmount) - for loading core application bundles
- Optional extras (extracss/extrajs) - for additional page-specific scripts/styles

This makes the template inheritance more explicit and easier to understand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)