### PR TITLE
feat: add filter dropdown for important/deprecated items on board

### DIFF
--- a/tasks/assets/components/Board.vue
+++ b/tasks/assets/components/Board.vue
@@ -8,6 +8,7 @@
             v-show="!listViewMode"
             :data="currentBoard.state"
             :options="options"
+            :filter="treeFilterQuery"
             ref="tree"
         >
             <template slot-scope="{ node }">
@@ -42,7 +43,17 @@
             <a class="menulink" href="/quests/view/">Journal</a>
             <a class="menulink" href="/accounts/settings/">⚙</a>
 
-            <button @click.prevent="prepareCommit" class="on-right">commit</button>
+            <select
+                v-show="!listViewMode"
+                v-model="filterMode"
+                class="filter-select on-right"
+            >
+                <option value="all">all</option>
+                <option value="important">important</option>
+                <option value="deprecated">deprecated</option>
+            </select>
+
+            <button @click.prevent="prepareCommit" :class="{ 'on-right': listViewMode }">commit</button>
         </div>
 
         <CommitConfirmationModal
@@ -107,6 +118,10 @@ export default {
             return this.findItemsToBeRemoved(this.currentBoard.state)
         },
 
+        treeFilterQuery() {
+            return this.filterMode === 'all' ? '' : this.filterMode
+        },
+
         options() {
             return {
                 checkbox: true,
@@ -114,6 +129,10 @@ export default {
                 dnd: true,
                 deletion: true,
                 keyboardNavigation: true,
+
+                filter: {
+                    matcher: this.matchesFilter,
+                },
 
                 store: {
                     store: this.$store,
@@ -135,6 +154,7 @@ export default {
         unwatch: null,
         showCommitModal: false,
         listViewMode: false,
+        filterMode: 'all',
     }),
 
     mounted() {
@@ -225,48 +245,61 @@ export default {
             )
         },
 
-        findItemsToBeRemoved(items) {
-            let result = []
+        matchesFilter(query, node) {
+            const markers = node.data?.meaningfulMarkers || {}
 
-            const willBeForceRemoved = (node) => {
-                const markers = node.data?.meaningfulMarkers || {}
+            if (query === 'important') {
+                return (markers.important || 0) > 0
+            }
 
-                // Only show items with weeksInList >= 5 that will be force-removed
-                const weeksInList = markers.weeksInList || 0
-                if (weeksInList < 5) {
-                    return false
-                }
-
-                // Keep categories (nodes with children)
-                if (node.children && node.children.length > 0) {
-                    return false
-                }
-
-                // Keep canBePostponed tasks
-                if (markers.canBePostponed) {
-                    return false
-                }
-
-                // Keep postponed tasks
-                if ((markers.postponedFor || 0) > 0) {
-                    return false
-                }
-
-                // Keep tasks that made progress
-                if (markers.madeProgress) {
-                    return false
-                }
-
-                // Do not show checked tasks
-                if (node.state?.checked) {
-                    return false
-                }
-
+            if (query === 'deprecated') {
+                if ((markers.weeksInList || 0) < 5) return false
+                if (node.hasChildren()) return false
+                if (markers.canBePostponed) return false
+                if ((markers.postponedFor || 0) > 0) return false
+                if (markers.madeProgress) return false
+                if (node.states?.checked) return false
                 return true
             }
 
+            return false
+        },
+
+        isItemDeprecated(item) {
+            const markers = item.data?.meaningfulMarkers || {}
+
+            if ((markers.weeksInList || 0) < 5) {
+                return false
+            }
+
+            if (item.children && item.children.length > 0) {
+                return false
+            }
+
+            if (markers.canBePostponed) {
+                return false
+            }
+
+            if ((markers.postponedFor || 0) > 0) {
+                return false
+            }
+
+            if (markers.madeProgress) {
+                return false
+            }
+
+            if (item.state?.checked) {
+                return false
+            }
+
+            return true
+        },
+
+        findItemsToBeRemoved(items) {
+            let result = []
+
             const traverse = (node) => {
-                if (willBeForceRemoved(node)) {
+                if (this.isItemDeprecated(node)) {
                     result.push({
                         text: node.text,
                         weeksInList: node.data?.meaningfulMarkers?.weeksInList || 0


### PR DESCRIPTION
## Summary
- Adds a filter `<select>` near the commit button on the board's lower pane with three options: `all`, `important`, `deprecated`.
- `important` shows items where `meaningfulMarkers.important > 0`; `deprecated` shows items the commit modal would force-remove (weeksInList ≥ 5 and not postponed/progressing/checked, no children).
- Ancestors of matching nodes stay visible so tree structure is preserved.
- Filter is tree-view only, hidden in list view, and resets to `all` on each page load.

## Implementation notes
- Uses liquor-tree's built-in `filter` prop + `options.filter.matcher` rather than a custom CSS-hide approach. The library's filter handles ancestor visibility via `recurseUp` automatically.
- A WeakSet keyed on raw item `data` references was attempted first but failed because liquor-tree's `Node` constructor copies `data` via `Object.assign({}, item.data, ...)`, so node-side and state-side references never match.
- The existing `findItemsToBeRemoved` logic (used by the commit modal) was extracted into `isItemDeprecated` for clarity, while the tree-side matcher (`matchesFilter`) operates on Node instances directly.

## Test plan
- [x] Switch filter to `important` — only items with the important marker (and their ancestors) remain.
- [x] Switch filter to `deprecated` — only items that would be removed on commit (and their ancestors) remain.
- [x] Switch back to `all` — full tree visible.
- [x] Toggle list view — filter dropdown is hidden, list view shows all items.
- [x] Reload the page — filter resets to `all`.
- [x] Commit modal still lists the same deprecated items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)