### PR TITLE
refactor(android): split UI into Today/Health/Settings drawer

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/MainActivity.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/MainActivity.kt
@@ -3,9 +3,46 @@ package org.polybrain.tasks.health
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.launch
+import org.polybrain.tasks.health.ui.HealthScreen
+import org.polybrain.tasks.health.ui.MainViewModel
 import org.polybrain.tasks.health.ui.SettingsScreen
+import org.polybrain.tasks.health.ui.TodayScreen
+
+private enum class Destination(val titleRes: Int) {
+    Today(R.string.nav_today),
+    Health(R.string.nav_health),
+    Settings(R.string.nav_settings),
+}
 
 class MainActivity : ComponentActivity() {
 
@@ -14,7 +51,69 @@ class MainActivity : ComponentActivity() {
         setContent {
             MaterialTheme {
                 Surface(color = MaterialTheme.colorScheme.background) {
-                    SettingsScreen()
+                    MainScaffold()
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun MainScaffold(vm: MainViewModel = viewModel()) {
+    var current by remember { mutableStateOf(Destination.Today) }
+    val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
+    val scope = rememberCoroutineScope()
+
+    ModalNavigationDrawer(
+        drawerState = drawerState,
+        drawerContent = {
+            ModalDrawerSheet {
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = stringResource(R.string.app_name),
+                    style = MaterialTheme.typography.titleLarge,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                )
+                Destination.entries.forEach { dest ->
+                    NavigationDrawerItem(
+                        label = { Text(stringResource(dest.titleRes)) },
+                        selected = dest == current,
+                        onClick = {
+                            current = dest
+                            scope.launch { drawerState.close() }
+                        },
+                        modifier = Modifier.padding(horizontal = 12.dp),
+                    )
+                }
+            }
+        },
+    ) {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text(stringResource(current.titleRes)) },
+                    navigationIcon = {
+                        IconButton(onClick = { scope.launch { drawerState.open() } }) {
+                            Icon(
+                                imageVector = Icons.Filled.Menu,
+                                contentDescription = stringResource(R.string.nav_open_menu),
+                            )
+                        }
+                    },
+                )
+            },
+        ) { innerPadding ->
+            Surface(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+                color = MaterialTheme.colorScheme.background,
+            ) {
+                when (current) {
+                    Destination.Today -> TodayScreen()
+                    Destination.Health -> HealthScreen(vm)
+                    Destination.Settings -> SettingsScreen(vm)
                 }
             }
         }

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/HealthScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/HealthScreen.kt
@@ -1,0 +1,111 @@
+package org.polybrain.tasks.health.ui
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.PermissionController
+import org.polybrain.tasks.health.R
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import kotlinx.coroutines.launch
+
+@Composable
+fun HealthScreen(vm: MainViewModel) {
+    val state by vm.settingsState.collectAsState()
+    val permissionsGranted by vm.permissionsGranted.collectAsState()
+    val todayMetrics by vm.todayMetrics.collectAsState()
+    val scope = rememberCoroutineScope()
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        contract = PermissionController.createRequestPermissionResultContract(),
+    ) {
+        scope.launch { vm.refreshPermissionState() }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        when (vm.healthConnectStatus) {
+            HealthConnectClient.SDK_UNAVAILABLE -> {
+                Text(stringResource(R.string.hc_unavailable))
+            }
+            HealthConnectClient.SDK_UNAVAILABLE_PROVIDER_UPDATE_REQUIRED -> {
+                Text(stringResource(R.string.hc_needs_update))
+            }
+            else -> {
+                if (!permissionsGranted) {
+                    Button(onClick = { permissionLauncher.launch(vm.requiredPermissions) }) {
+                        Text(stringResource(R.string.grant_permissions))
+                    }
+                }
+            }
+        }
+
+        Button(
+            onClick = { vm.syncNow() },
+            enabled = state.isConfigured && permissionsGranted,
+        ) {
+            Text(stringResource(R.string.sync_now))
+        }
+
+        Text(
+            text = when {
+                state.lastSyncError.isNotEmpty() ->
+                    stringResource(R.string.sync_failed_format).format(state.lastSyncError)
+                state.lastSyncEpochMs == 0L ->
+                    stringResource(R.string.last_sync_never)
+                else ->
+                    stringResource(R.string.last_sync_format).format(formatInstant(state.lastSyncEpochMs))
+            },
+        )
+
+        if (permissionsGranted) {
+            HorizontalDivider()
+            Text(
+                text = stringResource(R.string.today_metrics_heading),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            val metrics = todayMetrics
+            if (metrics == null) {
+                Text(stringResource(R.string.metric_loading))
+            } else {
+                Text(stringResource(R.string.metric_steps_format).format(metrics.steps))
+                Text(
+                    stringResource(R.string.metric_distance_format)
+                        .format(metrics.distanceMeters / 1000.0)
+                )
+                Text(stringResource(R.string.metric_active_format).format(metrics.activeMinutes))
+                Text(stringResource(R.string.metric_kcal_format).format(metrics.kcal))
+            }
+        }
+    }
+}
+
+private val displayFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+
+private fun formatInstant(epochMs: Long): String =
+    Instant.ofEpochMilli(epochMs)
+        .atZone(ZoneId.systemDefault())
+        .format(displayFormatter)

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/MainViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/MainViewModel.kt
@@ -18,13 +18,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
-data class UiState(
-    val settings: SettingsSnapshot = SettingsSnapshot("", "", 0L, ""),
-    val healthConnectStatus: Int = HealthConnectClient.SDK_UNAVAILABLE,
-    val permissionsGranted: Boolean = false,
-)
-
-class SettingsViewModel(application: Application) : AndroidViewModel(application) {
+class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     private val settings = Settings(application)
     private val health = HealthRepository(application)

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/SettingsScreen.kt
@@ -1,6 +1,5 @@
 package org.polybrain.tasks.health.ui
 
-import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,8 +8,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -19,38 +16,22 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
-import androidx.health.connect.client.HealthConnectClient
-import androidx.health.connect.client.PermissionController
-import androidx.lifecycle.viewmodel.compose.viewModel
 import org.polybrain.tasks.health.R
-import java.time.Instant
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
-import kotlinx.coroutines.launch
 
 @Composable
-fun SettingsScreen(vm: SettingsViewModel = viewModel()) {
+fun SettingsScreen(vm: MainViewModel) {
     val state by vm.settingsState.collectAsState()
-    val permissionsGranted by vm.permissionsGranted.collectAsState()
-    val todayMetrics by vm.todayMetrics.collectAsState()
-    val scope = rememberCoroutineScope()
 
     var url by remember { mutableStateOf("") }
     var token by remember { mutableStateOf("") }
     LaunchedEffect(state.serverUrl, state.apiToken) {
         if (url.isEmpty()) url = state.serverUrl
         if (token.isEmpty()) token = state.apiToken
-    }
-
-    val permissionLauncher = rememberLauncherForActivityResult(
-        contract = PermissionController.createRequestPermissionResultContract(),
-    ) {
-        scope.launch { vm.refreshPermissionState() }
     }
 
     Column(
@@ -63,8 +44,8 @@ fun SettingsScreen(vm: SettingsViewModel = viewModel()) {
         OutlinedTextField(
             value = url,
             onValueChange = { url = it },
-            label = { Text(stringRes(R.string.server_url_label)) },
-            placeholder = { Text(stringRes(R.string.server_url_placeholder)) },
+            label = { Text(stringResource(R.string.server_url_label)) },
+            placeholder = { Text(stringResource(R.string.server_url_placeholder)) },
             singleLine = true,
             modifier = Modifier.fillMaxWidth(),
         )
@@ -72,7 +53,7 @@ fun SettingsScreen(vm: SettingsViewModel = viewModel()) {
         OutlinedTextField(
             value = token,
             onValueChange = { token = it },
-            label = { Text(stringRes(R.string.api_token_label)) },
+            label = { Text(stringResource(R.string.api_token_label)) },
             singleLine = true,
             visualTransformation = PasswordVisualTransformation(),
             modifier = Modifier.fillMaxWidth(),
@@ -82,73 +63,7 @@ fun SettingsScreen(vm: SettingsViewModel = viewModel()) {
             onClick = { vm.save(url, token) },
             enabled = url.isNotBlank() && token.isNotBlank(),
         ) {
-            Text(stringRes(R.string.save))
-        }
-
-        when (vm.healthConnectStatus) {
-            HealthConnectClient.SDK_UNAVAILABLE -> {
-                Text(stringRes(R.string.hc_unavailable))
-            }
-            HealthConnectClient.SDK_UNAVAILABLE_PROVIDER_UPDATE_REQUIRED -> {
-                Text(stringRes(R.string.hc_needs_update))
-            }
-            else -> {
-                if (!permissionsGranted) {
-                    Button(onClick = { permissionLauncher.launch(vm.requiredPermissions) }) {
-                        Text(stringRes(R.string.grant_permissions))
-                    }
-                }
-            }
-        }
-
-        Button(
-            onClick = { vm.syncNow() },
-            enabled = state.isConfigured && permissionsGranted,
-        ) {
-            Text(stringRes(R.string.sync_now))
-        }
-
-        Text(
-            text = when {
-                state.lastSyncError.isNotEmpty() ->
-                    stringRes(R.string.sync_failed_format).format(state.lastSyncError)
-                state.lastSyncEpochMs == 0L ->
-                    stringRes(R.string.last_sync_never)
-                else ->
-                    stringRes(R.string.last_sync_format).format(formatInstant(state.lastSyncEpochMs))
-            },
-        )
-
-        if (permissionsGranted) {
-            HorizontalDivider()
-            Text(
-                text = stringRes(R.string.today_metrics_heading),
-                style = MaterialTheme.typography.titleMedium,
-            )
-            val metrics = todayMetrics
-            if (metrics == null) {
-                Text(stringRes(R.string.metric_loading))
-            } else {
-                Text(stringRes(R.string.metric_steps_format).format(metrics.steps))
-                Text(
-                    stringRes(R.string.metric_distance_format)
-                        .format(metrics.distanceMeters / 1000.0)
-                )
-                Text(stringRes(R.string.metric_active_format).format(metrics.activeMinutes))
-                Text(stringRes(R.string.metric_kcal_format).format(metrics.kcal))
-            }
+            Text(stringResource(R.string.save))
         }
     }
 }
-
-@Composable
-private fun stringRes(id: Int): String =
-    androidx.compose.ui.res.stringResource(id = id)
-
-private val displayFormatter: DateTimeFormatter =
-    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
-
-private fun formatInstant(epochMs: Long): String =
-    Instant.ofEpochMilli(epochMs)
-        .atZone(ZoneId.systemDefault())
-        .format(displayFormatter)

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayScreen.kt
@@ -1,0 +1,24 @@
+package org.polybrain.tasks.health.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.polybrain.tasks.health.R
+
+@Composable
+fun TodayScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(stringResource(R.string.today_placeholder))
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2,6 +2,13 @@
 <resources>
     <string name="app_name">Tasks Health</string>
 
+    <string name="nav_today">Today</string>
+    <string name="nav_health">Health</string>
+    <string name="nav_settings">Settings</string>
+    <string name="nav_open_menu">Open menu</string>
+
+    <string name="today_placeholder">Nothing here yet.</string>
+
     <string name="server_url_label">Server URL</string>
     <string name="server_url_placeholder">https://tasks.example.com</string>
     <string name="api_token_label">API token</string>


### PR DESCRIPTION
## Summary
- Replaces the single `SettingsScreen` with a `ModalNavigationDrawer` hosting three destinations: **Today** (empty placeholder), **Health** (existing Health Connect permissions, sync controls, and today's metrics), and **Settings** (server URL + API token form).
- Renames `SettingsViewModel` → `MainViewModel` since it now backs all three screens; drops the unused `UiState` data class.
- Adds nav/title strings (`nav_today`, `nav_health`, `nav_settings`, `nav_open_menu`, `today_placeholder`).

This lays the groundwork for an upcoming feature that will live on the Today tab.

## Test plan
- [x] `gradle :app:compileDebugKotlin` succeeds (verified locally)
- [x] Launch the app and confirm Today opens by default
- [x] Open the drawer, switch between Today / Health / Settings — TopAppBar title updates and the right screen renders
- [x] On Health: grant-permissions flow still works, "Sync now" still triggers a sync, today's metrics still load
- [x] On Settings: server URL + token persist and re-populate after navigating away and back

🤖 Generated with [Claude Code](https://claude.com/claude-code)