### PR TITLE
fix: stop board filter from corrupting saved tree state

### DIFF
--- a/tasks/apps/tree/board_operations.py
+++ b/tasks/apps/tree/board_operations.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.shortcuts import get_object_or_404
 
 from .models import Board, Thread
@@ -6,6 +8,7 @@ from .models import Board, Thread
 def create_task_item(text):
     """Creates the data structure for a new task."""
     return {
+        "id": str(uuid.uuid4()),
         "children": [],
         "data": {
             "state": "open",

--- a/tasks/apps/tree/commit.py
+++ b/tasks/apps/tree/commit.py
@@ -1,3 +1,4 @@
+import uuid
 from collections import OrderedDict
 from copy import deepcopy
 from functools import reduce
@@ -88,6 +89,7 @@ def transition_data_in_tree_item(item):
               - Visibility logic: hidden if postponedFor == 1, otherwise visible
     """
     return {
+        "id": item.get("id") or str(uuid.uuid4()),
         "text": item["text"],
         "children": transition_data_between_boards(item["children"]),
         "data": {

--- a/tasks/apps/tree/commit.py
+++ b/tasks/apps/tree/commit.py
@@ -104,7 +104,8 @@ def transition_data_in_tree_item(item):
                 True
                 if item["data"]["meaningfulMarkers"]["postponedFor"] == 1
                 else item.get("state", {}).get("visible", True)
-            )
+            ),
+            "expanded": item.get("state", {}).get("expanded", False),
         },
     }
 

--- a/tasks/assets/components/Board.vue
+++ b/tasks/assets/components/Board.vue
@@ -52,7 +52,7 @@
                 <option value="all">all</option>
                 <option value="important">important</option>
                 <option value="deprecated">deprecated</option>
-                <option value="finalizing">finalizing</option>
+                <option value="finalizing">clearable</option>
                 <optgroup label="MoSCoW">
                     <option value="moscow-must">Must have</option>
                     <option value="moscow-should">Should have</option>

--- a/tasks/assets/components/Board.vue
+++ b/tasks/assets/components/Board.vue
@@ -120,6 +120,11 @@ export default {
             'currentThreadId',
         ]),
 
+        filterMode: {
+            get() { return this.$store.state.filterMode },
+            set(value) { this.$store.commit('setFilterMode', value) }
+        },
+
         normalContext() {
             return !this.editingContext
         },
@@ -160,17 +165,7 @@ export default {
         unwatch: null,
         showCommitModal: false,
         listViewMode: false,
-        filterMode: 'all',
     }),
-
-    provide() {
-        const vm = this
-        return {
-            boardFilter: {
-                get mode() { return vm.filterMode }
-            }
-        }
-    },
 
     watch: {
         filterMode(newMode) {

--- a/tasks/assets/components/Board.vue
+++ b/tasks/assets/components/Board.vue
@@ -167,14 +167,6 @@ export default {
         listViewMode: false,
     }),
 
-    watch: {
-        filterMode(newMode) {
-            if (newMode !== 'all' && this.$refs.tree) {
-                this.$refs.tree.expandAll()
-            }
-        }
-    },
-
     mounted() {
         this.$refs.tree.$on('node:text:changed', (node, text, old) => {
             // console.log('changed text', node, text, old)

--- a/tasks/assets/components/Board.vue
+++ b/tasks/assets/components/Board.vue
@@ -8,7 +8,6 @@
             v-show="!listViewMode"
             :data="currentBoard.state"
             :options="options"
-            :filter="treeFilterQuery"
             ref="tree"
         >
             <template slot-scope="{ node }">
@@ -133,10 +132,6 @@ export default {
             return this.findItemsToBeRemoved(this.currentBoard.state)
         },
 
-        treeFilterQuery() {
-            return this.filterMode === 'all' ? '' : this.filterMode
-        },
-
         options() {
             return {
                 checkbox: true,
@@ -144,10 +139,6 @@ export default {
                 dnd: true,
                 deletion: true,
                 keyboardNavigation: true,
-
-                filter: {
-                    matcher: this.matchesFilter,
-                },
 
                 store: {
                     store: this.$store,
@@ -171,6 +162,23 @@ export default {
         listViewMode: false,
         filterMode: 'all',
     }),
+
+    provide() {
+        const vm = this
+        return {
+            boardFilter: {
+                get mode() { return vm.filterMode }
+            }
+        }
+    },
+
+    watch: {
+        filterMode(newMode) {
+            if (newMode !== 'all' && this.$refs.tree) {
+                this.$refs.tree.expandAll()
+            }
+        }
+    },
 
     mounted() {
         this.$refs.tree.$on('node:text:changed', (node, text, old) => {
@@ -258,38 +266,6 @@ export default {
                 'changeThread',
                 ev.target.value
             )
-        },
-
-        matchesFilter(query, node) {
-            const markers = node.data?.meaningfulMarkers || {}
-
-            if (query === 'important') {
-                return (markers.important || 0) > 0
-            }
-
-            if (query === 'deprecated') {
-                if ((markers.weeksInList || 0) < 5) return false
-                if (node.hasChildren()) return false
-                if (markers.canBePostponed) return false
-                if ((markers.postponedFor || 0) > 0) return false
-                if (markers.madeProgress) return false
-                if (node.states?.checked) return false
-                return true
-            }
-
-            if (query === 'finalizing') {
-                return !!markers.finalizing
-            }
-
-            if (query.startsWith('moscow-')) {
-                return markers.moscow === query.slice('moscow-'.length)
-            }
-
-            if (query.startsWith('eisenhower-')) {
-                return markers.eisenhower === query.slice('eisenhower-'.length)
-            }
-
-            return false
         },
 
         isItemDeprecated(item) {

--- a/tasks/assets/components/Eisenhower.vue
+++ b/tasks/assets/components/Eisenhower.vue
@@ -78,10 +78,10 @@
 import { mapGetters } from 'vuex'
 
 const QUADRANTS = [
-    { id: 'urgent-important', title: 'Urgent & Important' },
-    { id: 'not-urgent-important', title: 'Not Urgent & Important' },
-    { id: 'urgent-not-important', title: 'Urgent & Not Important' },
-    { id: 'not-urgent-not-important', title: 'Not Urgent & Not Important' },
+    { id: 'urgent-important', title: 'Urgent & Important – DO' },
+    { id: 'not-urgent-important', title: 'Not Urgent & Important – SCHEDULE' },
+    { id: 'urgent-not-important', title: 'Urgent & Not Important – DELEGATE' },
+    { id: 'not-urgent-not-important', title: 'Not Urgent & Not Important – ELIMINATE' },
 ]
 
 function deepClone(value) {

--- a/tasks/assets/components/NodeContent.vue
+++ b/tasks/assets/components/NodeContent.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="{ 'filter-hidden': !matchesFilter }">
+    <div :class="rowClasses">
         {{ node.text }}
 
         <span v-if="markers.madeProgress">
@@ -77,6 +77,37 @@
 </template>
 <script>
 
+const FILTER_MODES = [
+    'important',
+    'deprecated',
+    'finalizing',
+    'moscow-must', 'moscow-should', 'moscow-could', 'moscow-wont',
+    'eisenhower-urgent-important', 'eisenhower-not-urgent-important',
+    'eisenhower-urgent-not-important', 'eisenhower-not-urgent-not-important',
+]
+
+function nodeMatchesMode(node, mode) {
+    const markers = node.data?.meaningfulMarkers || {}
+
+    if (mode === 'important') return (markers.important || 0) > 0
+
+    if (mode === 'deprecated') {
+        if ((markers.weeksInList || 0) < 5) return false
+        if (node.hasChildren && node.hasChildren()) return false
+        if (markers.canBePostponed) return false
+        if ((markers.postponedFor || 0) > 0) return false
+        if (markers.madeProgress) return false
+        if (node.states?.checked) return false
+        return true
+    }
+
+    if (mode === 'finalizing') return !!markers.finalizing
+    if (mode.startsWith('moscow-')) return markers.moscow === mode.slice('moscow-'.length)
+    if (mode.startsWith('eisenhower-')) return markers.eisenhower === mode.slice('eisenhower-'.length)
+
+    return false
+}
+
 export default {
 
     props: {
@@ -88,39 +119,35 @@ export default {
             return this.node.data.meaningfulMarkers
         },
 
-        matchesFilter() {
-            const mode = this.$store.state.filterMode
-            if (mode === 'all') return true
+        descendantMatchModes() {
+            const modes = new Set()
+            const walk = (n) => {
+                const children = n.children || []
+                for (const child of children) {
+                    for (const m of FILTER_MODES) {
+                        if (nodeMatchesMode(child, m)) modes.add(m)
+                    }
+                    walk(child)
+                }
+            }
+            walk(this.node)
+            return modes
+        },
 
-            const markers = this.markers || {}
+        rowClasses() {
+            const classes = {}
 
-            if (mode === 'important') {
-                return (markers.important || 0) > 0
+            for (const mode of this.descendantMatchModes) {
+                classes[`has-children-${mode}`] = true
             }
 
-            if (mode === 'deprecated') {
-                if ((markers.weeksInList || 0) < 5) return false
-                if (this.node.hasChildren && this.node.hasChildren()) return false
-                if (markers.canBePostponed) return false
-                if ((markers.postponedFor || 0) > 0) return false
-                if (markers.madeProgress) return false
-                if (this.node.states?.checked) return false
-                return true
+            const active = this.$store.state.filterMode
+            if (active !== 'all') {
+                const selfMatches = nodeMatchesMode(this.node, active)
+                classes['filter-hidden'] = !selfMatches && !this.descendantMatchModes.has(active)
             }
 
-            if (mode === 'finalizing') {
-                return !!markers.finalizing
-            }
-
-            if (mode.startsWith('moscow-')) {
-                return markers.moscow === mode.slice('moscow-'.length)
-            }
-
-            if (mode.startsWith('eisenhower-')) {
-                return markers.eisenhower === mode.slice('eisenhower-'.length)
-            }
-
-            return false
+            return classes
         },
 
         cappedWeeksInList() {

--- a/tasks/assets/components/NodeContent.vue
+++ b/tasks/assets/components/NodeContent.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div :class="{ 'filter-hidden': !matchesFilter }">
         {{ node.text }}
 
         <span v-if="markers.madeProgress">
@@ -83,9 +83,48 @@ export default {
         node: Object,
     },
 
+    inject: {
+        boardFilter: { default: null },
+    },
+
     computed: {
         markers() {
             return this.node.data.meaningfulMarkers
+        },
+
+        matchesFilter() {
+            const mode = this.boardFilter ? this.boardFilter.mode : 'all'
+            if (mode === 'all') return true
+
+            const markers = this.markers || {}
+
+            if (mode === 'important') {
+                return (markers.important || 0) > 0
+            }
+
+            if (mode === 'deprecated') {
+                if ((markers.weeksInList || 0) < 5) return false
+                if (this.node.hasChildren && this.node.hasChildren()) return false
+                if (markers.canBePostponed) return false
+                if ((markers.postponedFor || 0) > 0) return false
+                if (markers.madeProgress) return false
+                if (this.node.states?.checked) return false
+                return true
+            }
+
+            if (mode === 'finalizing') {
+                return !!markers.finalizing
+            }
+
+            if (mode.startsWith('moscow-')) {
+                return markers.moscow === mode.slice('moscow-'.length)
+            }
+
+            if (mode.startsWith('eisenhower-')) {
+                return markers.eisenhower === mode.slice('eisenhower-'.length)
+            }
+
+            return false
         },
 
         cappedWeeksInList() {

--- a/tasks/assets/components/NodeContent.vue
+++ b/tasks/assets/components/NodeContent.vue
@@ -83,17 +83,13 @@ export default {
         node: Object,
     },
 
-    inject: {
-        boardFilter: { default: null },
-    },
-
     computed: {
         markers() {
             return this.node.data.meaningfulMarkers
         },
 
         matchesFilter() {
-            const mode = this.boardFilter ? this.boardFilter.mode : 'all'
+            const mode = this.$store.state.filterMode
             if (mode === 'all') return true
 
             const markers = this.markers || {}

--- a/tasks/assets/components/NodeContent.vue
+++ b/tasks/assets/components/NodeContent.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="rowClasses">
+    <div>
         {{ node.text }}
 
         <span v-if="markers.madeProgress">
@@ -77,8 +77,6 @@
 </template>
 <script>
 
-const EMPTY_MATCHES = { self: new Set(), descendants: new Set() }
-
 export default {
 
     props: {
@@ -88,26 +86,6 @@ export default {
     computed: {
         markers() {
             return this.node.data.meaningfulMarkers
-        },
-
-        filterMatches() {
-            return this.$store.getters.nodeFilterMatches.get(this.node.id) || EMPTY_MATCHES
-        },
-
-        rowClasses() {
-            const classes = {}
-
-            for (const mode of this.filterMatches.descendants) {
-                classes[`has-children-${mode}`] = true
-            }
-
-            const active = this.$store.state.filterMode
-            if (active !== 'all') {
-                classes['filter-hidden'] = !this.filterMatches.self.has(active)
-                    && !this.filterMatches.descendants.has(active)
-            }
-
-            return classes
         },
 
         cappedWeeksInList() {

--- a/tasks/assets/components/NodeContent.vue
+++ b/tasks/assets/components/NodeContent.vue
@@ -77,36 +77,7 @@
 </template>
 <script>
 
-const FILTER_MODES = [
-    'important',
-    'deprecated',
-    'finalizing',
-    'moscow-must', 'moscow-should', 'moscow-could', 'moscow-wont',
-    'eisenhower-urgent-important', 'eisenhower-not-urgent-important',
-    'eisenhower-urgent-not-important', 'eisenhower-not-urgent-not-important',
-]
-
-function nodeMatchesMode(node, mode) {
-    const markers = node.data?.meaningfulMarkers || {}
-
-    if (mode === 'important') return (markers.important || 0) > 0
-
-    if (mode === 'deprecated') {
-        if ((markers.weeksInList || 0) < 5) return false
-        if (node.hasChildren && node.hasChildren()) return false
-        if (markers.canBePostponed) return false
-        if ((markers.postponedFor || 0) > 0) return false
-        if (markers.madeProgress) return false
-        if (node.states?.checked) return false
-        return true
-    }
-
-    if (mode === 'finalizing') return !!markers.finalizing
-    if (mode.startsWith('moscow-')) return markers.moscow === mode.slice('moscow-'.length)
-    if (mode.startsWith('eisenhower-')) return markers.eisenhower === mode.slice('eisenhower-'.length)
-
-    return false
-}
+const EMPTY_MATCHES = { self: new Set(), descendants: new Set() }
 
 export default {
 
@@ -119,32 +90,21 @@ export default {
             return this.node.data.meaningfulMarkers
         },
 
-        descendantMatchModes() {
-            const modes = new Set()
-            const walk = (n) => {
-                const children = n.children || []
-                for (const child of children) {
-                    for (const m of FILTER_MODES) {
-                        if (nodeMatchesMode(child, m)) modes.add(m)
-                    }
-                    walk(child)
-                }
-            }
-            walk(this.node)
-            return modes
+        filterMatches() {
+            return this.$store.getters.nodeFilterMatches.get(this.node.id) || EMPTY_MATCHES
         },
 
         rowClasses() {
             const classes = {}
 
-            for (const mode of this.descendantMatchModes) {
+            for (const mode of this.filterMatches.descendants) {
                 classes[`has-children-${mode}`] = true
             }
 
             const active = this.$store.state.filterMode
             if (active !== 'all') {
-                const selfMatches = nodeMatchesMode(this.node, active)
-                classes['filter-hidden'] = !selfMatches && !this.descendantMatchModes.has(active)
+                classes['filter-hidden'] = !this.filterMatches.self.has(active)
+                    && !this.filterMatches.descendants.has(active)
             }
 
             return classes

--- a/tasks/assets/components/NodeContent.vue
+++ b/tasks/assets/components/NodeContent.vue
@@ -2,14 +2,14 @@
     <div>
         <span
             v-if="markers.moscow"
-            class="node-badge"
+            class="node-badge moscow"
             :class="`moscow-${markers.moscow}`"
             :title="moscowTitle"
         >{{ moscowLabel }}</span>
 
         <span
             v-if="markers.eisenhower"
-            class="node-badge"
+            class="node-badge eisenhower"
             :class="`eisenhower-${markers.eisenhower}`"
             :title="eisenhowerTitle"
         >{{ eisenhowerLabel }}</span>
@@ -115,9 +115,9 @@ export default {
         eisenhowerLabel() {
             const labels = {
                 'urgent-important': 'UI',
-                'not-urgent-important': 'i',
-                'urgent-not-important': 'u',
-                'not-urgent-not-important': '~',
+                'not-urgent-important': '.I',
+                'urgent-not-important': 'U.',
+                'not-urgent-not-important': '..',
             }
             return labels[this.markers.eisenhower] || ''
         },
@@ -134,10 +134,10 @@ export default {
 
         moscowLabel() {
             const labels = {
-                'must': 'Mo',
-                'should': 'S',
+                'must': 'Mu',
+                'should': 'Sh',
                 'could': 'Co',
-                'wont': 'W',
+                'wont': 'Wh',
             }
             return labels[this.markers.moscow] || ''
         }

--- a/tasks/assets/components/NodeContent.vue
+++ b/tasks/assets/components/NodeContent.vue
@@ -1,5 +1,19 @@
 <template>
     <div>
+        <span
+            v-if="markers.moscow"
+            class="node-badge"
+            :class="`moscow-${markers.moscow}`"
+            :title="moscowTitle"
+        >{{ moscowLabel }}</span>
+
+        <span
+            v-if="markers.eisenhower"
+            class="node-badge"
+            :class="`eisenhower-${markers.eisenhower}`"
+            :title="eisenhowerTitle"
+        >{{ eisenhowerLabel }}</span>
+
         {{ node.text }}
 
         <span v-if="markers.madeProgress">
@@ -57,22 +71,6 @@
             ⇒ {{ markers.transition }}
         </span>
 
-        <span
-            v-if="markers.eisenhower"
-            class="has-eisenhower"
-            :class="`eisenhower-${markers.eisenhower}`"
-            :title="eisenhowerTitle"
-        >
-        </span>
-
-        <span
-            v-if="markers.moscow"
-            class="has-moscow"
-            :class="`moscow-${markers.moscow}`"
-            :title="moscowTitle"
-        >
-        </span>
-
     </div>
 </template>
 <script>
@@ -114,6 +112,16 @@ export default {
             return titles[this.markers.eisenhower] || ''
         },
 
+        eisenhowerLabel() {
+            const labels = {
+                'urgent-important': 'UI',
+                'not-urgent-important': 'i',
+                'urgent-not-important': 'u',
+                'not-urgent-not-important': '~',
+            }
+            return labels[this.markers.eisenhower] || ''
+        },
+
         moscowTitle() {
             const titles = {
                 'must': 'Must have',
@@ -122,6 +130,16 @@ export default {
                 'wont': "Won't have",
             }
             return titles[this.markers.moscow] || ''
+        },
+
+        moscowLabel() {
+            const labels = {
+                'must': 'Mo',
+                'should': 'S',
+                'could': 'Co',
+                'wont': 'W',
+            }
+            return labels[this.markers.moscow] || ''
         }
     },
 }

--- a/tasks/assets/liquor-tree/src/components/TreeNode.vue
+++ b/tasks/assets/liquor-tree/src/components/TreeNode.vue
@@ -106,6 +106,20 @@
             classes[name] = !!this.node.data.meaningfulMarkers[name]
         })
 
+        const store = this.tree?.vm?.$store
+        if (store) {
+          const matches = store.getters.nodeFilterMatches.get(this.node.id)
+          if (matches) {
+            for (const mode of matches.descendants) {
+              classes[`has-children-${mode}`] = true
+            }
+            const active = store.state.filterMode
+            if (active !== 'all') {
+              classes['filter-hidden'] = !matches.self.has(active) && !matches.descendants.has(active)
+            }
+          }
+        }
+
         return classes
       }
     },

--- a/tasks/assets/liquor-tree/src/lib/Node.js
+++ b/tasks/assets/liquor-tree/src/lib/Node.js
@@ -686,6 +686,7 @@ export default class Node {
 
   toJSON () {
     return {
+      id: this.id,
       text: this.text,
       data: this.data,
       state: this.states,

--- a/tasks/assets/store.js
+++ b/tasks/assets/store.js
@@ -19,7 +19,7 @@ const apiRequest = async (url, options = {}) => {
     return response.json();
 };
 
-import { createTreeItem, createBoard, FILTER_MODES, nodeMatchesMode } from './utils'
+import { createTreeItem, createBoard, FILTER_MODES, nodeMatchesMode, ensureItemIds } from './utils'
 
 import equal from 'deep-equal'
 
@@ -108,10 +108,15 @@ export default {
 
     mutations: {
         setListResponse(state, payload) {
+            for (const board of payload?.results || []) {
+                ensureItemIds(board.state)
+            }
             state.listResponse = payload
         },
 
         updateBoardInListResponse(state, payload) {
+            ensureItemIds(payload.state)
+
             const index = state.listResponse.results.findIndex((item) => {
                 item.id === payload.id
             })

--- a/tasks/assets/store.js
+++ b/tasks/assets/store.js
@@ -52,6 +52,7 @@ export default {
         listResponse: null,
         threads: null,
         currentThreadPtr: name_ptr(DEFAULT_NAME),
+        filterMode: 'all',
     },
 
     getters: {
@@ -108,6 +109,10 @@ export default {
 
         setCurrentThreadName(state, threadName) {
             state.currentThreadPtr = name_ptr(threadName);
+        },
+
+        setFilterMode(state, mode) {
+            state.filterMode = mode;
         }
     },
 

--- a/tasks/assets/store.js
+++ b/tasks/assets/store.js
@@ -19,7 +19,7 @@ const apiRequest = async (url, options = {}) => {
     return response.json();
 };
 
-import { createTreeItem, createBoard } from './utils'
+import { createTreeItem, createBoard, FILTER_MODES, nodeMatchesMode } from './utils'
 
 import equal from 'deep-equal'
 
@@ -77,6 +77,32 @@ export default {
             return  state.threads && state.threads.count
                 ? state.threads.results
                 : [];
+        },
+
+        nodeFilterMatches(state, getters) {
+            const result = new Map()
+            const walk = (node) => {
+                const self = new Set()
+                for (const mode of FILTER_MODES) {
+                    if (nodeMatchesMode(node, mode)) self.add(mode)
+                }
+
+                const descendants = new Set()
+                for (const child of (node.children || [])) {
+                    walk(child)
+                    const entry = result.get(child.id)
+                    if (entry) {
+                        for (const m of entry.self) descendants.add(m)
+                        for (const m of entry.descendants) descendants.add(m)
+                    }
+                }
+
+                result.set(node.id, { self, descendants })
+            }
+            for (const root of (getters.currentBoard.state || [])) {
+                walk(root)
+            }
+            return result
         }
     },
 

--- a/tasks/assets/styles/example.scss
+++ b/tasks/assets/styles/example.scss
@@ -140,41 +140,13 @@ body, html {
 
 .has-finalizing {
     position: absolute;
-    bottom: 0;
+    bottom: -2px;
     left: 0;
     width: 20px;
     display: block;
     height: 3px;
     background-color: #9d06a7bf;
 }
-
-.has-eisenhower {
-    position: absolute;
-    bottom: 0;
-    left: 25px;
-    width: 20px;
-    display: block;
-    height: 3px;
-}
-
-.eisenhower-urgent-important { background-color: #d9534fbf; }
-.eisenhower-not-urgent-important { background-color: #5cb85cbf; }
-.eisenhower-urgent-not-important { background-color: #f0ad4ebf; }
-.eisenhower-not-urgent-not-important { background-color: #888888bf; }
-
-.has-moscow {
-    position: absolute;
-    bottom: 0;
-    left: 50px;
-    width: 20px;
-    display: block;
-    height: 3px;
-}
-
-.moscow-must { background-color: #b91c1cbf; }
-.moscow-should { background-color: #d97706bf; }
-.moscow-could { background-color: #0d9488bf; }
-.moscow-wont { background-color: #64748bbf; }
 
 .transition {
     color: #999;

--- a/tasks/assets/styles/tree.scss
+++ b/tasks/assets/styles/tree.scss
@@ -18,7 +18,7 @@
   height: calc(100vh - #{$lower-pane} - #{$upper-pane});
 }
 
-.tree-node:has(> .tree-content > .tree-anchor > .tree-text.filter-hidden) {
+.tree-node.filter-hidden {
   display: none;
 }
 

--- a/tasks/assets/styles/tree.scss
+++ b/tasks/assets/styles/tree.scss
@@ -36,6 +36,24 @@
   vertical-align: middle;
 }
 
+.node-badge.eisenhower {
+  border: 1px solid #999;
+  color: #333;
+  box-sizing: border-box;
+  
+  &.eisenhower-urgent-important { border-color: #d9534f; color: #d9534f; }
+  &.eisenhower-not-urgent-important { border-color: #5cb85c; color: #5cb85c; }
+  &.eisenhower-urgent-not-important { border-color: #f0ad4e; color: #f0ad4e; }
+  &.eisenhower-not-urgent-not-important { border-color: #888888; color: #888888; }
+}
+
+.node-badge.moscow {
+  &.moscow-must { background-color: #b91c1cbf; }
+  &.moscow-should { background-color: #d97706bf; }
+  &.moscow-could { background-color: #0d9488bf; }
+  &.moscow-wont { background-color: #64748bbf; }
+}
+
 .tree-node.has-child > .tree-content .tree-checkbox {
   display: none;
 }

--- a/tasks/assets/styles/tree.scss
+++ b/tasks/assets/styles/tree.scss
@@ -18,7 +18,7 @@
   height: calc(100vh - #{$lower-pane} - #{$upper-pane});
 }
 
-.tree-node:has(> .tree-content > .tree-anchor > .tree-text.filter-hidden):not(:has(.tree-children :is(.tree-text:not(.filter-hidden), .tree-input))) {
+.tree-node:has(> .tree-content > .tree-anchor > .tree-text.filter-hidden) {
   display: none;
 }
 

--- a/tasks/assets/styles/tree.scss
+++ b/tasks/assets/styles/tree.scss
@@ -18,6 +18,10 @@
   height: calc(100vh - #{$lower-pane} - #{$upper-pane});
 }
 
+.tree-node:has(> .tree-content > .tree-anchor > .tree-text.filter-hidden):not(:has(.tree-children :is(.tree-text:not(.filter-hidden), .tree-input))) {
+  display: none;
+}
+
 .tree-node.has-child > .tree-content .tree-checkbox {
   display: none;
 }

--- a/tasks/assets/styles/tree.scss
+++ b/tasks/assets/styles/tree.scss
@@ -22,6 +22,20 @@
   display: none;
 }
 
+.node-badge {
+  display: inline-block;
+  min-width: 18px;
+  padding: 0 4px;
+  margin-right: 4px;
+  border-radius: 3px;
+  color: #fff;
+  font-size: 0.75em;
+  font-weight: 600;
+  line-height: 1.5;
+  text-align: center;
+  vertical-align: middle;
+}
+
 .tree-node.has-child > .tree-content .tree-checkbox {
   display: none;
 }

--- a/tasks/assets/utils.js
+++ b/tasks/assets/utils.js
@@ -43,6 +43,37 @@ export function createBoard() {
     }
 }
 
+export const FILTER_MODES = [
+    'important',
+    'deprecated',
+    'finalizing',
+    'moscow-must', 'moscow-should', 'moscow-could', 'moscow-wont',
+    'eisenhower-urgent-important', 'eisenhower-not-urgent-important',
+    'eisenhower-urgent-not-important', 'eisenhower-not-urgent-not-important',
+]
+
+export function nodeMatchesMode(node, mode) {
+    const markers = node.data?.meaningfulMarkers || {}
+
+    if (mode === 'important') return (markers.important || 0) > 0
+
+    if (mode === 'deprecated') {
+        if ((markers.weeksInList || 0) < 5) return false
+        if (node.children && node.children.length > 0) return false
+        if (markers.canBePostponed) return false
+        if ((markers.postponedFor || 0) > 0) return false
+        if (markers.madeProgress) return false
+        if (node.state?.checked) return false
+        return true
+    }
+
+    if (mode === 'finalizing') return !!markers.finalizing
+    if (mode.startsWith('moscow-')) return markers.moscow === mode.slice('moscow-'.length)
+    if (mode.startsWith('eisenhower-')) return markers.eisenhower === mode.slice('eisenhower-'.length)
+
+    return false
+}
+
 export function promisifyTimeout(ms) {
     return new Promise((resolve) => {
         setTimeout(() => resolve(), ms)

--- a/tasks/assets/utils.js
+++ b/tasks/assets/utils.js
@@ -8,8 +8,25 @@ export function treeItemForRootAndPath(root, path) {
     }, root)
 }
 
+function s4() {
+    return Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1)
+}
+
+export function makeId() {
+    return s4() + s4() + '-' + s4() + '-' + s4() + '-' + s4() + '-' + s4() + s4() + s4()
+}
+
+export function ensureItemIds(items) {
+    if (!Array.isArray(items)) return
+    for (const item of items) {
+        if (!item.id) item.id = makeId()
+        if (item.children) ensureItemIds(item.children)
+    }
+}
+
 export function createTreeItem(text="") {
     return {
+        id: makeId(),
         data: {
             meaningfulMarkers: {
                 weeksInList: 0,


### PR DESCRIPTION
## Summary
Fix the bug where toggling the board filter persisted every row as hidden in the saved state, then layer on several related cleanups and a small UI rework while we were in there.

### Root cause
The tree's built-in `filter` prop mutates each node's `visible` state. Liquor-tree's `toJSON()` serializes that state, so every commit was writing back rows as not-visible.

### Filter rework
- **Stop using the library filter.** Visibility now comes from a `filter-hidden` class injected via `TreeNode.vue`'s existing `nodeClass` computed (which already injects marker-derived classes like `important`, `finalizing`). Node DOM is never mutated.
- **CSS** reduces to `.tree-node.filter-hidden { display: none }` — no `:has()` selector, no dependence on whether the inner `.tree-text` or `.tree-input` is currently rendered, so editing a node doesn't break visibility.
- **`filterMode` moves into the Vuex store**, next to the rest of the board state.

### Per-mode descendant classes
Each tree-node also receives `has-children-<mode>` classes for every filter mode any descendant matches (e.g. `has-children-eisenhower-urgent-important`, `has-children-moscow-must`), available for custom styling. No `expandAll()` needed when activating a filter — collapsed parents of matches stay visible on their own.

### Performance
`nodeFilterMatches` getter does one post-order walk of `currentBoard.state` and returns `Map<id, { self: Set<mode>, descendants: Set<mode> }>`. Each `TreeNode` does an O(1) lookup, taking total work per board change from O(N²) to O(N).

### Stable ids end-to-end
The Map-by-id approach required every raw item to actually carry an id, which they didn't — Django's `create_task_item` omitted it and liquor-tree's `toJSON` dropped the UUID it generated internally, so the Map was keyed by `undefined` everywhere. Fixed:
- `utils.ensureItemIds` backfills ids on items entering the Vuex store (`setListResponse`, `updateBoardInListResponse`).
- `createTreeItem` (JS) and `create_task_item` (Python) stamp an id on creation.
- Liquor-tree's `Node.toJSON()` now emits `id`, so ids survive the save round-trip.
- `transition_data_in_tree_item` preserves `id` through the commit transition (falls back to a fresh UUID for legacy items without one), and also preserves `state.expanded` so the user's collapse/expand state isn't reset on every commit.

### MoSCoW / Eisenhower badges
The empty bottom-bar indicator spans are replaced with inline text badges to the left of the node text:
- **MoSCoW**: `Mu` / `Sh` / `Co` / `Wh` — solid-fill badges (`.node-badge.moscow`).
- **Eisenhower**: `UI` / `.I` / `U.` / `..` — outline-style badges (colored border + colored text, `.node-badge.eisenhower`).
Eisenhower quadrant titles in the dedicated view also gain the action verb suffix (DO / SCHEDULE / DELEGATE / ELIMINATE), and the `finalizing` filter option label is renamed to `clearable` (value unchanged).

## Test plan
- [x] Toggle each filter mode (important, deprecated, clearable, MoSCoW × 4, Eisenhower × 4) — only matching rows + their ancestors are visible.
- [x] Apply a filter, commit/save the board, switch back to `all` — no rows are missing (saved state is clean).
- [x] Apply a filter, double-click a matching node to edit — the row stays visible, ancestors remain visible, blur saves correctly.
- [x] Collapse a branch, then activate a filter that matches inside it — branch stays visible without auto-expand; expanding shows the matches.
- [x] `all` mode behaves identically to before (no class on any row, nothing hidden).
- [x] Inspect a parent of a matching leaf — confirm `has-children-<mode>` class is present on the `<li class="tree-node">`.
- [x] Commit a board, then check that node ids persist on the new board and `state.expanded` on collapsed nodes is preserved.
- [x] Confirm the new MoSCoW / Eisenhower badges render to the left of node text with the right labels and colors, and that hover tooltips show full names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)