### PR TITLE
feat: ignore quoted lines when parsing journal entries

### DIFF
--- a/tasks/apps/tree/services/journalling/journal_processing.py
+++ b/tasks/apps/tree/services/journalling/journal_processing.py
@@ -5,8 +5,12 @@ This module coordinates the processing of journal entries after save,
 including reflection extraction and habit tracking.
 """
 
+import re
+
 from .habit_extraction import habits_line_to_habits_tracked
 from .reflection_extraction import add_reflection_items
+
+QUOTED_LINE_RE = re.compile(r"^[ \t]*>.*(?:\n|$)", re.MULTILINE)
 
 
 def process_journal_entry(journal_added, skip_habits=False):
@@ -14,7 +18,8 @@ def process_journal_entry(journal_added, skip_habits=False):
     Process a journal entry after it has been saved.
 
     Extracts reflection items and creates habit tracking entries
-    based on the journal content.
+    based on the journal content. Markdown blockquote lines (starting
+    with `>`) are stripped before parsing so quoted content is ignored.
 
     Args:
         journal_added: A saved JournalAdded instance.
@@ -23,12 +28,14 @@ def process_journal_entry(journal_added, skip_habits=False):
     # Import here to avoid circular imports
     from ...models import HabitTracked, Thread
 
-    add_reflection_items(journal_added)
+    comment = QUOTED_LINE_RE.sub("", journal_added.comment)
+
+    add_reflection_items(journal_added, comment=comment)
 
     if skip_habits:
         return
 
-    triplets = habits_line_to_habits_tracked(journal_added.comment)
+    triplets = habits_line_to_habits_tracked(comment)
 
     for occured, habit, note in triplets:
         HabitTracked.objects.create(

--- a/tasks/apps/tree/services/journalling/reflection_extraction.py
+++ b/tasks/apps/tree/services/journalling/reflection_extraction.py
@@ -60,7 +60,7 @@ def append_lines_to_value(value, lines):
     return (value + "\n" + "\n".join(lines)).strip()
 
 
-def add_reflection_items(journal_added):
+def add_reflection_items(journal_added, comment=None):
     """
     Extract reflection items from a journal entry and add them to the Reflection.
 
@@ -72,9 +72,14 @@ def add_reflection_items(journal_added):
 
     Args:
         journal_added: A JournalAdded instance to extract reflections from.
+        comment: Optional pre-processed comment text. Defaults to
+            ``journal_added.comment``.
     """
     # Import here to avoid circular imports
     from ...models import Reflection
+
+    if comment is None:
+        comment = journal_added.comment
 
     pub_date = journal_added.published.date()
 
@@ -85,7 +90,7 @@ def add_reflection_items(journal_added):
     if journal_added.thread.name == "big-picture":
         pub_date = pub_date.replace(day=monthrange(pub_date.year, pub_date.month)[1])
 
-    reflection_lines = extract_reflection_lines(journal_added.comment)
+    reflection_lines = extract_reflection_lines(comment)
 
     if not reflection_lines:
         return

--- a/tasks/apps/tree/tests/test_journal_processing.py
+++ b/tasks/apps/tree/tests/test_journal_processing.py
@@ -130,3 +130,42 @@ class JournalProcessingTestCase(TestCase):
         self.assertEqual(HabitTracked.objects.count(), 0)
         reflection = Reflection.objects.get()
         self.assertEqual(reflection.good, "good thing")
+
+    def test_quoted_lines_are_ignored(self):
+        """Lines starting with `>` are treated as blockquotes and skipped."""
+        journal = self._create_journal(
+            "> - [x] quoted reflection\n"
+            "> #food quoted habit\n"
+            "[x] real reflection\n"
+            "#food real habit"
+        )
+
+        process_journal_entry(journal)
+
+        reflection = Reflection.objects.get()
+        self.assertEqual(reflection.good, "real reflection")
+        self.assertEqual(HabitTracked.objects.count(), 1)
+        self.assertEqual(HabitTracked.objects.get().note, "#food real habit")
+
+    def test_indented_and_nested_quoted_lines_are_ignored(self):
+        """Indented (`  >`) and nested (`>>`) quote lines are also skipped."""
+        journal = self._create_journal(
+            "  > [x] indented quote\n"
+            ">> #food nested quote\n"
+            "[x] kept"
+        )
+
+        process_journal_entry(journal)
+
+        reflection = Reflection.objects.get()
+        self.assertEqual(reflection.good, "kept")
+        self.assertEqual(HabitTracked.objects.count(), 0)
+
+    def test_mid_line_gt_is_not_treated_as_quote(self):
+        """A `>` that is not at the line start does not skip the line."""
+        journal = self._create_journal("#food eaten > a lot")
+
+        process_journal_entry(journal)
+
+        self.assertEqual(HabitTracked.objects.count(), 1)
+        self.assertEqual(HabitTracked.objects.get().note, "#food eaten > a lot")


### PR DESCRIPTION
## Summary
- Strip Markdown blockquote lines (`> ...`) from journal comments before reflection/habit extraction so quoted content doesn't re-create Reflection items or HabitTracked entries.
- Implemented as a single `re.sub` at the top of `process_journal_entry`, keeping the per-extractor matchers free of quote-handling branches.
- `add_reflection_items` now accepts an optional pre-processed `comment` argument (defaults to `journal_added.comment`).

## Test plan
- [x] `python manage.py test tasks.apps.tree.tests.test_journal_processing` — 13 tests pass, including 3 new ones:
  - `test_quoted_lines_are_ignored`
  - `test_indented_and_nested_quoted_lines_are_ignored`
  - `test_mid_line_gt_is_not_treated_as_quote`
- [x] `python manage.py test tasks.apps.tree.tests.test_habits` — all habit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)