### PR TITLE
refactor: extract observation menu into reusable templatetag

### DIFF
--- a/tasks/apps/tree/templatetags/observation_menu.py
+++ b/tasks/apps/tree/templatetags/observation_menu.py
@@ -1,0 +1,20 @@
+from django import template
+
+from ..models import InsightRefined, Observation, ObservationClosed
+
+register = template.Library()
+
+
+@register.inclusion_tag("tree/_observation_menu.html", takes_context=True)
+def observation_menu(context, attach_mode=False):
+    request = context["request"]
+
+    return {
+        "mine_count": Observation.objects.filter(user=request.user).count(),
+        "open_count": Observation.objects.count(),
+        "closed_count": ObservationClosed.objects.count(),
+        "insights_count": (
+            InsightRefined.objects.values("event_stream_id").distinct().count()
+        ),
+        "attach_mode": attach_mode,
+    }

--- a/tasks/apps/tree/views_observation.py
+++ b/tasks/apps/tree/views_observation.py
@@ -155,13 +155,6 @@ class ObservationListView(LoginRequiredMixin, ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        context["open_count"] = Observation.objects.count()
-        context["closed_count"] = ObservationClosed.objects.count()
-        context["mine_count"] = Observation.objects.filter(
-            user=self.request.user
-        ).count()
-
-        # Add attach mode context
         context["attach_mode"] = self.request.GET.get("attach_mode") == "true"
         context["attach_observation_id"] = self.request.GET.get("observation_id")
 
@@ -175,17 +168,6 @@ class ObservationClosedListView(LoginRequiredMixin, ListView):
     )
 
     paginate_by = 100
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-
-        context["open_count"] = Observation.objects.count()
-        context["closed_count"] = ObservationClosed.objects.count()
-        context["mine_count"] = Observation.objects.filter(
-            user=self.request.user
-        ).count()
-
-        return context
 
 
 class ObservationMineListView(LoginRequiredMixin, ListView):
@@ -204,13 +186,6 @@ class ObservationMineListView(LoginRequiredMixin, ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        context["open_count"] = Observation.objects.count()
-        context["closed_count"] = ObservationClosed.objects.count()
-        context["mine_count"] = Observation.objects.filter(
-            user=self.request.user
-        ).count()
-
-        # Add attach mode context
         context["attach_mode"] = self.request.GET.get("attach_mode") == "true"
         context["attach_observation_id"] = self.request.GET.get("observation_id")
 
@@ -233,17 +208,6 @@ class InsightsListView(LoginRequiredMixin, ListView):
             .select_related("thread", "type")
             .order_by("-published")
         )
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-
-        context["open_count"] = Observation.objects.count()
-        context["closed_count"] = ObservationClosed.objects.count()
-        context["mine_count"] = Observation.objects.filter(
-            user=self.request.user
-        ).count()
-
-        return context
 
 
 @login_required

--- a/tasks/templates/tree/_observation_menu.html
+++ b/tasks/templates/tree/_observation_menu.html
@@ -1,0 +1,9 @@
+<p class="menu observation with-badges">
+    <a href="{% url 'public-observation-list' %}">Mine <span class="badge">{{ mine_count }}</span></a>
+    <a href="{% url 'public-observation-list-all' %}">All <span class="badge">{{ open_count }}</span></a>
+    <a href="{% url 'public-observation-list-closed' %}">Closed <span class="badge">{{ closed_count }}</span></a>
+    <a href="{% url 'public-insights-list' %}">Insights <span class="badge">{{ insights_count }}</span></a>
+    {% if attach_mode %}
+        <a href="?">Exit Attach Mode</a>
+    {% endif %}
+</p>

--- a/tasks/templates/tree/insights_list.html
+++ b/tasks/templates/tree/insights_list.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load render_assets %}
+{% load observation_menu %}
 
 {% block body_class %}page-daily{% endblock %}
 
@@ -12,12 +13,7 @@
     <div class="cont">
         {% include "menu.html" %}
 
-        <p class="menu observation with-badges">
-            <a href="{% url 'public-observation-list' %}">Mine <span class="badge">{{ mine_count }}</span></a>
-            <a href="{% url 'public-observation-list-all' %}">All <span class="badge">{{ open_count }}</span></a>
-            <a href="{% url 'public-observation-list-closed' %}">Closed <span class="badge">{{ closed_count }}</span></a>
-            <a href="{% url 'public-insights-list' %}">Insights</a>
-        </p>
+        {% observation_menu %}
     </div>
         {% for insight in object_list %}
         <article class="observation" id="insight-{{ insight.pk }}">

--- a/tasks/templates/tree/observation_list.html
+++ b/tasks/templates/tree/observation_list.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load render_assets %}
+{% load observation_menu %}
 
 {% block body_class %}page-daily{% endblock %}
 
@@ -13,15 +14,7 @@
     <div class="cont">
         {% include "menu.html" %}
 
-        <p class="menu observation with-badges">
-            <a href="{% url 'public-observation-list' %}">Mine <span class="badge">{{ mine_count }}</span></a>
-            <a href="{% url 'public-observation-list-all' %}">All <span class="badge">{{ open_count }}</span></a>
-            <a href="{% url 'public-observation-list-closed' %}">Closed <span class="badge">{{ closed_count }}</span></a>
-            <a href="{% url 'public-insights-list' %}">Insights</a>
-            {% if attach_mode %}
-                <a href="?">Exit Attach Mode</a>
-            {% endif %}
-        </p>
+        {% observation_menu attach_mode=attach_mode %}
     </div>
         {% for observation in object_list %}
         <article class="observation" id="observation-{{ observation.pk }}">

--- a/tasks/templates/tree/observationclosed_list.html
+++ b/tasks/templates/tree/observationclosed_list.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load render_assets %}
+{% load observation_menu %}
 
 {% block body_class %}page-daily{% endblock %}
 
@@ -12,12 +13,7 @@
     <div class="cont">
         {% include "menu.html" %}
 
-        <p class="menu observation with-badges">
-            <a href="{% url 'public-observation-list' %}">Mine <span class="badge">{{ mine_count }}</span></a>
-            <a href="{% url 'public-observation-list-all' %}">All <span class="badge">{{ open_count }}</span></a>
-            <a href="{% url 'public-observation-list-closed' %}">Closed <span class="badge">{{ closed_count }}</span></a>
-            <a href="{% url 'public-insights-list' %}">Insights</a>
-        </p>
+        {% observation_menu %}
     </div>
         {% for observation in object_list %}
         <article class="observation" id="observation-{{ observation.pk }}">


### PR DESCRIPTION
## Summary
- Extracts the duplicated badge-menu (`Mine` / `All` / `Closed` / `Insights`) into a `{% observation_menu %}` inclusion tag in `tasks/apps/tree/templatetags/observation_menu.py`, backed by a new `tree/_observation_menu.html` partial.
- Adds an Insights count badge (distinct `event_stream_id` of `InsightRefined`) so it matches the other entries.
- Removes the per-view count-context boilerplate from `ObservationListView`, `ObservationClosedListView`, `ObservationMineListView`, and `InsightsListView`; the tag computes counts on render.

## Test plan
- [x] Visit `/observations/` (Mine), `/observations/all/`, `/observations/closed/`, `/insights/` — each shows all four badges with correct counts.
- [x] On the open observations list, enter Attach Mode and verify the `Exit Attach Mode` link still appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)