### PR TITLE
feat: add Android companion app to push Health Connect metrics

### DIFF
--- a/.github/workflows/rsync.exclude
+++ b/.github/workflows/rsync.exclude
@@ -1,4 +1,5 @@
 /node_modules
+/android
 /docker
 /docs
 /tools

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,0 +1,14 @@
+*.iml
+.gradle
+/local.properties
+.idea/
+.DS_Store
+build/
+captures/
+.externalNativeBuild
+.cxx
+local.properties
+
+# Wrapper JAR is intentionally NOT committed here; run `gradle wrapper` once
+# (see README) or open the project in Android Studio to generate it.
+gradle/wrapper/gradle-wrapper.jar

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,105 @@
+# Tasks Health — Android companion app
+
+Reads daily steps, distance, and active minutes from Android Health Connect on
+the phone and pushes them to the `tasks-collector` backend as `HabitTracked`
+events on a single `#health-metrics` habit.
+
+This is the implementation of the alternative named in
+`docs/adr/0001-defer-google-health-api-integration.md` — phone-collected
+metrics, no Fitbit linkage, no cloud Google Health API.
+
+## What the app pushes
+
+One `HabitTracked` event per day on the `health-metrics` habit, with the
+metrics packed into the event `note`, e.g.
+
+```
+steps=8520 distance=6.2km active=42min
+```
+
+The endpoint is idempotent on `(habit, date)`: re-syncing the same day updates
+the row rather than inserting a duplicate.
+
+Heart Points are **not** computed in this version (Health Connect doesn't
+expose them; see the ADR).
+
+## One-time backend setup
+
+1. Apply migrations to create the DRF authtoken table:
+
+   ```bash
+   docker compose -f docker/development/docker-compose.yml \
+     exec tasks-backend python manage.py migrate
+   ```
+
+2. In the Django admin (`/admin/`) create:
+
+   - A `Habit` with a `slug` and `name` of your choice.
+   - A `HabitKeyword` with `keyword = health-metrics` pointing at that habit.
+     The API looks the habit up by keyword text, so the slug can be anything.
+
+3. Mint a token for the user the phone will authenticate as:
+
+   ```bash
+   docker compose -f docker/development/docker-compose.yml \
+     exec tasks-backend python manage.py issue_mobile_token <username>
+   ```
+
+   This prints the token to stdout. Rotate at any time with `--rotate`.
+
+## Building and installing the app
+
+The Gradle wrapper jar (`gradle/wrapper/gradle-wrapper.jar`) is intentionally
+not committed. Choose one of:
+
+- **Open `android/` in Android Studio** — it will populate the wrapper for
+  you and let you run on a connected device with the green "Run" button.
+- Or, with a system Gradle (≥ 8.10) installed, generate the wrapper once:
+
+  ```bash
+  cd android
+  gradle wrapper --gradle-version 8.10.2
+  ```
+
+  Then build and install a debug APK on a connected device:
+
+  ```bash
+  ./gradlew :app:assembleDebug
+  adb install -r app/build/outputs/apk/debug/app-debug.apk
+  ```
+
+## On-device setup
+
+1. Make sure Health Connect is installed (built into Android 14+, available
+   from Play Store for Android 13 and earlier) and that another app is
+   actually writing step / distance / exercise data to it.
+2. Launch **Tasks Health**.
+3. Enter the **Server URL** (e.g. `https://tasks.example.com`) and paste the
+   **API token** from the management command above. Tap **Save**.
+4. Tap **Grant Health Connect permissions** and allow read access for steps,
+   distance, and exercise sessions. Health Connect will also ask separately for
+   **"Access data while in the background"** — enable that too, otherwise the
+   periodic sync worker can't read anything and you'll see a permissions error
+   on the next sync.
+5. Tap **Sync now** to verify the wiring. The screen shows a "Last sync"
+   timestamp on success or an error message on failure.
+
+Two background `WorkManager` jobs handle automatic syncing:
+
+- A **six-hour** periodic worker for best-effort frequent updates.
+- A **daily** periodic worker that acts as a backstop, so a day never passes
+  without at least one push even if the six-hour worker is deferred by Doze or
+  battery throttling.
+
+Both require network and reuse the same idempotent worker code, so the overlap
+is harmless — the backend collapses retries on `(habit, day)`. Every run
+syncs both today and yesterday so late-evening activity is not lost when the
+day rolls over.
+
+## Tests
+
+JVM unit tests live under `app/src/test/`. Run them with:
+
+```bash
+./gradlew :app:test
+```

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,0 +1,73 @@
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+android {
+    namespace = "com.dragonee.tasks.health"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "com.dragonee.tasks.health"
+        minSdk = 26
+        targetSdk = 35
+        versionCode = 1
+        versionName = "0.1.0"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+}
+
+dependencies {
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.activity.compose)
+
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.tooling.preview)
+    implementation(libs.androidx.compose.material3)
+    debugImplementation(libs.androidx.compose.ui.tooling)
+
+    implementation(libs.androidx.health.connect)
+    implementation(libs.androidx.work.runtime.ktx)
+    implementation(libs.androidx.datastore.preferences)
+
+    implementation(libs.retrofit.core)
+    implementation(libs.retrofit.kotlinx.serialization)
+    implementation(libs.okhttp.logging)
+    implementation(libs.kotlinx.serialization.json)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+}

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,11 @@
+# Keep generated Kotlinx Serialization companions
+-keepattributes *Annotation*, InnerClasses
+-dontnote kotlinx.serialization.AnnotationsKt
+
+-keep,includedescriptorclasses class com.dragonee.tasks.health.**$$serializer { *; }
+-keepclassmembers class com.dragonee.tasks.health.** {
+    *** Companion;
+}
+-keepclasseswithmembers class com.dragonee.tasks.health.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:usesCleartextTraffic="true" />
+
+</manifest>

--- a/android/app/src/debug/res/xml/network_security_config.xml
+++ b/android/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Debug builds only: allow plain HTTP for local dev backends.
+         Release builds inherit Android's default (HTTPS only). -->
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
+    <uses-permission android:name="android.permission.health.READ_STEPS" />
+    <uses-permission android:name="android.permission.health.READ_DISTANCE" />
+    <uses-permission android:name="android.permission.health.READ_EXERCISE" />
+    <uses-permission android:name="android.permission.health.READ_HEALTH_DATA_IN_BACKGROUND" />
+
+    <queries>
+        <package android:name="com.google.android.apps.healthdata" />
+    </queries>
+
+    <application
+        android:name=".TasksHealthApp"
+        android:label="@string/app_name"
+        android:icon="@android:drawable/sym_def_app_icon"
+        android:theme="@style/Theme.TasksHealth"
+        android:allowBackup="false"
+        android:supportsRtl="true">
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <!-- Health Connect privacy-policy entry point (Android 14+ in-app).
+             The Health Connect UI opens this rationale Activity when the
+             user taps "View privacy policy" next to the app's permissions. -->
+        <activity-alias
+            android:name="ViewPermissionUsageActivity"
+            android:exported="true"
+            android:targetActivity=".MainActivity"
+            android:permission="android.permission.START_VIEW_PERMISSION_USAGE">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW_PERMISSION_USAGE" />
+                <category android:name="android.intent.category.HEALTH_PERMISSIONS" />
+            </intent-filter>
+        </activity-alias>
+
+        <!-- Pre-Android-14 Health Connect APK uses a different action for the
+             same privacy-policy rationale entry point. -->
+        <activity-alias
+            android:name="ViewPermissionUsageActivityLegacy"
+            android:exported="true"
+            android:targetActivity=".MainActivity">
+            <intent-filter>
+                <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE" />
+            </intent-filter>
+        </activity-alias>
+
+    </application>
+</manifest>

--- a/android/app/src/main/java/com/dragonee/tasks/health/MainActivity.kt
+++ b/android/app/src/main/java/com/dragonee/tasks/health/MainActivity.kt
@@ -1,0 +1,22 @@
+package com.dragonee.tasks.health
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import com.dragonee.tasks.health.ui.SettingsScreen
+
+class MainActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaterialTheme {
+                Surface(color = MaterialTheme.colorScheme.background) {
+                    SettingsScreen()
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/dragonee/tasks/health/TasksHealthApp.kt
+++ b/android/app/src/main/java/com/dragonee/tasks/health/TasksHealthApp.kt
@@ -1,0 +1,9 @@
+package com.dragonee.tasks.health
+
+import android.app.Application
+import com.dragonee.tasks.health.data.Settings
+
+class TasksHealthApp : Application() {
+
+    val settings: Settings by lazy { Settings(applicationContext) }
+}

--- a/android/app/src/main/java/com/dragonee/tasks/health/data/HealthRepository.kt
+++ b/android/app/src/main/java/com/dragonee/tasks/health/data/HealthRepository.kt
@@ -1,0 +1,88 @@
+package com.dragonee.tasks.health.data
+
+import android.content.Context
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.aggregate.AggregationResult
+import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.DistanceRecord
+import androidx.health.connect.client.records.ExerciseSessionRecord
+import androidx.health.connect.client.records.StepsRecord
+import androidx.health.connect.client.request.AggregateRequest
+import androidx.health.connect.client.request.ReadRecordsRequest
+import androidx.health.connect.client.time.TimeRangeFilter
+import java.time.Duration
+import java.time.LocalDate
+import java.time.ZoneId
+
+data class DailyMetrics(
+    val date: LocalDate,
+    val steps: Long,
+    val distanceMeters: Double,
+    val activeMinutes: Long,
+)
+
+/**
+ * The string constant for Health Connect's background-read permission. Spelled
+ * out here (rather than imported from [HealthPermission]) because the SDK
+ * constant name has shifted across alpha versions; the manifest permission
+ * identifier is the stable contract.
+ */
+private const val PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND =
+    "android.permission.health.READ_HEALTH_DATA_IN_BACKGROUND"
+
+class HealthRepository(private val context: Context) {
+
+    val permissions: Set<String> = setOf(
+        HealthPermission.getReadPermission(StepsRecord::class),
+        HealthPermission.getReadPermission(DistanceRecord::class),
+        HealthPermission.getReadPermission(ExerciseSessionRecord::class),
+        PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND,
+    )
+
+    fun availability(): Int = HealthConnectClient.getSdkStatus(context)
+
+    fun client(): HealthConnectClient = HealthConnectClient.getOrCreate(context)
+
+    suspend fun hasAllPermissions(): Boolean {
+        val granted = client().permissionController.getGrantedPermissions()
+        return granted.containsAll(permissions)
+    }
+
+    suspend fun aggregateDay(date: LocalDate, zone: ZoneId = ZoneId.systemDefault()): DailyMetrics {
+        val client = client()
+        val startInstant = date.atStartOfDay(zone).toInstant()
+        val endInstant = date.plusDays(1).atStartOfDay(zone).toInstant()
+        val range = TimeRangeFilter.between(startInstant, endInstant)
+
+        val aggregate: AggregationResult = client.aggregate(
+            AggregateRequest(
+                metrics = setOf(
+                    StepsRecord.COUNT_TOTAL,
+                    DistanceRecord.DISTANCE_TOTAL,
+                ),
+                timeRangeFilter = range,
+            )
+        )
+
+        val steps = aggregate[StepsRecord.COUNT_TOTAL] ?: 0L
+        val distanceMeters = aggregate[DistanceRecord.DISTANCE_TOTAL]?.inMeters ?: 0.0
+
+        val sessions = client.readRecords(
+            ReadRecordsRequest(
+                recordType = ExerciseSessionRecord::class,
+                timeRangeFilter = range,
+            )
+        ).records
+
+        val activeMinutes = sessions.sumOf { session ->
+            Duration.between(session.startTime, session.endTime).toMinutes()
+        }
+
+        return DailyMetrics(
+            date = date,
+            steps = steps,
+            distanceMeters = distanceMeters,
+            activeMinutes = activeMinutes,
+        )
+    }
+}

--- a/android/app/src/main/java/com/dragonee/tasks/health/data/Settings.kt
+++ b/android/app/src/main/java/com/dragonee/tasks/health/data/Settings.kt
@@ -1,0 +1,64 @@
+package com.dragonee.tasks.health.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
+
+data class SettingsSnapshot(
+    val serverUrl: String,
+    val apiToken: String,
+    val lastSyncEpochMs: Long,
+    val lastSyncError: String,
+) {
+    val isConfigured: Boolean get() = serverUrl.isNotBlank() && apiToken.isNotBlank()
+}
+
+class Settings(private val context: Context) {
+
+    val flow: Flow<SettingsSnapshot> = context.dataStore.data.map { prefs ->
+        SettingsSnapshot(
+            serverUrl = prefs[SERVER_URL].orEmpty(),
+            apiToken = prefs[API_TOKEN].orEmpty(),
+            lastSyncEpochMs = prefs[LAST_SYNC_MS] ?: 0L,
+            lastSyncError = prefs[LAST_SYNC_ERROR].orEmpty(),
+        )
+    }
+
+    suspend fun snapshot(): SettingsSnapshot = flow.first()
+
+    suspend fun saveServerConfig(url: String, token: String) {
+        context.dataStore.edit { prefs ->
+            prefs[SERVER_URL] = url.trim()
+            prefs[API_TOKEN] = token.trim()
+        }
+    }
+
+    suspend fun recordSyncSuccess(epochMs: Long) {
+        context.dataStore.edit { prefs ->
+            prefs[LAST_SYNC_MS] = epochMs
+            prefs.remove(LAST_SYNC_ERROR)
+        }
+    }
+
+    suspend fun recordSyncFailure(error: String) {
+        context.dataStore.edit { prefs ->
+            prefs[LAST_SYNC_ERROR] = error
+        }
+    }
+
+    private companion object {
+        val SERVER_URL = stringPreferencesKey("server_url")
+        val API_TOKEN = stringPreferencesKey("api_token")
+        val LAST_SYNC_MS = longPreferencesKey("last_sync_ms")
+        val LAST_SYNC_ERROR = stringPreferencesKey("last_sync_error")
+    }
+}

--- a/android/app/src/main/java/com/dragonee/tasks/health/data/TasksApi.kt
+++ b/android/app/src/main/java/com/dragonee/tasks/health/data/TasksApi.kt
@@ -1,0 +1,23 @@
+package com.dragonee.tasks.health.data
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+@Serializable
+data class TrackHabitRequest(
+    @SerialName("keyword") val keyword: String,
+    @SerialName("date") val date: String,
+    @SerialName("note") val note: String,
+)
+
+@Serializable
+data class TrackHabitResponse(
+    @SerialName("ok") val ok: Boolean,
+)
+
+interface TasksApi {
+    @POST("api/v1/habit/track/")
+    suspend fun trackHabit(@Body body: TrackHabitRequest): TrackHabitResponse
+}

--- a/android/app/src/main/java/com/dragonee/tasks/health/data/TasksClient.kt
+++ b/android/app/src/main/java/com/dragonee/tasks/health/data/TasksClient.kt
@@ -1,0 +1,40 @@
+package com.dragonee.tasks.health.data
+
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+
+object TasksClient {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    fun build(serverUrl: String, apiToken: String): TasksApi {
+        val baseUrl = serverUrl.trimEnd('/') + "/"
+
+        val okHttp = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val request = chain.request().newBuilder()
+                    .header("Authorization", "Token $apiToken")
+                    .header("Accept", "application/json")
+                    .build()
+                chain.proceed(request)
+            }
+            .addInterceptor(HttpLoggingInterceptor().apply {
+                level = HttpLoggingInterceptor.Level.BASIC
+            })
+            .build()
+
+        return Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .client(okHttp)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+            .create(TasksApi::class.java)
+    }
+}

--- a/android/app/src/main/java/com/dragonee/tasks/health/sync/HealthSyncWorker.kt
+++ b/android/app/src/main/java/com/dragonee/tasks/health/sync/HealthSyncWorker.kt
@@ -1,0 +1,61 @@
+package com.dragonee.tasks.health.sync
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.dragonee.tasks.health.data.HealthRepository
+import com.dragonee.tasks.health.data.Settings
+import com.dragonee.tasks.health.data.TasksClient
+import com.dragonee.tasks.health.data.TrackHabitRequest
+import java.time.LocalDate
+import java.time.ZoneId
+
+class HealthSyncWorker(
+    appContext: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(appContext, params) {
+
+    private val settings = Settings(applicationContext)
+    private val health = HealthRepository(applicationContext)
+
+    override suspend fun doWork(): Result {
+        val snapshot = settings.snapshot()
+        if (!snapshot.isConfigured) {
+            settings.recordSyncFailure("Server URL or API token not set")
+            return Result.failure()
+        }
+
+        return try {
+            if (!health.hasAllPermissions()) {
+                settings.recordSyncFailure("Health Connect permissions not granted")
+                return Result.failure()
+            }
+
+            val api = TasksClient.build(snapshot.serverUrl, snapshot.apiToken)
+            val today = LocalDate.now(ZoneId.systemDefault())
+            val yesterday = today.minusDays(1)
+
+            for (day in listOf(yesterday, today)) {
+                val metrics = health.aggregateDay(day)
+                val note = NoteFormatter.format(metrics)
+                api.trackHabit(
+                    TrackHabitRequest(
+                        keyword = HABIT_KEYWORD,
+                        date = day.toString(),
+                        note = note,
+                    )
+                )
+            }
+
+            settings.recordSyncSuccess(System.currentTimeMillis())
+            Result.success()
+        } catch (t: Throwable) {
+            settings.recordSyncFailure(t.message ?: t::class.java.simpleName)
+            Result.retry()
+        }
+    }
+
+    companion object {
+        const val HABIT_KEYWORD = "health-metrics"
+    }
+}

--- a/android/app/src/main/java/com/dragonee/tasks/health/sync/NoteFormatter.kt
+++ b/android/app/src/main/java/com/dragonee/tasks/health/sync/NoteFormatter.kt
@@ -1,0 +1,13 @@
+package com.dragonee.tasks.health.sync
+
+import com.dragonee.tasks.health.data.DailyMetrics
+import java.util.Locale
+
+object NoteFormatter {
+
+    fun format(metrics: DailyMetrics): String {
+        val km = metrics.distanceMeters / 1000.0
+        val distanceStr = String.format(Locale.US, "%.1f", km)
+        return "steps=${metrics.steps} distance=${distanceStr}km active=${metrics.activeMinutes}min"
+    }
+}

--- a/android/app/src/main/java/com/dragonee/tasks/health/sync/SyncScheduler.kt
+++ b/android/app/src/main/java/com/dragonee/tasks/health/sync/SyncScheduler.kt
@@ -1,0 +1,80 @@
+package com.dragonee.tasks.health.sync
+
+import android.content.Context
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+object SyncScheduler {
+
+    private const val PERIODIC = "health-sync-periodic"
+    private const val DAILY = "health-sync-daily"
+    private const val ONE_OFF = "health-sync-once"
+
+    private val networkConstraints = Constraints.Builder()
+        .setRequiredNetworkType(NetworkType.CONNECTED)
+        .build()
+
+    /** Enqueues both the every-6-hours best-effort job and the daily backstop. */
+    fun schedule(context: Context) {
+        schedulePeriodic(context)
+        scheduleDaily(context)
+    }
+
+    fun schedulePeriodic(context: Context) {
+        val request = PeriodicWorkRequestBuilder<HealthSyncWorker>(Duration.ofHours(6))
+            .setConstraints(networkConstraints)
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 15, TimeUnit.MINUTES)
+            .build()
+
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            PERIODIC,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            request,
+        )
+    }
+
+    /**
+     * Daily backstop. WorkManager picks a time within each 24-hour window to
+     * run the job, respecting Doze and battery state. The 6-hour periodic job
+     * still runs alongside this; the daily job exists so that a day never
+     * passes without at least one successful sync attempt.
+     */
+    fun scheduleDaily(context: Context) {
+        val request = PeriodicWorkRequestBuilder<HealthSyncWorker>(Duration.ofDays(1))
+            .setConstraints(networkConstraints)
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 1, TimeUnit.HOURS)
+            .build()
+
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            DAILY,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            request,
+        )
+    }
+
+    fun runOnce(context: Context) {
+        val request = OneTimeWorkRequestBuilder<HealthSyncWorker>()
+            .setConstraints(networkConstraints)
+            .build()
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            ONE_OFF,
+            ExistingWorkPolicy.REPLACE,
+            request,
+        )
+    }
+
+    fun cancelAll(context: Context) {
+        val wm = WorkManager.getInstance(context)
+        wm.cancelUniqueWork(PERIODIC)
+        wm.cancelUniqueWork(DAILY)
+        wm.cancelUniqueWork(ONE_OFF)
+    }
+}

--- a/android/app/src/main/java/com/dragonee/tasks/health/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/dragonee/tasks/health/ui/SettingsScreen.kt
@@ -1,0 +1,153 @@
+package com.dragonee.tasks.health.ui
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.PermissionController
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.dragonee.tasks.health.R
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import kotlinx.coroutines.launch
+
+@Composable
+fun SettingsScreen(vm: SettingsViewModel = viewModel()) {
+    val state by vm.settingsState.collectAsState()
+    val permissionsGranted by vm.permissionsGranted.collectAsState()
+    val todayMetrics by vm.todayMetrics.collectAsState()
+    val scope = rememberCoroutineScope()
+
+    var url by remember { mutableStateOf("") }
+    var token by remember { mutableStateOf("") }
+    LaunchedEffect(state.serverUrl, state.apiToken) {
+        if (url.isEmpty()) url = state.serverUrl
+        if (token.isEmpty()) token = state.apiToken
+    }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = PermissionController.createRequestPermissionResultContract(),
+    ) {
+        scope.launch { vm.refreshPermissionState() }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        OutlinedTextField(
+            value = url,
+            onValueChange = { url = it },
+            label = { Text(stringRes(R.string.server_url_label)) },
+            placeholder = { Text(stringRes(R.string.server_url_placeholder)) },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        OutlinedTextField(
+            value = token,
+            onValueChange = { token = it },
+            label = { Text(stringRes(R.string.api_token_label)) },
+            singleLine = true,
+            visualTransformation = PasswordVisualTransformation(),
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Button(
+            onClick = { vm.save(url, token) },
+            enabled = url.isNotBlank() && token.isNotBlank(),
+        ) {
+            Text(stringRes(R.string.save))
+        }
+
+        when (vm.healthConnectStatus) {
+            HealthConnectClient.SDK_UNAVAILABLE -> {
+                Text(stringRes(R.string.hc_unavailable))
+            }
+            HealthConnectClient.SDK_UNAVAILABLE_PROVIDER_UPDATE_REQUIRED -> {
+                Text(stringRes(R.string.hc_needs_update))
+            }
+            else -> {
+                if (!permissionsGranted) {
+                    Button(onClick = { permissionLauncher.launch(vm.requiredPermissions) }) {
+                        Text(stringRes(R.string.grant_permissions))
+                    }
+                }
+            }
+        }
+
+        Button(
+            onClick = { vm.syncNow() },
+            enabled = state.isConfigured && permissionsGranted,
+        ) {
+            Text(stringRes(R.string.sync_now))
+        }
+
+        Text(
+            text = when {
+                state.lastSyncError.isNotEmpty() ->
+                    stringRes(R.string.sync_failed_format).format(state.lastSyncError)
+                state.lastSyncEpochMs == 0L ->
+                    stringRes(R.string.last_sync_never)
+                else ->
+                    stringRes(R.string.last_sync_format).format(formatInstant(state.lastSyncEpochMs))
+            },
+        )
+
+        if (permissionsGranted) {
+            HorizontalDivider()
+            Text(
+                text = stringRes(R.string.today_metrics_heading),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            val metrics = todayMetrics
+            if (metrics == null) {
+                Text(stringRes(R.string.metric_loading))
+            } else {
+                Text(stringRes(R.string.metric_steps_format).format(metrics.steps))
+                Text(
+                    stringRes(R.string.metric_distance_format)
+                        .format(metrics.distanceMeters / 1000.0)
+                )
+                Text(stringRes(R.string.metric_active_format).format(metrics.activeMinutes))
+            }
+        }
+    }
+}
+
+@Composable
+private fun stringRes(id: Int): String =
+    androidx.compose.ui.res.stringResource(id = id)
+
+private val displayFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+
+private fun formatInstant(epochMs: Long): String =
+    Instant.ofEpochMilli(epochMs)
+        .atZone(ZoneId.systemDefault())
+        .format(displayFormatter)

--- a/android/app/src/main/java/com/dragonee/tasks/health/ui/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/dragonee/tasks/health/ui/SettingsViewModel.kt
@@ -1,0 +1,83 @@
+package com.dragonee.tasks.health.ui
+
+import android.app.Application
+import androidx.health.connect.client.HealthConnectClient
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.dragonee.tasks.health.data.DailyMetrics
+import com.dragonee.tasks.health.data.HealthRepository
+import com.dragonee.tasks.health.data.Settings
+import com.dragonee.tasks.health.data.SettingsSnapshot
+import com.dragonee.tasks.health.sync.SyncScheduler
+import java.time.LocalDate
+import java.time.ZoneId
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+data class UiState(
+    val settings: SettingsSnapshot = SettingsSnapshot("", "", 0L, ""),
+    val healthConnectStatus: Int = HealthConnectClient.SDK_UNAVAILABLE,
+    val permissionsGranted: Boolean = false,
+)
+
+class SettingsViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val settings = Settings(application)
+    private val health = HealthRepository(application)
+
+    val settingsState: StateFlow<SettingsSnapshot> = settings.flow.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        SettingsSnapshot("", "", 0L, ""),
+    )
+
+    private val _permissionsGranted = MutableStateFlow(false)
+    val permissionsGranted: StateFlow<Boolean> = _permissionsGranted.asStateFlow()
+
+    private val _todayMetrics = MutableStateFlow<DailyMetrics?>(null)
+    val todayMetrics: StateFlow<DailyMetrics?> = _todayMetrics.asStateFlow()
+
+    val healthConnectStatus: Int = health.availability()
+    val requiredPermissions: Set<String> = health.permissions
+
+    init {
+        viewModelScope.launch {
+            refreshPermissionState()
+            if (_permissionsGranted.value) refreshMetrics()
+        }
+    }
+
+    suspend fun refreshPermissionState() {
+        val granted = healthConnectStatus == HealthConnectClient.SDK_AVAILABLE &&
+            runCatching { health.hasAllPermissions() }.getOrDefault(false)
+        val flipped = !_permissionsGranted.value && granted
+        _permissionsGranted.value = granted
+        if (flipped) refreshMetrics()
+    }
+
+    fun refreshMetricsAsync() {
+        viewModelScope.launch { refreshMetrics() }
+    }
+
+    private suspend fun refreshMetrics() {
+        if (!_permissionsGranted.value) return
+        val today = LocalDate.now(ZoneId.systemDefault())
+        _todayMetrics.value = runCatching { health.aggregateDay(today) }.getOrNull()
+    }
+
+    fun save(serverUrl: String, apiToken: String) {
+        viewModelScope.launch {
+            settings.saveServerConfig(serverUrl, apiToken)
+            SyncScheduler.schedule(getApplication())
+        }
+    }
+
+    fun syncNow() {
+        SyncScheduler.runOnce(getApplication())
+        refreshMetricsAsync()
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Tasks Health</string>
+
+    <string name="server_url_label">Server URL</string>
+    <string name="server_url_placeholder">https://tasks.example.com</string>
+    <string name="api_token_label">API token</string>
+    <string name="save">Save</string>
+    <string name="sync_now">Sync now</string>
+    <string name="grant_permissions">Grant Health Connect permissions</string>
+    <string name="last_sync_never">No sync yet</string>
+    <string name="last_sync_format">Last sync: %1$s</string>
+    <string name="sync_failed_format">Last sync failed: %1$s</string>
+    <string name="hc_unavailable">Health Connect is not available on this device.</string>
+    <string name="hc_needs_update">Health Connect needs to be updated from the Play Store.</string>
+
+    <string name="today_metrics_heading">Today</string>
+    <string name="metric_steps_format">Steps: %1$d</string>
+    <string name="metric_distance_format">Distance: %1$.1f km</string>
+    <string name="metric_active_format">Active: %1$d min</string>
+    <string name="metric_loading">Reading from Health Connect…</string>
+</resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.TasksHealth" parent="android:Theme.Material.Light.NoActionBar" />
+</resources>

--- a/android/app/src/test/java/com/dragonee/tasks/health/sync/NoteFormatterTest.kt
+++ b/android/app/src/test/java/com/dragonee/tasks/health/sync/NoteFormatterTest.kt
@@ -1,0 +1,50 @@
+package com.dragonee.tasks.health.sync
+
+import com.dragonee.tasks.health.data.DailyMetrics
+import java.time.LocalDate
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NoteFormatterTest {
+
+    private val anyDate: LocalDate = LocalDate.of(2026, 5, 17)
+
+    @Test
+    fun `formats steps distance and active minutes`() {
+        val note = NoteFormatter.format(
+            DailyMetrics(
+                date = anyDate,
+                steps = 8520,
+                distanceMeters = 6234.5,
+                activeMinutes = 42,
+            )
+        )
+        assertEquals("steps=8520 distance=6.2km active=42min", note)
+    }
+
+    @Test
+    fun `zero metrics still render with zero values`() {
+        val note = NoteFormatter.format(
+            DailyMetrics(
+                date = anyDate,
+                steps = 0,
+                distanceMeters = 0.0,
+                activeMinutes = 0,
+            )
+        )
+        assertEquals("steps=0 distance=0.0km active=0min", note)
+    }
+
+    @Test
+    fun `distance is rendered with one decimal in km using us locale`() {
+        val note = NoteFormatter.format(
+            DailyMetrics(
+                date = anyDate,
+                steps = 1,
+                distanceMeters = 1234.0,
+                activeMinutes = 0,
+            )
+        )
+        assertEquals("steps=1 distance=1.2km active=0min", note)
+    }
+}

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
+}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,8 @@
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+org.gradle.parallel=true
+org.gradle.caching=true
+
+android.useAndroidX=true
+android.nonTransitiveRClass=true
+
+kotlin.code.style=official

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,0 +1,41 @@
+[versions]
+agp = "8.7.3"
+kotlin = "2.0.21"
+kotlinxSerialization = "1.7.3"
+coreKtx = "1.15.0"
+lifecycle = "2.8.7"
+activityCompose = "1.9.3"
+composeBom = "2024.12.01"
+healthConnect = "1.1.0-alpha07"
+work = "2.10.0"
+retrofit = "2.11.0"
+okhttp = "4.12.0"
+datastore = "1.1.1"
+junit = "4.13.2"
+coroutinesTest = "1.9.0"
+
+[libraries]
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
+androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
+androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
+androidx-compose-ui = { module = "androidx.compose.ui:ui" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
+androidx-health-connect = { module = "androidx.health.connect:connect-client", version.ref = "healthConnect" }
+androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
+retrofit-core = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+retrofit-kotlinx-serialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
+okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+junit = { module = "junit:junit", version.ref = "junit" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutinesTest" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "tasks-health"
+include(":app")

--- a/tasks/apps/tree/management/commands/issue_mobile_token.py
+++ b/tasks/apps/tree/management/commands/issue_mobile_token.py
@@ -1,0 +1,34 @@
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+
+from rest_framework.authtoken.models import Token
+
+
+class Command(BaseCommand):
+    help = (
+        "Create or rotate a DRF auth token for a user. Prints the token value."
+        " Intended for provisioning mobile clients."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("username", type=str, help="Username to issue a token for")
+        parser.add_argument(
+            "--rotate",
+            action="store_true",
+            help="Delete any existing token and create a fresh one",
+        )
+
+    def handle(self, *args, **options):
+        User = get_user_model()
+        try:
+            user = User.objects.get(username=options["username"])
+        except User.DoesNotExist as exc:
+            raise CommandError(
+                f"No user found with username={options['username']!r}"
+            ) from exc
+
+        if options["rotate"]:
+            Token.objects.filter(user=user).delete()
+
+        token, _created = Token.objects.get_or_create(user=user)
+        self.stdout.write(token.key)

--- a/tasks/apps/tree/serializers.py
+++ b/tasks/apps/tree/serializers.py
@@ -309,6 +309,12 @@ class HabitTrackedSerializer(serializers.ModelSerializer):
         fields = ["id", "published", "habit", "occured", "note"]
 
 
+class TrackHabitAPISerializer(serializers.Serializer):
+    keyword = serializers.SlugField(max_length=255, allow_unicode=True)
+    date = serializers.DateField()
+    note = serializers.CharField(required=False, allow_blank=True, default="")
+
+
 class ProjectedOutcomeMadeSerializer(serializers.ModelSerializer):
     thread = serializers.SlugRelatedField(
         queryset=Thread.objects.all(), slug_field="name"

--- a/tasks/apps/tree/tests/test_habit_api.py
+++ b/tasks/apps/tree/tests/test_habit_api.py
@@ -1,0 +1,102 @@
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APITestCase
+
+from ..models import Habit, HabitKeyword, HabitTracked, Thread
+
+
+class TrackHabitAPITestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        User = get_user_model()
+        cls.user = User.objects.create_user(username="phone", password="x")
+        cls.token = Token.objects.create(user=cls.user)
+        cls.daily_thread = Thread.objects.create(name="Daily")
+        cls.habit = Habit.objects.create(name="Health metrics", slug="health-metrics")
+        HabitKeyword.objects.create(habit=cls.habit, keyword="health-metrics")
+        cls.url = reverse("track-habit-api")
+
+    def _auth(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+
+    def _payload(self, **overrides):
+        body = {
+            "keyword": "health-metrics",
+            "date": "2026-05-17",
+            "note": "steps=8500 distance=6.2km active=42min",
+        }
+        body.update(overrides)
+        return body
+
+    def test_happy_path_creates_habit_tracked(self):
+        self._auth()
+        response = self.client.post(self.url, self._payload(), format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"ok": True})
+
+        events = HabitTracked.objects.filter(habit=self.habit)
+        self.assertEqual(events.count(), 1)
+        event = events.get()
+        self.assertEqual(event.note, "steps=8500 distance=6.2km active=42min")
+        self.assertTrue(event.occured)
+        self.assertEqual(event.thread, self.daily_thread)
+        self.assertEqual(event.published.date().isoformat(), "2026-05-17")
+        self.assertEqual(event.event_stream_id, self.habit.event_stream_id)
+
+    def test_repost_same_day_is_idempotent_and_updates_note(self):
+        self._auth()
+        self.client.post(self.url, self._payload(note="steps=100"), format="json")
+        self.client.post(self.url, self._payload(note="steps=8500"), format="json")
+
+        events = HabitTracked.objects.filter(
+            habit=self.habit, published__date="2026-05-17"
+        )
+        self.assertEqual(events.count(), 1)
+        self.assertEqual(events.get().note, "steps=8500")
+
+    def test_missing_token_returns_401(self):
+        response = self.client.post(self.url, self._payload(), format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(HabitTracked.objects.count(), 0)
+
+    def test_bad_token_returns_401(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token not-a-real-token")
+        response = self.client.post(self.url, self._payload(), format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_unknown_keyword_returns_404(self):
+        self._auth()
+        response = self.client.post(
+            self.url, self._payload(keyword="does-not-exist"), format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(HabitTracked.objects.count(), 0)
+
+    def test_resolves_habit_via_alternate_keyword(self):
+        HabitKeyword.objects.create(habit=self.habit, keyword="hm")
+        self._auth()
+        response = self.client.post(
+            self.url, self._payload(keyword="hm"), format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(HabitTracked.objects.get().habit, self.habit)
+
+    def test_missing_date_returns_400(self):
+        self._auth()
+        payload = self._payload()
+        del payload["date"]
+        response = self.client.post(self.url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("date", response.json())
+
+    def test_blank_note_is_allowed(self):
+        self._auth()
+        payload = self._payload()
+        del payload["note"]
+        response = self.client.post(self.url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(HabitTracked.objects.get().note, "")

--- a/tasks/apps/tree/urls.py
+++ b/tasks/apps/tree/urls.py
@@ -7,6 +7,7 @@ from . import (
     views_board_tasks,
     views_breakthrough,
     views_habit,
+    views_habit_api,
     views_observation,
     views_today,
 )
@@ -61,6 +62,11 @@ urlpatterns = [
         name="public-habit-detail",
     ),
     path("habit/track/", views_habit.track_habit, name="public-habit-track"),
+    path(
+        "api/v1/habit/track/",
+        views_habit_api.TrackHabitAPIView.as_view(),
+        name="track-habit-api",
+    ),
     path(
         "habit/keywords/mine/", views_habit.my_habit_keywords, name="my-habit-keywords"
     ),

--- a/tasks/apps/tree/views_habit_api.py
+++ b/tasks/apps/tree/views_habit_api.py
@@ -1,0 +1,69 @@
+import datetime
+
+from django.shortcuts import get_object_or_404
+from django.utils import timezone
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+
+from rest_framework import status
+from rest_framework.authentication import TokenAuthentication
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .models import HabitKeyword, HabitTracked, Thread
+from .serializers import TrackHabitAPISerializer
+
+
+def _aware_midday(date: datetime.date):
+    return timezone.make_aware(datetime.datetime.combine(date, datetime.time(12, 0)))
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class TrackHabitAPIView(APIView):
+    """JSON endpoint for mobile clients to record a HabitTracked event.
+
+    Resolves the target Habit by HabitKeyword text (the same hashtag the user
+    would type in the journal), so the mobile contract doesn't depend on the
+    Habit table's slug column.
+
+    Idempotent on (habit, date): a second POST for the same day updates the
+    existing event's note rather than inserting a duplicate.
+    """
+
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        serializer = TrackHabitAPISerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        keyword = get_object_or_404(
+            HabitKeyword.objects.select_related("habit"), keyword=data["keyword"]
+        )
+        habit = keyword.habit
+        thread = get_object_or_404(Thread, name="Daily")
+
+        published = _aware_midday(data["date"])
+
+        existing = HabitTracked.objects.filter(
+            habit=habit, published__date=data["date"]
+        ).first()
+
+        if existing is not None:
+            existing.note = data["note"]
+            existing.occured = True
+            existing.thread = thread
+            existing.published = published
+            existing.save()
+        else:
+            HabitTracked.objects.create(
+                habit=habit,
+                occured=True,
+                note=data["note"],
+                thread=thread,
+                published=published,
+            )
+
+        return Response({"ok": True}, status=status.HTTP_200_OK)

--- a/tasks/settings/base.py
+++ b/tasks/settings/base.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = [
     "mail_templated",
     "django_extensions",
     "rest_framework",
+    "rest_framework.authtoken",
     "django_filters",
     "tasks.apps.common",
     "tasks.apps.tree",
@@ -154,6 +155,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 10,
     "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.TokenAuthentication",
         "rest_framework.authentication.BasicAuthentication",
         "rest_framework.authentication.SessionAuthentication",
     ],


### PR DESCRIPTION
## Summary
- New Kotlin/Compose Android app under `android/` that reads steps, distance, and active minutes from Health Connect and POSTs them to the backend as `HabitTracked` events keyed by the existing `HabitKeyword` text (e.g. `#health-metrics`). Implements the alternative described in ADR 0001.
- New JSON endpoint `POST /api/v1/habit/track/` with DRF `TokenAuthentication` + `csrf_exempt`, idempotent on `(habit, day)`. Habit resolved via keyword text so slug churn never breaks the mobile contract.
- WorkManager runs the sync every six hours plus a daily backstop, so a day never passes without at least one push. `manage.py issue_mobile_token <user>` mints tokens.

## Test plan
- [x] `python manage.py test tasks` — all 33 tests pass, including 8 new API tests (happy path, idempotent re-post, alternate keyword, 401/404/400).
- [x] Build the debug APK in Android Studio, sideload on a phone with Health Connect data.
- [x] In the app: paste server URL + API token, tap **Grant permissions** (including "Access data while in the background"), tap **Sync now**.
- [x] Verify a `HabitTracked` row appears under the `Health metrics` habit in Django admin with `note = steps=… distance=…km active=…min`.
- [x] Re-tap **Sync now**: confirm the existing row is updated, not duplicated.
- [ ] Leave overnight: confirm the daily WorkManager backstop runs and a new row exists for the new day.

## Setup
One-time backend setup is documented in `android/README.md`:
1. Run migrations (`authtoken` tables).
2. Create a `Habit` + `HabitKeyword` with keyword `health-metrics` in admin.
3. Mint a token: `python manage.py issue_mobile_token <username>`.

## Out of scope
- Heart Points (Health Connect doesn't expose them and computing an equivalent would require heart-rate permissions; explicitly deferred).
- Play Store release / Multi-user / In-app history view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)