### PR TITLE
feat: add ProjectedOutcomeEvolved event with HTMX note input

### DIFF
--- a/tasks/apps/tree/forms.py
+++ b/tasks/apps/tree/forms.py
@@ -203,6 +203,17 @@ class DecimalSliderWidget(forms.NumberInput):
         return float(value)
 
 
+class ProjectedOutcomeEvolvedForm(forms.Form):
+    note = forms.CharField(
+        max_length=512,
+        widget=forms.TextInput(
+            attrs={
+                "placeholder": "Add a note about this outcome...",
+            }
+        ),
+    )
+
+
 class ProjectedOutcomeForm(forms.ModelForm):
     class Meta:
         model = ProjectedOutcome

--- a/tasks/apps/tree/migrations/0066_projectedoutcomeevolved.py
+++ b/tasks/apps/tree/migrations/0066_projectedoutcomeevolved.py
@@ -1,0 +1,44 @@
+from django.db import migrations, models
+import django.db.models.deletion
+import tasks.apps.tree.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("tree", "0065_insightrefined"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ProjectedOutcomeEvolved",
+            fields=[
+                (
+                    "event_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="tree.event",
+                    ),
+                ),
+                ("note", models.CharField(max_length=512)),
+                (
+                    "projected_outcome",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        to="tree.projectedoutcome",
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+                "base_manager_name": "objects",
+            },
+            bases=("tree.event", tasks.apps.tree.models.ProjectedOutcomeEventMixin),
+        ),
+    ]

--- a/tasks/apps/tree/models.py
+++ b/tasks/apps/tree/models.py
@@ -724,6 +724,23 @@ class ProjectedOutcomeMoved(Event, ProjectedOutcomeEventMixin):
         )
 
 
+class ProjectedOutcomeEvolved(Event, ProjectedOutcomeEventMixin):
+    projected_outcome = models.ForeignKey(
+        ProjectedOutcome, on_delete=models.SET_NULL, null=True, blank=True
+    )
+
+    note = models.CharField(max_length=512)
+
+    @staticmethod
+    def from_projected_outcome(projected_outcome, note):
+        return ProjectedOutcomeEvolved(
+            projected_outcome=projected_outcome,
+            note=note,
+            event_stream_id=projected_outcome.event_stream_id,
+            thread=_get_thread_from_breakthrough(projected_outcome.breakthrough),
+        )
+
+
 class ObservationAttached(Event, ObservationEventMixin):
     observation = models.ForeignKey(
         Observation, on_delete=models.SET_NULL, null=True, blank=True

--- a/tasks/apps/tree/presentation.py
+++ b/tasks/apps/tree/presentation.py
@@ -7,6 +7,7 @@ from .models import (
     Event,
     ProjectedOutcome,
     ProjectedOutcomeClosed,
+    ProjectedOutcomeEvolved,
     ProjectedOutcomeMade,
     ProjectedOutcomeMoved,
     ProjectedOutcomeRedefined,
@@ -48,6 +49,7 @@ class ProjectedOutcomePresentation:
         self._decorate_with_events("rescheduled_events", ProjectedOutcomeRescheduled)
         self._decorate_with_events("closed_events", ProjectedOutcomeClosed)
         self._decorate_with_events("moved_events", ProjectedOutcomeMoved)
+        self._decorate_with_events("evolved_events", ProjectedOutcomeEvolved)
 
         # Start with initial state from Made event
         if not self.made_events:

--- a/tasks/apps/tree/templatetags/model_presenters.py
+++ b/tasks/apps/tree/templatetags/model_presenters.py
@@ -43,6 +43,13 @@ def habit_without_name(tracked):
 
 
 @register.filter
+def get_item(mapping, key):
+    if mapping is None:
+        return []
+    return mapping.get(key, [])
+
+
+@register.filter
 def missing_months(regrouped_habits):
     year = regrouped_habits[0][1][0].published.year
 

--- a/tasks/apps/tree/templatetags/model_presenters.py
+++ b/tasks/apps/tree/templatetags/model_presenters.py
@@ -43,13 +43,6 @@ def habit_without_name(tracked):
 
 
 @register.filter
-def get_item(mapping, key):
-    if mapping is None:
-        return []
-    return mapping.get(key, [])
-
-
-@register.filter
 def missing_months(regrouped_habits):
     year = regrouped_habits[0][1][0].published.year
 

--- a/tasks/apps/tree/urls.py
+++ b/tasks/apps/tree/urls.py
@@ -166,6 +166,11 @@ urlpatterns = [
         views_breakthrough.projected_outcome_move,
         name="projected-outcome-move",
     ),
+    path(
+        "projected-outcome/<int:projected_outcome_id>/evolve/",
+        views_breakthrough.projected_outcome_evolve,
+        name="projected-outcome-evolve",
+    ),
     # === Journal / Diary (views) ===
     path("diary/add/", views.journal_add, name="public-journal-add"),
     path(

--- a/tasks/apps/tree/utils/statistics.py
+++ b/tasks/apps/tree/utils/statistics.py
@@ -15,6 +15,7 @@ from ..models import (
     ObservationUpdated,
     Plan,
     ProjectedOutcomeClosed,
+    ProjectedOutcomeEvolved,
     ProjectedOutcomeMade,
     ProjectedOutcomeRedefined,
     ProjectedOutcomeRescheduled,
@@ -184,6 +185,7 @@ aggregate_models_dict = {
     "projected_outcome_redefined_count": ProjectedOutcomeRedefined,
     "projected_outcome_rescheduled_count": ProjectedOutcomeRescheduled,
     "projected_outcome_closed_count": ProjectedOutcomeClosed,
+    "projected_outcome_evolved_count": ProjectedOutcomeEvolved,
     "event_count": Event,
 }
 

--- a/tasks/apps/tree/views_breakthrough.py
+++ b/tasks/apps/tree/views_breakthrough.py
@@ -1,19 +1,24 @@
+from collections import defaultdict
+
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
 from django.forms import inlineformset_factory
+from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
+from django.views.decorators.http import require_POST
 
 from rest_framework import status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response as RestResponse
 
-from .forms import BreakthroughForm, ProjectedOutcomeForm
+from .forms import BreakthroughForm, ProjectedOutcomeEvolvedForm, ProjectedOutcomeForm
 from .models import (
     Breakthrough,
     HabitTracked,
     ProjectedOutcome,
     ProjectedOutcomeClosed,
+    ProjectedOutcomeEvolved,
     ProjectedOutcomeMoved,
 )
 
@@ -77,6 +82,16 @@ def breakthrough(request, year):
         closed_outcomes = ProjectedOutcomeClosed.objects.none()
         moved_outcomes = ProjectedOutcomeMoved.objects.none()
 
+    evolved_by_stream = defaultdict(list)
+    stream_ids = [po.event_stream_id for po in projected_outcome_queryset]
+    if stream_ids:
+        for evolved in ProjectedOutcomeEvolved.objects.filter(
+            event_stream_id__in=stream_ids
+        ).order_by("published"):
+            evolved_by_stream[evolved.event_stream_id].append(evolved)
+
+    evolved_form = ProjectedOutcomeEvolvedForm()
+
     return render(
         request,
         "tree/breakthrough.html",
@@ -90,6 +105,8 @@ def breakthrough(request, year):
             "projected_outcome_queryset": projected_outcome_queryset,
             "closed_outcomes": closed_outcomes,
             "moved_outcomes": moved_outcomes,
+            "evolved_by_stream": dict(evolved_by_stream),
+            "evolved_form": evolved_form,
         },
     )
 
@@ -118,6 +135,7 @@ def projected_outcome_events_history(request, event_stream_id):
             "rescheduled_events": presentation.rescheduled_events,
             "closed_events": presentation.closed_events,
             "moved_events": presentation.moved_events,
+            "evolved_events": presentation.evolved_events,
         },
     )
 
@@ -141,6 +159,32 @@ def projected_outcome_close(request, projected_outcome_id):
     )
 
     return response
+
+
+@require_POST
+@login_required
+def projected_outcome_evolve(request, projected_outcome_id):
+    projected_outcome = get_object_or_404(ProjectedOutcome, pk=projected_outcome_id)
+
+    form = ProjectedOutcomeEvolvedForm(request.POST)
+    if not form.is_valid():
+        return HttpResponseBadRequest("Invalid note")
+
+    evolved = ProjectedOutcomeEvolved.from_projected_outcome(
+        projected_outcome, form.cleaned_data["note"]
+    )
+    evolved.save()
+
+    return render(
+        request,
+        "tree/breakthrough/evolved_list.html",
+        {
+            "evolved_events": ProjectedOutcomeEvolved.objects.filter(
+                event_stream_id=projected_outcome.event_stream_id
+            ).order_by("published"),
+            "outcome_pk": projected_outcome.pk,
+        },
+    )
 
 
 @api_view(["POST"])

--- a/tasks/apps/tree/views_breakthrough.py
+++ b/tasks/apps/tree/views_breakthrough.py
@@ -1,9 +1,7 @@
-from collections import defaultdict
-
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
 from django.forms import inlineformset_factory
-from django.http import HttpResponse, HttpResponseBadRequest
+from django.http import HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.views.decorators.http import require_POST
@@ -82,16 +80,6 @@ def breakthrough(request, year):
         closed_outcomes = ProjectedOutcomeClosed.objects.none()
         moved_outcomes = ProjectedOutcomeMoved.objects.none()
 
-    evolved_by_stream = defaultdict(list)
-    stream_ids = [po.event_stream_id for po in projected_outcome_queryset]
-    if stream_ids:
-        for evolved in ProjectedOutcomeEvolved.objects.filter(
-            event_stream_id__in=stream_ids
-        ).order_by("published"):
-            evolved_by_stream[evolved.event_stream_id].append(evolved)
-
-    evolved_form = ProjectedOutcomeEvolvedForm()
-
     return render(
         request,
         "tree/breakthrough.html",
@@ -105,8 +93,6 @@ def breakthrough(request, year):
             "projected_outcome_queryset": projected_outcome_queryset,
             "closed_outcomes": closed_outcomes,
             "moved_outcomes": moved_outcomes,
-            "evolved_by_stream": dict(evolved_by_stream),
-            "evolved_form": evolved_form,
         },
     )
 

--- a/tasks/templates/tree/breakthrough.html
+++ b/tasks/templates/tree/breakthrough.html
@@ -238,6 +238,34 @@
                                         {{ form.confidence_level }}
                                     </div>
                                 </div>
+                                {% if form.instance.pk %}
+                                <div class="field evolved-section">
+                                    <div class="meta">Evolution notes</div>
+                                    {% include "tree/breakthrough/evolved_list.html" with evolved_events=evolved_by_stream|get_item:form.instance.event_stream_id outcome_pk=form.instance.pk %}
+                                    <div class="evolved-add">
+                                        <input
+                                            type="text"
+                                            form="not-a-real-form"
+                                            name="note"
+                                            id="evolved-note-input-{{ form.instance.pk }}"
+                                            maxlength="512"
+                                            placeholder="Add an evolution note..."
+                                            data-evolved-input
+                                            data-outcome-id="{{ form.instance.pk }}"
+                                        >
+                                        <button
+                                            type="button"
+                                            class="evolved-add-btn"
+                                            hx-post="{% url 'projected-outcome-evolve' projected_outcome_id=form.instance.pk %}"
+                                            hx-target="#evolved-notes-{{ form.instance.pk }}"
+                                            hx-swap="outerHTML"
+                                            hx-include="#evolved-note-input-{{ form.instance.pk }}"
+                                            hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                                            data-input-id="evolved-note-input-{{ form.instance.pk }}"
+                                        >Add</button>
+                                    </div>
+                                </div>
+                                {% endif %}
                             </div>
                         </div>
                     {% endfor %}
@@ -338,6 +366,27 @@ document.addEventListener('DOMContentLoaded', function() {
                 console.error('Error:', error);
                 alert('Failed to close the outcome. Please try again.');
             });
+        });
+    });
+
+    // Evolved notes: clear the input after htmx swaps in the new list
+    document.body.addEventListener('htmx:afterRequest', function(evt) {
+        const trigger = evt.detail.elt;
+        if (!trigger || !trigger.classList || !trigger.classList.contains('evolved-add-btn')) return;
+        if (!evt.detail.successful) return;
+        const inputId = trigger.dataset.inputId;
+        const input = document.getElementById(inputId);
+        if (input) input.value = '';
+    });
+
+    // Evolved notes: pressing Enter in the input triggers the Add button
+    document.querySelectorAll('input[data-evolved-input]').forEach(input => {
+        input.addEventListener('keydown', function(e) {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                const button = this.parentElement.querySelector('.evolved-add-btn');
+                if (button) button.click();
+            }
         });
     });
 

--- a/tasks/templates/tree/breakthrough.html
+++ b/tasks/templates/tree/breakthrough.html
@@ -241,7 +241,7 @@
                                 {% if form.instance.pk %}
                                 <div class="field evolved-section">
                                     <div class="meta">Evolution notes</div>
-                                    {% include "tree/breakthrough/evolved_list.html" with evolved_events=evolved_by_stream|get_item:form.instance.event_stream_id outcome_pk=form.instance.pk %}
+                                    {% include "tree/breakthrough/evolved_list.html" with evolved_events=form.instance.projectedoutcomeevolved_set.all outcome_pk=form.instance.pk %}
                                     <div class="evolved-add">
                                         <input
                                             type="text"

--- a/tasks/templates/tree/breakthrough/evolved_list.html
+++ b/tasks/templates/tree/breakthrough/evolved_list.html
@@ -1,0 +1,8 @@
+<ul class="evolved-notes" id="evolved-notes-{{ outcome_pk }}">
+    {% for evolved in evolved_events %}
+        <li class="evolved-note">
+            <span class="evolved-date">{{ evolved.published|date:"M d" }}</span>
+            <span class="evolved-text">{{ evolved.note }}</span>
+        </li>
+    {% endfor %}
+</ul>

--- a/tasks/templates/tree/projected_outcome_events_history.html
+++ b/tasks/templates/tree/projected_outcome_events_history.html
@@ -152,6 +152,13 @@
                                             {% endif %}
                                         </div>
                                     </div>
+                                {% elif event in evolved_events %}
+                                    <div class="event-type event-evolved">
+                                        <h3>🌱 Projected Outcome Evolved</h3>
+                                        <div class="event-details">
+                                            <p>{{ event.note }}</p>
+                                        </div>
+                                    </div>
                                 {% endif %}
                             </div>
                         </div>

--- a/tasks/templates/tree/stats.html
+++ b/tasks/templates/tree/stats.html
@@ -82,6 +82,10 @@
             <td><strong>{{ projected_outcome_closed_count }}</strong></td>
         </tr>
         <tr>
+            <td>Outcomes Evolved:</td>
+            <td><strong>{{ projected_outcome_evolved_count }}</strong></td>
+        </tr>
+        <tr>
             <th colspan="2">Summary</th>
         </tr>
         <tr>


### PR DESCRIPTION
## Summary
- New `ProjectedOutcomeEvolved` event (`note: CharField(512)`) for journaling incremental progress on an outcome without redefining it
- HTMX endpoint `projected-outcome/<id>/evolve/` adds a note and returns the refreshed list partial
- Breakthrough page renders evolution notes inline per active outcome with an inline add input (Enter or Add button)
- `/stats/` page now reports an "Outcomes Evolved" count, and the events history view renders the new event type

## Test plan
- [x] `python manage.py migrate` applies `0066_projectedoutcomeevolved`
- [x] Open `/breakthrough/<year>/` for a year with active outcomes — verify each outcome shows its evolution notes section under "Open"
- [x] Type a note, press Enter (or click Add) — verify the note appears immediately and the input clears
- [x] Add a second note — verify both notes are displayed and ordered by date
- [x] Submit the parent breakthrough form — verify the evolution-note inputs do NOT pollute the formset (they're detached via `form="not-a-real-form"`)
- [x] Visit `/projected-outcome/<event_stream_id>/events/` — verify 🌱 events show up in the timeline
- [x] Visit `/stats/` — verify "Outcomes Evolved" row is present and counts increment

🤖 Generated with [Claude Code](https://claude.com/claude-code)