### PR TITLE
fix: defer ObservationEventViewSet queryset to avoid import-time DB query

### DIFF
--- a/tasks/apps/tree/views_observation.py
+++ b/tasks/apps/tree/views_observation.py
@@ -133,12 +133,15 @@ class ObservationUpdatedViewSet(viewsets.ModelViewSet):
 
 class ObservationEventViewSet(viewsets.ModelViewSet):
     # XXX do we need to filter out events that are not of the observation type?
-    queryset = Event.objects.instance_of(*observation_event_types)
+    queryset = Event.objects.all()
 
     serializer_class = ObservationEventSerializer
 
     filter_backends = [DjangoFilterBackend]
     filter_class = EventFilter
+
+    def get_queryset(self):
+        return Event.objects.instance_of(*observation_event_types)
 
 
 class ObservationListView(LoginRequiredMixin, ListView):


### PR DESCRIPTION
## Summary
- `Event.objects.instance_of(*observation_event_types)` was evaluated at class-definition time on `ObservationEventViewSet`. Polymorphic's filter translation eagerly resolves `ContentType` IDs, so importing the module hit the DB.
- On a fresh database this blocked `manage.py migrate` (and every other management command) with `relation "django_content_type" does not exist`.
- Moved the filtered queryset into `get_queryset()` and kept a minimal `queryset = Event.objects.all()` on the class so DRF's router can still infer a basename.

## Test plan
- [x] Drop the dev DB, run `manage.py migrate` — completes without the ContentType error.
- [x] Hit the `observation-events` endpoint and confirm results are still filtered to `observation_event_types`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)