### PR TITLE
Add task to plan feature with notifications

### DIFF
--- a/tasks/apps/tree/urls.py
+++ b/tasks/apps/tree/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
 
     path('boards/<int:id>/commit/', views.commit_board),
     path('boards/append/', views.add_task),
+    path('plans/add-task/', views.add_task_to_plan, name='plan-add-task'),
     path('observations/add/', views.observation_edit, name='public-observation-add'),
     re_path(r'^observations/(?P<observation_id>[a-f0-9\-]+)/$', views.observation_edit, name='public-observation-edit'),
     path('observations/', views.ObservationMineListView.as_view(), name='public-observation-list'),

--- a/tasks/apps/tree/views.py
+++ b/tasks/apps/tree/views.py
@@ -4,6 +4,7 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 
 from rest_framework import viewsets
 from rest_framework import status
+from rest_framework.decorators import action
 
 
 from .serializers import *
@@ -329,6 +330,46 @@ def _get_current_plans():
         'big_picture_plan': big_picture_plan,
     }
 
+def _add_task_to_plan(text, timeframe):
+    """Helper function to add a task to a plan
+
+    Args:
+        text: The task text to add
+        timeframe: One of 'today', 'tomorrow', 'this_week'
+
+    Returns:
+        The Plan object that was created or updated
+    """
+    from datetime import date, timedelta
+
+    if timeframe == 'today':
+        focus_date = date.today()
+        thread = Thread.objects.get(name='Daily')
+    elif timeframe == 'tomorrow':
+        focus_date = date.today() + timedelta(days=1)
+        thread = Thread.objects.get(name='Daily')
+    elif timeframe == 'this_week':
+        focus_date = make_last_day_of_the_week(date.today())
+        thread = Thread.objects.get(name='Weekly')
+    else:
+        raise ValueError(f"Invalid timeframe: {timeframe}")
+
+    plan, created = Plan.objects.get_or_create(
+        pub_date=focus_date,
+        thread=thread,
+        defaults={'focus': text}
+    )
+    if not created:
+        # Append to existing focus content
+        if plan.focus:
+            plan.focus += '\n' + text
+        else:
+            plan.focus = text
+        plan.save()
+
+    return plan
+
+
 def _add_task_to_board(text, thread_name):
     """Helper function to add a task to a board"""
     thread = get_object_or_404(Thread, name=thread_name)
@@ -362,9 +403,42 @@ def add_task(request):
     # XXX hackish
     if 'text' not in item or 'thread-name' not in item:
         return RestResponse({'errors': 'no thread-name and text'}, status=status.HTTP_400_BAD_REQUEST)
-    
+
     board = _add_task_to_board(item['text'], item['thread-name'])
     return RestResponse(BoardSerializer(board).data)
+
+@api_view(['POST'])
+def add_task_to_plan(request):
+    """Add a task to a plan (today, tomorrow, or this week)"""
+    task_text = request.data.get('text')
+    timeframe = request.data.get('timeframe')  # 'today', 'tomorrow', 'this_week'
+
+    if not task_text or not timeframe:
+        return RestResponse(
+            {'error': 'text and timeframe are required'},
+            status=status.HTTP_400_BAD_REQUEST
+        )
+
+    try:
+        plan = _add_task_to_plan(task_text, timeframe)
+        return RestResponse(
+            {
+                'success': True,
+                'plan_id': plan.id,
+                'plan_date': plan.pub_date,
+            },
+            status=status.HTTP_200_OK
+        )
+    except Thread.DoesNotExist:
+        return RestResponse(
+            {'error': 'Required thread not found'},
+            status=status.HTTP_404_NOT_FOUND
+        )
+    except ValueError as e:
+        return RestResponse(
+            {'error': str(e)},
+            status=status.HTTP_400_BAD_REQUEST
+        )
 
 @login_required
 def board_summary(request, id):

--- a/tasks/assets/app.scss
+++ b/tasks/assets/app.scss
@@ -8,6 +8,7 @@ $lower-pane: 40px;
 $upper-pane: 54px;
 
 @import './styles/tree.scss';
+@import './styles/notifier.scss';
 
 @import './styles/example.scss';
 

--- a/tasks/assets/liquor-tree/src/components/TreeRoot.vue
+++ b/tasks/assets/liquor-tree/src/components/TreeRoot.vue
@@ -125,6 +125,7 @@
   import { VueContext }from 'vue-context';
 
   import { mapGetters } from 'vuex';
+  import { Notifier } from '../../../notifier';
 
   const UNSET = '__UNSET';
 
@@ -257,6 +258,7 @@
             } else if (method === 'addToPlan') {
                 const taskText = node.data.text
                 const timeframe = value  // 'today', 'tomorrow', 'this_week'
+                const notifier = Notifier({ time: 3000 })
 
                 try {
                     const response = await fetch('/plans/add-task/', {
@@ -272,13 +274,15 @@
                     })
 
                     if (!response.ok) {
-                        throw new Error('Failed to add task to plan')
+                        const errorData = await response.json()
+                        notifier.error(errorData.error || 'Failed to add task to plan')
+                        return
                     }
 
-                    const data = await response.json()
-                    console.log('Task added to plan:', data)
+                    const timeframeLabel = timeframe === 'this_week' ? 'this week' : timeframe
+                    notifier.success(`Task added to ${timeframeLabel}'s plan`)
                 } catch (error) {
-                    console.error('Error adding task to plan:', error)
+                    notifier.error(`Error: ${error.message}`)
                 }
             } else if (method === 'remove') {
                 node.remove()

--- a/tasks/assets/liquor-tree/src/components/TreeRoot.vue
+++ b/tasks/assets/liquor-tree/src/components/TreeRoot.vue
@@ -89,6 +89,21 @@
                     </li>
                 </ul>
             </li>
+            <li class="v-context__sub">
+                <a>Add to Plan</a>
+
+                <ul class="v-context">
+                    <li>
+                        <a href="#" @click.prevent="onClick('addToPlan', {... child.data, value: 'today' })">Today</a>
+                    </li>
+                    <li>
+                        <a href="#" @click.prevent="onClick('addToPlan', {... child.data, value: 'tomorrow' })">Tomorrow</a>
+                    </li>
+                    <li>
+                        <a href="#" @click.prevent="onClick('addToPlan', {... child.data, value: 'this_week' })">This Week</a>
+                    </li>
+                </ul>
+            </li>
             <li>
                 <a href="#" @click.prevent="onClick('remove', { ...child.data  })">Remove</a>
             </li>
@@ -239,9 +254,39 @@
                 }
 
                 this.$emit('LIQUOR_NOISE')
+            } else if (method === 'addToPlan') {
+                const taskText = node.data.text
+                const timeframe = value  // 'today', 'tomorrow', 'this_week'
+
+                try {
+                    const response = await fetch('/plans/add-task/', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            'X-CSRFToken': this.getCsrfToken(),
+                        },
+                        body: JSON.stringify({
+                            text: taskText,
+                            timeframe: timeframe
+                        })
+                    })
+
+                    if (!response.ok) {
+                        throw new Error('Failed to add task to plan')
+                    }
+
+                    const data = await response.json()
+                    console.log('Task added to plan:', data)
+                } catch (error) {
+                    console.error('Error adding task to plan:', error)
+                }
             } else if (method === 'remove') {
                 node.remove()
             }
+        },
+        getCsrfToken() {
+            const token = document.body.querySelector('[name=csrfmiddlewaretoken]')
+            return token ? token.value : ''
         }
     },
 

--- a/tasks/assets/notifier.js
+++ b/tasks/assets/notifier.js
@@ -1,0 +1,75 @@
+/**
+ * Simple notification system
+ *
+ * Usage:
+ *   const notifier = Notifier({time: 3000, classes: "my-positioning"})
+ *   notifier.success("Task added successfully")
+ *   notifier.error("Something went wrong")
+ *
+ *   // Persistent notification (stays until closed)
+ *   const persistentNotifier = Notifier({time: null})
+ *   persistentNotifier.info("This stays until you close it")
+ */
+
+export function Notifier(options = {}) {
+    const defaults = {
+        time: 3000,
+        classes: ''
+    };
+
+    const config = { ...defaults, ...options };
+
+    function removeNotification(notification) {
+        notification.classList.remove('notifier-visible');
+        notification.classList.add('notifier-hiding');
+
+        // Remove from DOM after transition
+        setTimeout(() => {
+            if (notification.parentNode) {
+                notification.parentNode.removeChild(notification);
+            }
+        }, 300);
+    }
+
+    function show(message, type = 'info') {
+        const notification = document.createElement('div');
+        notification.className = `notifier notifier-${type} ${config.classes}`;
+
+        const messageSpan = document.createElement('span');
+        messageSpan.className = 'notifier-message';
+        messageSpan.textContent = message;
+
+        const closeButton = document.createElement('button');
+        closeButton.className = 'notifier-close';
+        closeButton.innerHTML = '&times;';
+        closeButton.setAttribute('aria-label', 'Close notification');
+        closeButton.addEventListener('click', () => {
+            removeNotification(notification);
+        });
+
+        notification.appendChild(messageSpan);
+        notification.appendChild(closeButton);
+
+        document.body.appendChild(notification);
+
+        // Trigger reflow to enable CSS transition
+        notification.offsetHeight;
+
+        // Add visible class for fade-in
+        notification.classList.add('notifier-visible');
+
+        // Auto-dismiss after specified time (if time is not null)
+        if (config.time !== null) {
+            setTimeout(() => {
+                removeNotification(notification);
+            }, config.time);
+        }
+    }
+
+    return {
+        success: (message) => show(message, 'success'),
+        error: (message) => show(message, 'error'),
+        info: (message) => show(message, 'info'),
+        warning: (message) => show(message, 'warning')
+    };
+}

--- a/tasks/assets/styles/notifier.scss
+++ b/tasks/assets/styles/notifier.scss
@@ -1,0 +1,75 @@
+.notifier {
+    position: fixed;
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 9999;
+
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+
+    padding: 1rem 1.5rem;
+    border-radius: 4px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+
+    font-size: 1rem;
+    font-weight: 500;
+
+    opacity: 0;
+    transition: opacity 0.3s ease-in-out;
+
+    &.notifier-visible {
+        opacity: 1;
+    }
+
+    &.notifier-hiding {
+        opacity: 0;
+    }
+
+    &.notifier-success {
+        background-color: #28a745;
+        color: white;
+    }
+
+    &.notifier-error {
+        background-color: #dc3545;
+        color: white;
+    }
+
+    &.notifier-info {
+        background-color: #17a2b8;
+        color: white;
+    }
+
+    &.notifier-warning {
+        background-color: #ffc107;
+        color: #212529;
+    }
+}
+
+.notifier-message {
+    flex: 1;
+}
+
+.notifier-close {
+    background: transparent;
+    border: none;
+    color: inherit;
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0;
+    margin: 0;
+    opacity: 0.7;
+    transition: opacity 0.2s ease-in-out;
+
+    &:hover {
+        opacity: 1;
+    }
+
+    &:focus {
+        outline: 2px solid currentColor;
+        outline-offset: 2px;
+    }
+}


### PR DESCRIPTION
## Summary
- Add "Add to Plan" context menu option to tasks with today/tomorrow/this week
- Create backend API endpoint `/plans/add-task/` to append tasks to plans
- Implement reusable Notifier component for user feedback
- Add close button support for manual notification dismissal
- Support persistent notifications with nullable time option

## Changes
### Backend
- Add `_add_task_to_plan()` helper function
- Create `add_task_to_plan` API view with CSRF protection
- Add URL route at `/plans/add-task/`

### Frontend
- Add context menu submenu for adding tasks to plans
- Create Notifier module with success/error/info/warning methods
- Add notifier styles with smooth transitions
- Wire up API calls with user-friendly notifications

## Usage
Right-click on any task in the board → "Add to Plan" → Select timeframe

🤖 Generated with [Claude Code](https://claude.com/claude-code)