### PR TITLE
fix: add missing ProjectedOutcomeEvolved serializer to EventSerializer

### DIFF
--- a/tasks/apps/tree/serializers.py
+++ b/tasks/apps/tree/serializers.py
@@ -406,6 +406,22 @@ class ProjectedOutcomeMovedSerializer(serializers.ModelSerializer):
         ]
 
 
+class ProjectedOutcomeEvolvedSerializer(serializers.ModelSerializer):
+    thread = serializers.SlugRelatedField(
+        queryset=Thread.objects.all(), slug_field="name"
+    )
+
+    class Meta:
+        model = ProjectedOutcomeEvolved
+        fields = [
+            "id",
+            "published",
+            "event_stream_id",
+            "thread",
+            "note",
+        ]
+
+
 def get_observation_object(obj):
     if obj.observation:
         return obj.observation
@@ -481,6 +497,7 @@ class EventSerializer(PolymorphicSerializer):
         ProjectedOutcomeRescheduled: ProjectedOutcomeRescheduledSerializer,
         ProjectedOutcomeClosed: ProjectedOutcomeClosedSerializer,
         ProjectedOutcomeMoved: ProjectedOutcomeMovedSerializer,
+        ProjectedOutcomeEvolved: ProjectedOutcomeEvolvedSerializer,
         InsightRefined: InsightRefinedSerializer,
     }
 


### PR DESCRIPTION
## Summary
- Adds `ProjectedOutcomeEvolvedSerializer` and registers it in `EventSerializer.model_serializer_mapping`
- Without it, any polymorphic event endpoint hitting a `ProjectedOutcomeEvolved` row raised `KeyError: 'EventSerializer.model_serializer_mapping is missing a corresponding serializer for ProjectedOutcomeEvolved model'`
- Mirrors the shape of the other ProjectedOutcome event serializers (id, published, event_stream_id, thread, note)

## Test plan
- [x] Hit an endpoint that returns events (e.g. `/events/<year>/<month>/`, the daily events API) for a stream that contains a `ProjectedOutcomeEvolved` row — verify it serializes instead of 500ing
- [x] `python manage.py check` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)