### PR TITLE
fix: calendar counts only journal entries

### DIFF
--- a/tasks/apps/tree/views_today.py
+++ b/tasks/apps/tree/views_today.py
@@ -205,7 +205,7 @@ class Monthly(Period):
 
 def _event_calendar(start, end):
     events = (
-        Event.objects.filter(
+        JournalAdded.objects.filter(
             published__range=(start, end),
         )
         .order_by("published")


### PR DESCRIPTION
## Summary
- Changed the calendar event count query from `Event.objects` to `JournalAdded.objects` so the calendar heatmap reflects only journal entries, not all event types.

## Test plan
- [x] Verify the calendar on the main view shows counts based on journal entries only
- [x] Confirm days without journal entries show zero count

🤖 Generated with [Claude Code](https://claude.com/claude-code)