### PR TITLE
feat: Eisenhower matrix view for classifying board tasks

### DIFF
--- a/tasks/apps/tree/board_operations.py
+++ b/tasks/apps/tree/board_operations.py
@@ -14,6 +14,7 @@ def create_task_item(text):
                 "weeksInList": 0,
                 "important": False,
                 "finalizing": False,
+                "eisenhower": None,
                 "canBeDoneOutsideOfWork": False,
                 "canBePostponed": False,
                 "postponedFor": 0,

--- a/tasks/apps/tree/commit.py
+++ b/tasks/apps/tree/commit.py
@@ -61,6 +61,11 @@ def transition_markers_in_tree_item(markers, children=None):
     if value:
         new_markers["transition"] = value
 
+    eisenhower = markers.get("eisenhower")
+
+    if eisenhower:
+        new_markers["eisenhower"] = eisenhower
+
     return new_markers
 
 

--- a/tasks/assets/components/Board.vue
+++ b/tasks/assets/components/Board.vue
@@ -31,6 +31,7 @@
 
             <router-link class="menulink" to="/">Board</router-link>
             <router-link class="menulink" to="/journal">Journal</router-link>
+            <router-link class="menulink" to="/eisenhower">Eisenhower</router-link>
 
             <span class="menulink">/</span>
 

--- a/tasks/assets/components/Eisenhower.vue
+++ b/tasks/assets/components/Eisenhower.vue
@@ -1,0 +1,375 @@
+<template>
+    <div class="board eisenhower">
+        <div class="upper-pane">
+            <h1>Eisenhower Matrix</h1>
+        </div>
+
+        <div class="eisenhower-layout">
+            <div class="task-tree-pane">
+                <ul class="task-tree">
+                    <li
+                        v-for="item in flatItems"
+                        :key="item.pathKey"
+                        class="task-item"
+                        :class="{
+                            classified: item.eisenhower,
+                            checked: item.checked
+                        }"
+                        :style="{ paddingLeft: (0.5 + item.depth * 1.2) + 'rem' }"
+                        draggable="true"
+                        @dragstart="onDragStart($event, item)"
+                    >
+                        <span
+                            class="eisenhower-badge"
+                            :class="item.eisenhower ? `badge-${item.eisenhower}` : 'badge-empty'"
+                            :title="item.eisenhower ? quadrantTitle(item.eisenhower) : ''"
+                        ></span>
+                        <span class="task-text">{{ item.text }}</span>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="eisenhower-grid">
+                <div
+                    v-for="quadrant in quadrants"
+                    :key="quadrant.id"
+                    class="quadrant"
+                    :class="`q-${quadrant.id}`"
+                    @dragover.prevent="onDragOver"
+                    @drop="onDrop($event, quadrant.id)"
+                >
+                    <h3>{{ quadrant.title }}</h3>
+                    <ul>
+                        <li
+                            v-for="item in itemsByQuadrant(quadrant.id)"
+                            :key="item.pathKey"
+                            class="grid-item"
+                            :class="{ checked: item.checked }"
+                            draggable="true"
+                            @dragstart="onDragStart($event, item)"
+                            @contextmenu.prevent="showContextMenu($event, item)"
+                        >
+                            {{ item.text }}
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <div
+            v-if="contextMenu.visible"
+            class="context-menu"
+            :style="{ top: contextMenu.y + 'px', left: contextMenu.x + 'px' }"
+            @click.stop
+        >
+            <button @click="removeStatus">Remove</button>
+        </div>
+
+        <div class="lower-pane">
+            <router-link class="menulink" to="/">Board</router-link>
+            <router-link class="menulink" to="/journal">Journal</router-link>
+            <router-link class="menulink" to="/eisenhower">Eisenhower</router-link>
+        </div>
+    </div>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+
+const QUADRANTS = [
+    { id: 'urgent-important', title: 'Urgent & Important' },
+    { id: 'not-urgent-important', title: 'Not Urgent & Important' },
+    { id: 'urgent-not-important', title: 'Urgent & Not Important' },
+    { id: 'not-urgent-not-important', title: 'Not Urgent & Not Important' },
+]
+
+function deepClone(value) {
+    return JSON.parse(JSON.stringify(value))
+}
+
+function getNodeByPath(state, path) {
+    let cur = state[path[0]]
+    for (let i = 1; i < path.length; i++) {
+        cur = cur.children[path[i]]
+    }
+    return cur
+}
+
+export default {
+    data: () => ({
+        contextMenu: { visible: false, x: 0, y: 0, item: null },
+        draggedItem: null,
+    }),
+
+    computed: {
+        ...mapGetters(['currentBoard']),
+
+        quadrants() {
+            return QUADRANTS
+        },
+
+        flatItems() {
+            const items = []
+            const traverse = (nodes, parentPath, depth) => {
+                nodes.forEach((node, idx) => {
+                    const path = [...parentPath, idx]
+                    items.push({
+                        text: node.text,
+                        path,
+                        pathKey: path.join('/'),
+                        depth,
+                        eisenhower: node.data && node.data.meaningfulMarkers && node.data.meaningfulMarkers.eisenhower
+                            ? node.data.meaningfulMarkers.eisenhower
+                            : null,
+                        checked: node.state && node.state.checked,
+                    })
+                    if (node.children && node.children.length > 0) {
+                        traverse(node.children, path, depth + 1)
+                    }
+                })
+            }
+            traverse(this.currentBoard.state || [], [], 0)
+            return items
+        },
+    },
+
+    mounted() {
+        if (this.$route.params.slug) {
+            this.$store.dispatch('initBoard', this.$route.params.slug)
+        } else {
+            const appElement = document.getElementById('app-meta')
+            const defaultThread = appElement
+                ? appElement.dataset.defaultThread
+                : this.$store.state.currentThreadPtr.value
+            this.$store.dispatch('initBoard', defaultThread)
+        }
+
+        document.addEventListener('click', this.hideContextMenu)
+    },
+
+    beforeDestroy() {
+        document.removeEventListener('click', this.hideContextMenu)
+    },
+
+    methods: {
+        quadrantTitle(id) {
+            const q = QUADRANTS.find(q => q.id === id)
+            return q ? q.title : ''
+        },
+
+        itemsByQuadrant(id) {
+            return this.flatItems.filter(item => item.eisenhower === id)
+        },
+
+        onDragStart(ev, item) {
+            this.draggedItem = item
+            ev.dataTransfer.effectAllowed = 'move'
+            ev.dataTransfer.setData('text/plain', item.pathKey)
+        },
+
+        onDragOver(ev) {
+            ev.dataTransfer.dropEffect = 'move'
+        },
+
+        onDrop(ev, quadrantId) {
+            if (!this.draggedItem) return
+            this.setEisenhower(this.draggedItem.path, quadrantId)
+            this.draggedItem = null
+        },
+
+        setEisenhower(path, value) {
+            const newState = deepClone(this.currentBoard.state)
+            const node = getNodeByPath(newState, path)
+            if (!node.data) node.data = {}
+            if (!node.data.meaningfulMarkers) node.data.meaningfulMarkers = {}
+            if (value === null) {
+                delete node.data.meaningfulMarkers.eisenhower
+            } else {
+                node.data.meaningfulMarkers.eisenhower = value
+            }
+            this.$store.dispatch('save', {
+                state: newState,
+                focus: this.currentBoard.focus,
+            })
+        },
+
+        showContextMenu(ev, item) {
+            this.contextMenu = {
+                visible: true,
+                x: ev.clientX,
+                y: ev.clientY,
+                item,
+            }
+        },
+
+        hideContextMenu() {
+            this.contextMenu.visible = false
+        },
+
+        removeStatus() {
+            if (this.contextMenu.item) {
+                this.setEisenhower(this.contextMenu.item.path, null)
+            }
+            this.hideContextMenu()
+        },
+    },
+}
+</script>
+
+<style scoped>
+.eisenhower-layout {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+    height: calc(100vh - 8rem);
+}
+
+.task-tree-pane {
+    width: 20%;
+    min-width: 200px;
+    overflow-y: auto;
+    border-right: 1px solid #ddd;
+    padding: 0.5rem 0;
+}
+
+.task-tree {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.task-item {
+    padding: 0.3rem 0.5rem;
+    cursor: grab;
+    user-select: none;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    border-radius: 3px;
+}
+
+.task-item:active {
+    cursor: grabbing;
+}
+
+.task-item:hover {
+    background: #f0f0f0;
+}
+
+.task-item.classified {
+    font-weight: 500;
+    background: #f7f7fc;
+}
+
+.task-item.checked .task-text {
+    text-decoration: line-through;
+    color: #888;
+}
+
+.task-text {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.eisenhower-badge {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    border: 1px solid #ccc;
+}
+
+.badge-empty {
+    background: transparent;
+    border-color: #ddd;
+}
+
+.badge-urgent-important { background: #d9534f; border-color: #d9534f; }
+.badge-not-urgent-important { background: #5cb85c; border-color: #5cb85c; }
+.badge-urgent-not-important { background: #f0ad4e; border-color: #f0ad4e; }
+.badge-not-urgent-not-important { background: #888; border-color: #888; }
+
+.eisenhower-grid {
+    flex: 1;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr 1fr;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    min-height: 0;
+}
+
+.quadrant {
+    border: 2px dashed #ccc;
+    border-radius: 4px;
+    padding: 0.5rem;
+    overflow-y: auto;
+    background: #fafafa;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.quadrant h3 {
+    margin: 0 0 0.5rem 0;
+    font-size: 1rem;
+}
+
+.q-urgent-important { border-color: #d9534f; }
+.q-not-urgent-important { border-color: #5cb85c; }
+.q-urgent-not-important { border-color: #f0ad4e; }
+.q-not-urgent-not-important { border-color: #888; }
+
+.quadrant ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    overflow-y: auto;
+    flex: 1;
+}
+
+.grid-item {
+    padding: 0.3rem 0.5rem;
+    margin: 0.25rem 0;
+    background: white;
+    border: 1px solid #ddd;
+    border-radius: 3px;
+    cursor: grab;
+}
+
+.grid-item:active {
+    cursor: grabbing;
+}
+
+.grid-item.checked {
+    text-decoration: line-through;
+    color: #888;
+}
+
+.context-menu {
+    position: fixed;
+    background: white;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    z-index: 1000;
+    min-width: 120px;
+}
+
+.context-menu button {
+    display: block;
+    background: none;
+    border: none;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    width: 100%;
+    text-align: left;
+}
+
+.context-menu button:hover {
+    background: #f0f0f0;
+}
+</style>

--- a/tasks/assets/components/Eisenhower.vue
+++ b/tasks/assets/components/Eisenhower.vue
@@ -22,7 +22,7 @@
                         <span
                             class="eisenhower-badge"
                             :class="item.eisenhower ? `badge-${item.eisenhower}` : 'badge-empty'"
-                            :title="item.eisenhower ? quadrantTitle(item.eisenhower) : ''"
+                            :title="item.eisenhower ? quadrantTitleById[item.eisenhower] : ''"
                         ></span>
                         <span class="task-text">{{ item.text }}</span>
                     </li>
@@ -41,7 +41,7 @@
                     <h3>{{ quadrant.title }}</h3>
                     <ul>
                         <li
-                            v-for="item in itemsByQuadrant(quadrant.id)"
+                            v-for="item in itemsByQuadrant[quadrant.id]"
                             :key="item.pathKey"
                             class="grid-item"
                             :class="{ checked: item.checked }"
@@ -131,6 +131,20 @@ export default {
             traverse(this.currentBoard.state || [], [], 0)
             return items
         },
+
+        quadrantTitleById() {
+            return Object.fromEntries(QUADRANTS.map(q => [q.id, q.title]))
+        },
+
+        itemsByQuadrant() {
+            const groups = Object.fromEntries(QUADRANTS.map(q => [q.id, []]))
+            for (const item of this.flatItems) {
+                if (item.eisenhower && groups[item.eisenhower]) {
+                    groups[item.eisenhower].push(item)
+                }
+            }
+            return groups
+        },
     },
 
     mounted() {
@@ -152,15 +166,6 @@ export default {
     },
 
     methods: {
-        quadrantTitle(id) {
-            const q = QUADRANTS.find(q => q.id === id)
-            return q ? q.title : ''
-        },
-
-        itemsByQuadrant(id) {
-            return this.flatItems.filter(item => item.eisenhower === id)
-        },
-
         onDragStart(ev, item) {
             this.draggedItem = item
             ev.dataTransfer.effectAllowed = 'move'

--- a/tasks/assets/components/NodeContent.vue
+++ b/tasks/assets/components/NodeContent.vue
@@ -57,6 +57,13 @@
             ⇒ {{ markers.transition }}
         </span>
 
+        <span
+            v-if="markers.eisenhower"
+            class="has-eisenhower"
+            :class="`eisenhower-${markers.eisenhower}`"
+            :title="eisenhowerTitle"
+        >
+        </span>
 
     </div>
 </template>
@@ -87,7 +94,18 @@ export default {
 
         cappedImportant() {
             return Math.min(this.markers.important, 3)
+        },
+
+        eisenhowerTitle() {
+            const titles = {
+                'urgent-important': 'Urgent & Important',
+                'not-urgent-important': 'Not Urgent & Important',
+                'urgent-not-important': 'Urgent & Not Important',
+                'not-urgent-not-important': 'Not Urgent & Not Important',
+            }
+            return titles[this.markers.eisenhower] || ''
         }
     },
 }
 </script>
+

--- a/tasks/assets/components/hello_world_mount.js
+++ b/tasks/assets/components/hello_world_mount.js
@@ -4,6 +4,7 @@ import VueRouter from 'vue-router'
 import HelloWorldComponent from './hello_world.vue'
 import Board from './Board.vue'
 import Journal from './Journal.vue'
+import Eisenhower from './Eisenhower.vue'
 
 import store from '../store'
 
@@ -39,8 +40,10 @@ const apiRequest = async (url, options = {}) => {
 
 const routes = [
     { path: '/', component: Board },
-    { path: '/board/:slug', component: Board }, 
+    { path: '/board/:slug', component: Board },
     { path: '/journal/:date', component: Journal },
+    { path: '/eisenhower', component: Eisenhower },
+    { path: '/eisenhower/:slug', component: Eisenhower },
 ]
 
 const router = new VueRouter({

--- a/tasks/assets/styles/example.scss
+++ b/tasks/assets/styles/example.scss
@@ -148,6 +148,20 @@ body, html {
     background-color: #9d06a7bf;
 }
 
+.has-eisenhower {
+    position: absolute;
+    bottom: 0;
+    left: 25px;
+    width: 20px;
+    display: block;
+    height: 3px;
+}
+
+.eisenhower-urgent-important { background-color: #d9534fbf; }
+.eisenhower-not-urgent-important { background-color: #5cb85cbf; }
+.eisenhower-urgent-not-important { background-color: #f0ad4ebf; }
+.eisenhower-not-urgent-not-important { background-color: #888888bf; }
+
 .transition {
     color: #999;
     font-size: 0.8em;
@@ -407,6 +421,10 @@ h1 + .cont .menu a:first-child {
 
         .has-finalizing {
             left: 10px;
+        }
+
+        .has-eisenhower {
+            left: 35px;
         }
     }
 

--- a/tasks/assets/utils.js
+++ b/tasks/assets/utils.js
@@ -16,6 +16,7 @@ export function createTreeItem(text="") {
                 // 0...3
                 important: 0,
                 finalizing: false,
+                eisenhower: null,
                 canBeDoneOutsideOfWork: false,
                 canBePostponed: false,
                 // 0+


### PR DESCRIPTION
## Summary
- New `/eisenhower` route with a 20% scrollable task tree and a 2×2 urgency/importance grid; drag from the tree (or between quadrants) to classify, right-click a grid item to remove the status.
- Persistence lives in `meaningfulMarkers.eisenhower` (string enum) and is preserved through commit transitions in `commit.py`.
- Board view shows a colored underline bar in `NodeContent.vue` styled in parallel with `.has-finalizing`, sitting just to the right so both can coexist.
- `createTreeItem` (JS) and `create_task_item` (Python) both initialize the new field for shape consistency.

## Test plan
- [x] `python manage.py test` — 25 tests pass
- [x] Build frontend and load `/eisenhower`; drag items between tree and quadrants
- [x] Right-click a grid item, confirm status is cleared on tree and grid
- [x] Commit a board with classified items; confirm `eisenhower` survives on the next board
- [x] Confirm bar appears on the regular board view next to finalizing without overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)