### PR TITLE
fix(api): board "checked" flag + empty-note journal entries

### DIFF
--- a/docs/design-tasks-on-android.md
+++ b/docs/design-tasks-on-android.md
@@ -1,0 +1,256 @@
+# Today tasks on Android
+
+This note explains how the Today tab on the Android companion app is wired
+to the Django backend. It covers the four endpoints, the service module
+that orchestrates them, the two extension patterns (progress-counted
+tasks; journal-note modal), and the wire contract.
+
+## Why this exists
+
+The web app already splits "what I plan to do today" into three records:
+
+- `Board.state` (JSON tree of task nodes — the canonical task store)
+- `Plan.focus` (today's plan, newline-joined lines of free text)
+- `Reflection.good` (today's wins, newline-joined)
+
+On the phone we wanted a single flat checklist with **add / check / delete**
+that touches all three records consistently. The Android client sees a
+plain CRUD surface; the backend does the small multi-record dance behind
+each call.
+
+## Endpoints
+
+All four live under the existing mobile-API namespace and use the same
+auth as `/api/v1/habit/track/`: DRF `TokenAuthentication` +
+`IsAuthenticated`, `@csrf_exempt`, JSON request and response.
+
+| Method | URL                                  | Body / query                                   | Returns                          |
+|--------|--------------------------------------|------------------------------------------------|----------------------------------|
+| GET    | `/api/v1/android/task/today/`        | `?date=YYYY-MM-DD`                             | `{"items":[{"text","done"}…]}`   |
+| POST   | `/api/v1/android/task/add/`          | `{"text","date":"YYYY-MM-DD"}`                 | `{"ok": true}`                   |
+| POST   | `/api/v1/android/task/complete/`     | `{"text","done","date":"<ISO 8601 ts>","note"?}` | `{"ok": true}`                 |
+| POST   | `/api/v1/android/task/delete/`       | `{"text","date":"YYYY-MM-DD"}`                 | `{"ok": true}`                   |
+
+Error model: `400` on missing/malformed input, `401` without a valid
+token, `409` if the user has no `Board` on their configured thread, `200`
+otherwise.
+
+### Why `/complete` carries a full timestamp
+
+Three of the four endpoints only need to know *which day* the user means,
+so they pass a date-only string. `/complete` is different: every check
+that comes with a free-form note is also recorded as a `JournalAdded`,
+and that journal entry should carry the device's real wall-clock moment
+of the tap — not a server-side synthesized noon. The Android client uses
+`OffsetDateTime.now().toString()` (e.g. `2026-05-21T15:42:33.123+02:00`)
+on `/complete` only; the server derives `pub_date = published.date()`
+from it for Plan / Reflection lookup and uses the timestamp verbatim for
+`JournalAdded.published`.
+
+## Service module
+
+`tasks/apps/tree/services/today/` contains everything the backend does
+for these endpoints. The views are thin: parse, dispatch, translate
+exceptions to HTTP.
+
+```
+services/today/
+├── __init__.py        # public surface: add_task, set_task_done, ...
+├── operations.py      # @transaction.atomic orchestrators
+├── board_tree.py      # walking + mutating Board.state JSON
+├── text_lines.py      # multiline-text helpers (Plan, Reflection.good)
+└── progress.py        # progress-marker parsing / rendering
+```
+
+Each public operation in `operations.py` is wrapped in
+`@transaction.atomic` — a board write, a Plan write, a Reflection write,
+and (for `/complete` with a note) a `JournalAdded.create` either all
+commit together or none do.
+
+### Identity = text
+
+Tasks are identified by exact-string equality everywhere on the wire and
+internally. The Plan line *is* the identity. This keeps the contract
+simple and matches how the web UI already types Plan lines. The trade-off
+is that two identical lines collapse to one; in practice the user knows
+this and rephrases.
+
+### "Current board"
+
+`Profile.default_board_thread` selects which `Thread` the Board lives on.
+If that's unset, we fall back to the Daily thread so the operation never
+silently no-ops. The most recent `Board` on the chosen thread is used.
+
+### Operation semantics
+
+- **Add (`add_task`)**: if the task text isn't already anywhere in the
+  Board tree (DFS over `board_tree.find_task_by_text`), append a fresh
+  node at root level (`board_operations.create_task_item`). Then ensure
+  the line exists in today's `Plan.focus` via `add_unique_line`.
+- **List (`list_today_tasks`)**: read today's `Plan.focus` lines; flag
+  each as `done=True` iff it also appears in `Reflection.good`; sort
+  unchecked first (preserving original Plan order within each group).
+- **Set done (`set_task_done`)**: branches on whether the text matches a
+  progress marker (see *Progress* below). For plain tasks: flip the
+  board node's "done-ness" — both `data.state` (`open` ↔ `done`, used by
+  the commit pipeline) *and* `state.checked` (boolean, what the Vue
+  Board view actually renders) — and add/remove the line in
+  `Reflection.good`. Also conditionally writes a `JournalAdded` (see
+  *Journal-note modal* below). `board_tree.set_state` keeps both flags
+  in lockstep so the Android tick is indistinguishable from a web-side
+  checkbox click.
+- **Delete (`delete_task`)**: remove the line from today's `Plan.focus`
+  unconditionally; remove the board node only if it has no children;
+  **leave `Reflection.good` untouched** so a task that was checked
+  earlier still shows in the historical "what went well" record.
+
+## Progress-counted tasks
+
+A line whose text contains a counter — `Do tasks (3)`, `Buy (5) apples`,
+`(2/4) Walk 1km` — advances one step per `/complete` tick rather than
+flipping straight to done. The text itself mutates and stays in lockstep
+across all three records.
+
+Grammar: regex `\((\d+)(?:/(\d+))?\)`, first occurrence in the line wins.
+
+- `(N)` (no slash) → `current=0, total=N` (pristine)
+- `(K/N)` (slash) → `current=K, total=N`
+- `total < 1` is rejected (not a progress marker)
+
+Render rules:
+
+- `current == 0` → emit `(total)` form
+- `0 < current ≤ total` → emit `(current/total)`
+
+State transitions (see `_next_progress_step`):
+
+| State          | done=True               | done=False                |
+|----------------|-------------------------|---------------------------|
+| `(N)`          | → `(1/N)` if N>1 else `(N/N)` | no-op                |
+| `(K/N)`, K<N-1 | → `(K+1/N)`             | no-op                     |
+| `(K/N)`, K==N-1| → `(N/N)`, mark done    | no-op                     |
+| `(N/N)`        | no-op (already done)    | → `(N)`, clear Reflection |
+
+The fully-complete form (`K==N`) is the only state that lands in
+`Reflection.good`. Untick is only meaningful from `(N/N)`; untick on
+pristine or partial states is a no-op so progress can only flow forward
+except for one explicit reversal.
+
+`_set_task_done_progress` renames the board node (`board_tree.rename`),
+replaces the Plan line (`text_lines.replace_line`), and updates
+`Reflection.good` only on the complete ↔ uncomplete transitions.
+
+## Journal-note modal
+
+On a check, the Android client shows a small modal with a multiline
+`OutlinedTextField` and OK / Cancel buttons. The `/complete` request
+fires only when the user taps OK; the `note` field carries whatever they
+typed (empty string allowed). On the server, `_maybe_add_journal`
+creates a `JournalAdded` like:
+
+```
+- [x] <post-tick text>
+<user-typed note (multi-line)>
+```
+
+The marker uses markdown task-list syntax (`- [x] `) so the journal renders
+cleanly in the web view. **Crucially, this entry deliberately bypasses
+`services.journalling.process_journal_entry`** — the `[x]` prefix would
+otherwise re-trigger `reflection_extraction.add_reflection_items`, which
+would duplicate the line in `Reflection.good` that `_set_task_done_*`
+already wrote there.
+
+Rules:
+
+- Modal opens **only on check** (`done=True`). Untick fires `/complete`
+  directly with no modal and no journal entry — the `[x]` semantics
+  don't fit reversal.
+- Cancel: no API call, no checkbox flip, no journal entry.
+- Empty note (`""` from the modal): the `/complete` still fires and the
+  task is ticked, but **no `JournalAdded` is created** — confirming a
+  check without any text counts as "just tick the task".
+- Missing `note` field (e.g., pre-modal client builds): same as
+  empty note — no journal entry.
+- For progress tasks the marker carries the **post-tick text**: ticking
+  `Do tasks (2/3)` produces `- [x] Do tasks (3/3)`, matching the line in
+  `Reflection.good` for the same operation.
+- Idempotent operations (tick on already-complete, untick on pristine)
+  return early without creating a journal entry.
+
+`JournalAdded.published` is the device's wall-clock timestamp from the
+request (`timezone.now()` is the safe fallback for callers that don't
+supply one, e.g., unit tests). The `event_stream_id` field is filled by
+the existing `pre_save` signal handler in
+`tasks/apps/tree/signals.py` — derived from the Daily thread.
+
+## Android architecture
+
+Compose UI on top of `kotlinx.coroutines` `StateFlow`s in a single
+`AndroidViewModel`.
+
+```
+android/app/src/main/java/org/polybrain/tasks/health/
+├── data/TasksApi.kt          # Retrofit interface + DTOs
+├── data/TasksClient.kt       # OkHttp + Authorization: Token interceptor
+├── data/Settings.kt          # DataStore: server URL + API token
+├── ui/TodayScreen.kt         # Compose: LazyColumn, AddTaskRow, dialog
+├── ui/TodayViewModel.kt      # tasks / loading / error / pendingComplete
+└── ...
+```
+
+The ViewModel exposes four state flows: `tasks`, `loading`, `error`,
+`configured`, `pendingComplete`. Mutations follow a common pattern:
+optimistic local update → `api.<call>(…)` → on success or failure,
+`reload()` reconciles against server truth. A null check on
+`Settings.snapshot().isConfigured` short-circuits the request when the
+user hasn't set a server URL + token yet.
+
+Checkbox flow:
+
+- `requestSetDone(text, done)` is the UI entry point.
+  - `done = false` → fires `/complete` immediately, no modal.
+  - `done = true` → stashes `PendingComplete(text)`; the modal observes
+    `pendingComplete` and shows itself. No API call yet; no optimistic
+    flip.
+- `confirmCompletion(note)` (OK button) → optimistic flip, fire
+  `/complete` with the note, reload.
+- `cancelCompletion()` (Cancel button or backdrop dismiss) → clear
+  pending state, no side effects.
+
+Pull-to-refresh is wired via `PullToRefreshBox` whose `isRefreshing`
+reflects `vm.loading`. The empty-state `Box` is given
+`Modifier.verticalScroll(rememberScrollState())` so the nested-scroll
+gesture also fires when the list is empty.
+
+## Invariants worth preserving
+
+- **All writes for a single endpoint share one transaction.** Don't
+  split `Board.save()` out from the Plan/Reflection writes — partial
+  state would surface immediately on the next list call.
+- **Text identity is preserved through every operation.** When the text
+  has to change (progress tick), update Board, Plan, *and* Reflection in
+  the same transaction.
+- **Reflection.good is treated as historical.** Delete leaves it alone;
+  only `set_task_done(done=False)` clears the line, and only when
+  transitioning out of fully-complete.
+- **Journal entries from `/complete` never re-enter the reflection
+  pipeline.** Always call `JournalAdded.objects.create(...)` directly;
+  never call `process_journal_entry` on these entries.
+
+## Where to start reading
+
+For backend behavior: `services/today/operations.py` → `progress.py` →
+`board_tree.py` + `text_lines.py`.
+
+For the wire contract: `views_android_api.py`.
+
+For the Android side: `ui/TodayScreen.kt` then `ui/TodayViewModel.kt`,
+then `data/TasksApi.kt`.
+
+Tests live in `tasks/apps/tree/tests/`:
+
+- `test_today_tasks_service.py` — boolean lifecycle, atomicity, journal
+  entry rules.
+- `test_today_progress.py` — progress parsing, rendering, full
+  lifecycle.
+- `test_android_task_api.py` — end-to-end HTTP coverage.

--- a/tasks/apps/tree/services/today/board_tree.py
+++ b/tasks/apps/tree/services/today/board_tree.py
@@ -43,8 +43,15 @@ def has_children(node):
 
 
 def set_state(node, new_state):
+    """Set the work state ("open" / "done") *and* the top-level
+    ``state.checked`` flag the Vue Board view uses to render the checkbox.
+    The two fields are kept in lockstep: a "done" node is also checked, an
+    "open" node is also unchecked.
+    """
     data = node.setdefault("data", {})
     data["state"] = new_state
+    ui_state = node.setdefault("state", {})
+    ui_state["checked"] = new_state == "done"
 
 
 def get_state(node):

--- a/tasks/apps/tree/services/today/operations.py
+++ b/tasks/apps/tree/services/today/operations.py
@@ -35,22 +35,22 @@ def _today(today, published=None):
 
 
 def _maybe_add_journal(text_for_marker, note, published, daily, done):
-    """Record a JournalAdded with ``[x] <text_for_marker>`` (optionally
-    followed by the user's free-form note).
+    """Record a JournalAdded with ``- [x] <text_for_marker>`` followed by
+    the user's free-form note.
 
-    Only fires on ``done=True`` and when ``note is not None`` — uncheck or
-    a missing ``note`` field skips the journal entry entirely.
+    Skipped when:
+    - ``done`` is False (the [x] semantics don't fit reversal); or
+    - ``note`` is falsy (None or empty string) — confirming a check
+      without any text counts as "just tick the task", not journal-worthy.
 
     Deliberately bypasses ``services.journalling.process_journal_entry``:
     the ``[x]`` prefix would otherwise re-trigger reflection extraction
     and duplicate the line that ``_set_task_done_*`` already wrote to
     ``Reflection.good``.
     """
-    if not done or note is None:
+    if not done or not note:
         return
-    comment = f"- [x] {text_for_marker}"
-    if note:
-        comment = f"{comment}\n{note}"
+    comment = f"- [x] {text_for_marker}\n{note}"
     JournalAdded.objects.create(
         thread=daily,
         comment=comment,

--- a/tasks/apps/tree/tests/test_android_task_api.py
+++ b/tasks/apps/tree/tests/test_android_task_api.py
@@ -240,18 +240,19 @@ class AndroidTaskAPITestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         entry = JournalAdded.objects.get(thread=self.daily)
-        self.assertEqual(entry.comment, "[x] buy bread\nbought rye instead")
+        self.assertEqual(entry.comment, "- [x] buy bread\nbought rye instead")
         # Timestamp is taken verbatim from the request, not synthesized.
         self.assertEqual(entry.published, COMPLETE_AT)
 
-    def test_complete_with_empty_note_creates_marker_only_entry(self):
+    def test_complete_with_empty_note_creates_no_journal_entry(self):
         self._auth()
         self._add("buy bread")
 
         self._complete("buy bread", True, note="")
 
-        entry = JournalAdded.objects.get(thread=self.daily)
-        self.assertEqual(entry.comment, "[x] buy bread")
+        # Empty note from the modal means "just confirm the tick" — no
+        # journal entry is recorded.
+        self.assertFalse(JournalAdded.objects.exists())
 
     def test_complete_without_note_creates_no_journal_entry(self):
         self._auth()
@@ -295,4 +296,4 @@ class AndroidTaskAPITestCase(APITestCase):
 
         entry = JournalAdded.objects.get(thread=self.daily)
         # Post-tick text in the [x] line, then the user's note.
-        self.assertEqual(entry.comment, "[x] Do tasks (1/3)\nstep one done")
+        self.assertEqual(entry.comment, "- [x] Do tasks (1/3)\nstep one done")

--- a/tasks/apps/tree/tests/test_today_progress.py
+++ b/tasks/apps/tree/tests/test_today_progress.py
@@ -161,6 +161,10 @@ class ProgressLifecycleTestCase(TestCase):
         plan, reflection = self._reload()
         self.assertEqual(plan.focus, "Do tasks (3/3)")
         self.assertEqual(self.board.state[0]["data"]["state"], "done")
+        # The Vue Board view shows the strikethrough only when this flag
+        # is set — regression for the bug where progressed tasks fully
+        # completed via Android stayed visually unchecked on the web board.
+        self.assertTrue(self.board.state[0]["state"]["checked"])
         self.assertEqual(reflection.good, "Do tasks (3/3)")
 
     def test_full_cycle_3_to_complete(self):

--- a/tasks/apps/tree/tests/test_today_tasks_service.py
+++ b/tasks/apps/tree/tests/test_today_tasks_service.py
@@ -113,9 +113,20 @@ class TodayServiceTestCase(TestCase):
 
         self.board.refresh_from_db()
         self.assertEqual(self.board.state[0]["data"]["state"], "done")
+        # The Vue Board view renders a node as checked from this flag.
+        self.assertTrue(self.board.state[0]["state"]["checked"])
 
         reflection = Reflection.objects.get(pub_date=TODAY, thread=self.daily)
         self.assertEqual(reflection.good, "buy bread")
+
+    def test_set_task_done_false_clears_board_checked_flag(self):
+        add_task(self.user, "buy bread", today=TODAY)
+        set_task_done(self.user, "buy bread", True, today=TODAY)
+        set_task_done(self.user, "buy bread", False, today=TODAY)
+
+        self.board.refresh_from_db()
+        self.assertEqual(self.board.state[0]["data"]["state"], "open")
+        self.assertFalse(self.board.state[0]["state"]["checked"])
 
     def test_set_task_done_false_removes_only_that_reflection_line(self):
         add_task(self.user, "buy bread", today=TODAY)
@@ -236,19 +247,20 @@ class TodayServiceTestCase(TestCase):
         )
 
         entry = JournalAdded.objects.get(thread=self.daily)
-        self.assertEqual(entry.comment, "[x] buy bread\nbought rye instead")
+        self.assertEqual(entry.comment, "- [x] buy bread\nbought rye instead")
         self.assertEqual(entry.published, PUBLISHED_AT)
         # Reflection.good still holds exactly one line — no duplication.
         reflection = Reflection.objects.get(thread=self.daily)
         self.assertEqual(reflection.good, "buy bread")
 
-    def test_check_with_empty_note_creates_marker_only_entry(self):
+    def test_check_with_empty_note_creates_no_journal_entry(self):
         add_task(self.user, "buy bread", today=TODAY)
 
         set_task_done(self.user, "buy bread", True, published=PUBLISHED_AT, note="")
 
-        entry = JournalAdded.objects.get(thread=self.daily)
-        self.assertEqual(entry.comment, "[x] buy bread")
+        # Confirming a check with no text isn't journal-worthy — only
+        # actual content gets a JournalAdded.
+        self.assertFalse(JournalAdded.objects.exists())
 
     def test_check_without_note_creates_no_journal_entry(self):
         add_task(self.user, "buy bread", today=TODAY)
@@ -285,7 +297,7 @@ class TodayServiceTestCase(TestCase):
         )
 
         entry = JournalAdded.objects.get(thread=self.daily)
-        self.assertEqual(entry.comment, "[x] Do tasks (1/3)\nstep one done")
+        self.assertEqual(entry.comment, "- [x] Do tasks (1/3)\nstep one done")
 
     def test_progress_completion_journal_matches_reflection_line(self):
         add_task(self.user, "Do tasks (3)", today=TODAY)
@@ -304,7 +316,7 @@ class TodayServiceTestCase(TestCase):
         )
 
         entry = JournalAdded.objects.get(thread=self.daily)
-        self.assertEqual(entry.comment, "[x] Do tasks (3/3)\nfinished")
+        self.assertEqual(entry.comment, "- [x] Do tasks (3/3)\nfinished")
         reflection = Reflection.objects.get(thread=self.daily)
         self.assertEqual(reflection.good, "Do tasks (3/3)")
 


### PR DESCRIPTION
## Summary

Two follow-up bugs on the Today `/complete` pipeline (#211).

### 1. Progress completion didn't show as checked on the web Board

When ticking the final step of a progress task on Android (e.g. `Do tasks (2/3) → (3/3)`), the row stayed visually unchecked on `/todo/`. Root cause: the Vue Board view reads `node.state.checked` (boolean) to render the strikethrough checkbox, but `board_tree.set_state` only flipped `node.data.state` (the "open" / "done" label preserved by the commit pipeline). Both the boolean and progress paths went through `set_state`, so plain boolean ticks had the same blind spot — just less obvious because the row's strikethrough on the Today list came from `Reflection.good`, not from the board.

**Fix**: `board_tree.set_state` now sets both fields in lockstep — `data.state` for the commit pipeline, `state.checked` for the UI. An Android tick is now indistinguishable from a manual click on the web board.

### 2. Empty notes still created a JournalAdded

Tapping OK on the journal-note modal with an empty text field still recorded a `JournalAdded` whose comment was just `- [x] Task name`. Per the user's preference, an empty note means "just confirm the tick" and shouldn't be journal-worthy.

**Fix**: `_maybe_add_journal` now skips when `note` is falsy (`None` or `""`). `/complete` still fires and the task is ticked; only the `JournalAdded` is suppressed.

## Tests

76 passing tests:

- New `test_set_task_done_false_clears_board_checked_flag`.
- Hardened `test_set_task_done_true_marks_board_and_appends_reflection` — asserts `state.checked == True`.
- Hardened progress regression `test_final_tick_marks_complete_and_adds_to_reflection` — asserts `state.checked == True` on `(2/3) → (3/3)` (direct regression for bug #1).
- Inverted `test_check_with_empty_note_creates_no_journal_entry` + API equivalent — empty note ⇒ no `JournalAdded`.

## Docs

`docs/design-tasks-on-android.md` updated to call out the dual-flag `set_state` and the "empty note = no journal" rule.

## Test plan

- [ ] On Android, tick `Do tasks (3)` three times → web `/todo/` shows the `(3/3)` task with a strikethrough/checked box (not just renamed).
- [ ] Untick `Do tasks (3/3)` → web board shows it unchecked, text reverts to `Do tasks (3)`.
- [ ] Tick a plain task → web board shows it checked.
- [ ] Tap a task, OK with empty note → row ticks, no new `JournalAdded` in admin.
- [ ] Tap a task, OK with text → row ticks, `JournalAdded` recorded as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)