### PR TITLE
fix: count all observation event types in calendar heatmap

### DIFF
--- a/tasks/apps/tree/templatetags/observation_calendar.py
+++ b/tasks/apps/tree/templatetags/observation_calendar.py
@@ -4,7 +4,7 @@ from collections import Counter
 from django import template
 from django.utils import timezone
 
-from ..models import ObservationMade
+from ..models import Event, InsightRefined, observation_event_types
 from ..utils.datetime import DayCount, adjust_start_date_to_monday, date_range_generator
 from ..utils.itertools import itemize
 
@@ -13,7 +13,8 @@ register = template.Library()
 
 def _observation_calendar(start, end):
     events = (
-        ObservationMade.objects.filter(
+        Event.objects.instance_of(*observation_event_types, InsightRefined)
+        .filter(
             published__range=(start, end),
         )
         .order_by("published")


### PR DESCRIPTION
## Summary
- Include all observation event types (ObservationMade through InsightRefined) in the calendar heatmap instead of only ObservationMade

## Test plan
- [ ] Verify the observation calendar reflects activity from all observation event types, not just new observations

🤖 Generated with [Claude Code](https://claude.com/claude-code)