### PR TITLE
feat: add observation calendar heatmap widget

### DIFF
--- a/tasks/apps/tree/templatetags/observation_calendar.py
+++ b/tasks/apps/tree/templatetags/observation_calendar.py
@@ -1,0 +1,50 @@
+import datetime
+from collections import Counter
+
+from django import template
+from django.utils import timezone
+
+from ..models import ObservationMade
+from ..utils.datetime import DayCount, adjust_start_date_to_monday, date_range_generator
+from ..utils.itertools import itemize
+
+register = template.Library()
+
+
+def _observation_calendar(start, end):
+    events = (
+        ObservationMade.objects.filter(
+            published__range=(start, end),
+        )
+        .order_by("published")
+        .values("published")
+    )
+
+    c = Counter()
+
+    for event in events:
+        c[event["published"].date()] += 1
+
+    return c
+
+
+def observation_calendar_data(end):
+    start = end - datetime.timedelta(weeks=52)
+    start = adjust_start_date_to_monday(start)
+
+    return list(
+        itemize(
+            date_range_generator(start, end),
+            _observation_calendar(start, end),
+            default=0,
+            item_type=DayCount,
+        )
+    )
+
+
+@register.inclusion_tag("tree/_observation_calendar.html")
+def observation_calendar():
+    end = timezone.now()
+    return {
+        "observation_calendar": observation_calendar_data(end),
+    }

--- a/tasks/templates/tree/_observation_calendar.html
+++ b/tasks/templates/tree/_observation_calendar.html
@@ -1,0 +1,12 @@
+<div class="calendar">
+    <div class="calendar-daily-row">
+    {% for event in observation_calendar %}
+        <div
+            title="{{ event.count }} observation{{ event.count|pluralize }} on {{ event.date|date:"Y-m-d" }}"
+            class="event-day"
+            data-count="{{ event.count }}"
+            data-date="{{ event.date|date:"Y-m-d" }}"
+        ></div>
+    {% endfor %}
+    </div>
+</div>

--- a/tasks/templates/tree/insights_list.html
+++ b/tasks/templates/tree/insights_list.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% load render_assets %}
 {% load observation_menu %}
+{% load observation_calendar %}
 
 {% block body_class %}page-daily{% endblock %}
 
@@ -12,6 +13,8 @@
 <div class="observations">
     <div class="cont">
         {% include "menu.html" %}
+
+        {% observation_calendar %}
 
         {% observation_menu %}
     </div>

--- a/tasks/templates/tree/observation_list.html
+++ b/tasks/templates/tree/observation_list.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% load render_assets %}
 {% load observation_menu %}
+{% load observation_calendar %}
 
 {% block body_class %}page-daily{% endblock %}
 
@@ -13,6 +14,8 @@
 <div class="observations">
     <div class="cont">
         {% include "menu.html" %}
+
+        {% observation_calendar %}
 
         {% observation_menu attach_mode=attach_mode %}
     </div>

--- a/tasks/templates/tree/observationclosed_list.html
+++ b/tasks/templates/tree/observationclosed_list.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% load render_assets %}
 {% load observation_menu %}
+{% load observation_calendar %}
 
 {% block body_class %}page-daily{% endblock %}
 
@@ -12,6 +13,8 @@
 <div class="observations">
     <div class="cont">
         {% include "menu.html" %}
+
+        {% observation_calendar %}
 
         {% observation_menu %}
     </div>


### PR DESCRIPTION
## Summary
- New `observation_calendar` template tag that queries `ObservationMade` events from the last 52 weeks and renders a heatmap calendar
- Added to all observation pages (mine, all, closed, insights) above the navigation links
- Reuses existing `.calendar` / `.event-day` CSS for consistent styling with the main view's journal calendar

## Test plan
- [x] Visit /observations/ and verify the calendar heatmap appears above the mine/all/closed/insights links
- [x] Navigate between mine, all, closed, and insights views — calendar should appear on all of them
- [x] Hover over calendar cells to confirm tooltip shows observation count and date

🤖 Generated with [Claude Code](https://claude.com/claude-code)