### PR TITLE
feat(android,api): send device-local date with every task request

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/data/TasksApi.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/TasksApi.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Query
 
 @Serializable
 data class TrackHabitRequest(
@@ -26,12 +27,14 @@ data class OkResponse(
 @Serializable
 data class TaskTextRequest(
     @SerialName("text") val text: String,
+    @SerialName("date") val date: String,
 )
 
 @Serializable
 data class TaskCompleteRequest(
     @SerialName("text") val text: String,
     @SerialName("done") val done: Boolean,
+    @SerialName("date") val date: String,
 )
 
 @Serializable
@@ -50,7 +53,7 @@ interface TasksApi {
     suspend fun trackHabit(@Body body: TrackHabitRequest): TrackHabitResponse
 
     @GET("api/v1/android/task/today/")
-    suspend fun listTodayTasks(): TodayTasksResponse
+    suspend fun listTodayTasks(@Query("date") date: String): TodayTasksResponse
 
     @POST("api/v1/android/task/add/")
     suspend fun addTodayTask(@Body body: TaskTextRequest): OkResponse

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayViewModel.kt
@@ -3,6 +3,7 @@ package org.polybrain.tasks.health.ui
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import java.time.LocalDate
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -39,7 +40,7 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
         val trimmed = text.trim()
         if (trimmed.isEmpty()) return
         viewModelScope.launch {
-            mutate { api -> api.addTodayTask(TaskTextRequest(trimmed)) }
+            mutate { api -> api.addTodayTask(TaskTextRequest(trimmed, today())) }
         }
     }
 
@@ -49,14 +50,14 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
             _tasks.value = _tasks.value.map { t ->
                 if (t.text == text) t.copy(done = done) else t
             }
-            mutate { api -> api.completeTodayTask(TaskCompleteRequest(text, done)) }
+            mutate { api -> api.completeTodayTask(TaskCompleteRequest(text, done, today())) }
         }
     }
 
     fun delete(text: String) {
         viewModelScope.launch {
             _tasks.value = _tasks.value.filterNot { it.text == text }
-            mutate { api -> api.deleteTodayTask(TaskTextRequest(text)) }
+            mutate { api -> api.deleteTodayTask(TaskTextRequest(text, today())) }
         }
     }
 
@@ -74,7 +75,7 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
         _loading.value = true
         try {
             val api = buildApi(snapshot)
-            _tasks.value = api.listTodayTasks().items
+            _tasks.value = api.listTodayTasks(today()).items
             _error.value = null
         } catch (t: Throwable) {
             _error.value = t.message ?: t.javaClass.simpleName
@@ -101,4 +102,9 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
 
     private fun buildApi(snapshot: SettingsSnapshot): TasksApi =
         TasksClient.build(snapshot.serverUrl, snapshot.apiToken)
+
+    // Local date in the device's current timezone, ISO 8601 (YYYY-MM-DD).
+    // Resolved per call so a request made just after midnight follows the
+    // user's wall-clock day, not the moment the ViewModel was created.
+    private fun today(): String = LocalDate.now().toString()
 }

--- a/tasks/apps/tree/tests/test_android_task_api.py
+++ b/tasks/apps/tree/tests/test_android_task_api.py
@@ -1,4 +1,5 @@
 from datetime import date as date_cls
+from datetime import timedelta
 
 from django.contrib.auth import get_user_model
 from django.urls import reverse
@@ -8,6 +9,9 @@ from rest_framework.authtoken.models import Token
 from rest_framework.test import APITestCase
 
 from ..models import Board, Plan, Profile, Reflection, Thread
+
+TODAY = date_cls(2026, 5, 21)
+TODAY_ISO = TODAY.isoformat()
 
 
 class AndroidTaskAPITestCase(APITestCase):
@@ -30,51 +34,64 @@ class AndroidTaskAPITestCase(APITestCase):
     def _auth(self):
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
 
+    def _add(self, text, date=TODAY_ISO):
+        return self.client.post(
+            reverse("android-task-add"),
+            {"text": text, "date": date},
+            format="json",
+        )
+
+    def _complete(self, text, done, date=TODAY_ISO):
+        return self.client.post(
+            reverse("android-task-complete"),
+            {"text": text, "done": done, "date": date},
+            format="json",
+        )
+
+    def _delete(self, text, date=TODAY_ISO):
+        return self.client.post(
+            reverse("android-task-delete"),
+            {"text": text, "date": date},
+            format="json",
+        )
+
+    def _list(self, date=TODAY_ISO):
+        url = reverse("android-task-today")
+        if date is None:
+            return self.client.get(url)
+        return self.client.get(url, {"date": date})
+
     def test_add_creates_board_node_and_plan_line(self):
         self._auth()
-        response = self.client.post(
-            reverse("android-task-add"), {"text": "buy bread"}, format="json"
-        )
+        response = self._add("buy bread")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), {"ok": True})
 
         self.board.refresh_from_db()
         self.assertEqual(len(self.board.state), 1)
         self.assertEqual(self.board.state[0]["text"], "buy bread")
-        self.assertTrue(Plan.objects.filter(thread=self.daily).exists())
+        plan = Plan.objects.get(thread=self.daily)
+        self.assertEqual(plan.pub_date, TODAY)
 
     def test_complete_then_uncomplete_round_trip(self):
         self._auth()
-        self.client.post(
-            reverse("android-task-add"), {"text": "buy bread"}, format="json"
-        )
+        self._add("buy bread")
 
-        response = self.client.post(
-            reverse("android-task-complete"),
-            {"text": "buy bread", "done": True},
-            format="json",
-        )
+        response = self._complete("buy bread", True)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         reflection = Reflection.objects.get(thread=self.daily)
         self.assertEqual(reflection.good, "buy bread")
+        self.assertEqual(reflection.pub_date, TODAY)
 
-        response = self.client.post(
-            reverse("android-task-complete"),
-            {"text": "buy bread", "done": False},
-            format="json",
-        )
+        response = self._complete("buy bread", False)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         reflection.refresh_from_db()
         self.assertEqual(reflection.good, "")
 
     def test_delete_removes_plan_line(self):
         self._auth()
-        self.client.post(
-            reverse("android-task-add"), {"text": "buy bread"}, format="json"
-        )
-        response = self.client.post(
-            reverse("android-task-delete"), {"text": "buy bread"}, format="json"
-        )
+        self._add("buy bread")
+        response = self._delete("buy bread")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         plan = Plan.objects.get(thread=self.daily)
         self.assertEqual(plan.focus, "")
@@ -84,14 +101,10 @@ class AndroidTaskAPITestCase(APITestCase):
     def test_list_returns_done_flag_and_unchecked_first(self):
         self._auth()
         for line in ("alpha", "bravo"):
-            self.client.post(reverse("android-task-add"), {"text": line}, format="json")
-        self.client.post(
-            reverse("android-task-complete"),
-            {"text": "alpha", "done": True},
-            format="json",
-        )
+            self._add(line)
+        self._complete("alpha", True)
 
-        response = self.client.get(reverse("android-task-today"))
+        response = self._list()
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             response.json(),
@@ -103,26 +116,67 @@ class AndroidTaskAPITestCase(APITestCase):
             },
         )
 
+    def test_date_drives_target_plan(self):
+        """A request that names a different date hits that day's Plan,
+        regardless of the server's clock."""
+        self._auth()
+        yesterday = (TODAY - timedelta(days=1)).isoformat()  # 2026-05-20
+        self._add("buy bread", date=yesterday)
+        self._add("walk dog", date=TODAY_ISO)
+
+        plans = {p.pub_date.isoformat(): p.focus for p in Plan.objects.all()}
+        self.assertEqual(plans[yesterday], "buy bread")
+        self.assertEqual(plans[TODAY_ISO], "walk dog")
+
+        # Listing yesterday only shows yesterday's task.
+        response = self._list(date=yesterday)
+        self.assertEqual(
+            response.json(),
+            {"items": [{"text": "buy bread", "done": False}]},
+        )
+
     def test_missing_token_returns_401(self):
-        response = self.client.get(reverse("android-task-today"))
+        response = self._list()
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_add_missing_text_returns_400(self):
         self._auth()
-        response = self.client.post(reverse("android-task-add"), {}, format="json")
+        response = self.client.post(
+            reverse("android-task-add"), {"date": TODAY_ISO}, format="json"
+        )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_complete_missing_done_returns_400(self):
         self._auth()
         response = self.client.post(
-            reverse("android-task-complete"), {"text": "x"}, format="json"
+            reverse("android-task-complete"),
+            {"text": "x", "date": TODAY_ISO},
+            format="json",
         )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_add_missing_date_returns_400(self):
+        self._auth()
+        response = self.client.post(
+            reverse("android-task-add"), {"text": "x"}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_list_missing_date_returns_400(self):
+        self._auth()
+        response = self._list(date=None)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_malformed_date_returns_400(self):
+        self._auth()
+        response = self._add("x", date="not-a-date")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        response = self._list(date="2026/05/21")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_no_board_returns_409(self):
         Board.objects.all().delete()
         self._auth()
-        response = self.client.post(
-            reverse("android-task-add"), {"text": "x"}, format="json"
-        )
+        response = self._add("x")
         self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)

--- a/tasks/apps/tree/views_android_api.py
+++ b/tasks/apps/tree/views_android_api.py
@@ -1,3 +1,5 @@
+from datetime import date as date_cls
+
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 
@@ -23,6 +25,20 @@ def _text_from(request):
     return str(text)
 
 
+def _parse_date(value):
+    """Parse a YYYY-MM-DD string. Returns the date or None on any failure."""
+    if not value:
+        return None
+    try:
+        return date_cls.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _bad_request(message):
+    return Response({"error": message}, status=status.HTTP_400_BAD_REQUEST)
+
+
 def _no_board_response():
     return Response(
         {"error": "no board configured for user"},
@@ -34,14 +50,22 @@ def _no_board_response():
 class AndroidTaskListView(APIView):
     """Return today's tasks: every line in today's Plan.focus, with a
     ``done`` flag for those that also appear in today's Reflection.good.
-    Unchecked items first."""
+    Unchecked items first.
+
+    ``date`` query parameter is required (YYYY-MM-DD) — the client sends
+    the device's local date so the call follows the user's day regardless
+    of the server's timezone.
+    """
 
     authentication_classes = [TokenAuthentication]
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
+        today = _parse_date(request.query_params.get("date"))
+        if today is None:
+            return _bad_request("date is required (YYYY-MM-DD)")
         try:
-            items = list_today_tasks(request.user)
+            items = list_today_tasks(request.user, today=today)
         except NoBoardError:
             return _no_board_response()
         return Response(
@@ -58,11 +82,12 @@ class AndroidTaskAddView(APIView):
     def post(self, request):
         text = _text_from(request)
         if text is None:
-            return Response(
-                {"error": "text is required"}, status=status.HTTP_400_BAD_REQUEST
-            )
+            return _bad_request("text is required")
+        today = _parse_date(request.data.get("date"))
+        if today is None:
+            return _bad_request("date is required (YYYY-MM-DD)")
         try:
-            add_task(request.user, text)
+            add_task(request.user, text, today=today)
         except NoBoardError:
             return _no_board_response()
         return Response({"ok": True}, status=status.HTTP_200_OK)
@@ -79,16 +104,15 @@ class AndroidTaskCompleteView(APIView):
     def post(self, request):
         text = _text_from(request)
         if text is None:
-            return Response(
-                {"error": "text is required"}, status=status.HTTP_400_BAD_REQUEST
-            )
+            return _bad_request("text is required")
         if "done" not in request.data:
-            return Response(
-                {"error": "done is required"}, status=status.HTTP_400_BAD_REQUEST
-            )
+            return _bad_request("done is required")
+        today = _parse_date(request.data.get("date"))
+        if today is None:
+            return _bad_request("date is required (YYYY-MM-DD)")
         done = bool(request.data.get("done"))
         try:
-            set_task_done(request.user, text, done)
+            set_task_done(request.user, text, done, today=today)
         except NoBoardError:
             return _no_board_response()
         return Response({"ok": True}, status=status.HTTP_200_OK)
@@ -102,11 +126,12 @@ class AndroidTaskDeleteView(APIView):
     def post(self, request):
         text = _text_from(request)
         if text is None:
-            return Response(
-                {"error": "text is required"}, status=status.HTTP_400_BAD_REQUEST
-            )
+            return _bad_request("text is required")
+        today = _parse_date(request.data.get("date"))
+        if today is None:
+            return _bad_request("date is required (YYYY-MM-DD)")
         try:
-            delete_task(request.user, text)
+            delete_task(request.user, text, today=today)
         except NoBoardError:
             return _no_board_response()
         return Response({"ok": True}, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Summary

All four Today endpoints now require an explicit `date` field so the user's wall-clock day drives Plan / Board / Reflection writes, instead of whatever date the server happens to be in. Without this, a task added at 23:50 local while the server runs in UTC could land in tomorrow's Plan.

- Backend (`views_android_api.py`): every view parses `date` from the body (POSTs) or query string (GET), validates with `date.fromisoformat`, and forwards it via the existing `today=` kwarg of the service operations. Missing or malformed → `400`.
- Android client: `TaskTextRequest` and `TaskCompleteRequest` gain a `date` field; `listTodayTasks` gains a `@Query("date")` parameter. `TodayViewModel` resolves the date *per call* via `LocalDate.now().toString()` (device default timezone), so requests made after midnight follow the new day rather than the date the VM was constructed with.

## Tests

Backend: 28 tests pass. New cases cover:
- `test_date_drives_target_plan` — same user, two requests with different dates; each task lands in the right day's Plan.
- `test_add_missing_date_returns_400`, `test_list_missing_date_returns_400`, `test_malformed_date_returns_400`.

Android: `gradle :app:compileDebugKotlin` clean.

## Test plan

- [ ] Open Today; pull-to-refresh — list still loads (now using device date).
- [ ] Add a task, check it, delete it — round-trip still works end-to-end.
- [ ] Set the device clock back to yesterday → Today screen reloads → Plan for yesterday is what's shown, not today's.
- [ ] Restore the clock to today, verify the original day reappears.
- [ ] Send a request without `date` via curl → server returns 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)