### PR TITLE
feat(android,api): Add another / Reset dialog on completed progress

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayScreen.kt
@@ -82,12 +82,21 @@ fun TodayScreen(vm: TodayViewModel = viewModel()) {
     }
 
     pendingComplete?.let { pending ->
-        JournalNoteDialog(
-            onConfirm = vm::confirmCompletion,
-            onCancel = vm::cancelCompletion,
-            // Reset the draft each time a new pending request arrives.
-            resetKey = pending.text,
-        )
+        when (pending) {
+            is TodayViewModel.PendingComplete.AddNote -> JournalNoteDialog(
+                onConfirm = vm::confirmCompletion,
+                onCancel = vm::cancelCompletion,
+                // Reset the draft each time a new pending request arrives.
+                resetKey = pending.text,
+            )
+            is TodayViewModel.PendingComplete.CompletedAction -> CompletedTaskDialog(
+                taskText = pending.text,
+                onAddAnother = vm::confirmAddAnother,
+                onReset = vm::confirmReset,
+                onCancel = vm::cancelCompletion,
+                resetKey = pending.text,
+            )
+        }
     }
 }
 
@@ -119,6 +128,56 @@ private fun JournalNoteDialog(
         dismissButton = {
             TextButton(onClick = onCancel) {
                 Text(stringResource(R.string.today_note_cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun CompletedTaskDialog(
+    taskText: String,
+    onAddAnother: (String) -> Unit,
+    onReset: () -> Unit,
+    onCancel: () -> Unit,
+    resetKey: Any,
+) {
+    var draft by remember(resetKey) { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onCancel,
+        title = { Text(stringResource(R.string.today_done_dialog_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    text = taskText,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                OutlinedTextField(
+                    value = draft,
+                    onValueChange = { draft = it },
+                    placeholder = { Text(stringResource(R.string.today_note_hint)) },
+                    singleLine = false,
+                    minLines = 3,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onAddAnother(draft) }) {
+                Text(stringResource(R.string.today_done_add_another))
+            }
+        },
+        dismissButton = {
+            // Material3's dismissButton slot accepts arbitrary content;
+            // we stack two TextButtons here so all three actions (Add
+            // another / Reset / Cancel) are visible on a single row.
+            Row {
+                TextButton(onClick = onReset) {
+                    Text(stringResource(R.string.today_done_reset))
+                }
+                TextButton(onClick = onCancel) {
+                    Text(stringResource(R.string.today_note_cancel))
+                }
             }
         },
     )

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayViewModel.kt
@@ -33,7 +33,23 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
     private val _configured = MutableStateFlow(false)
     val configured: StateFlow<Boolean> = _configured.asStateFlow()
 
-    data class PendingComplete(val text: String)
+    /**
+     * What the user just initiated by tapping a row's checkbox. Drives
+     * which dialog (if any) is shown. ``null`` = no pending interaction.
+     */
+    sealed class PendingComplete {
+        abstract val text: String
+
+        /** Tick on an unchecked task → opens the "Add a note" dialog. */
+        data class AddNote(override val text: String) : PendingComplete()
+
+        /**
+         * Tap on a checked progress task (`(K/N)` with `K >= N`) → opens
+         * the completed-task dialog with Add another / Reset / Cancel.
+         * Plain boolean done tasks skip this path and untick immediately.
+         */
+        data class CompletedAction(override val text: String) : PendingComplete()
+    }
 
     private val _pendingComplete = MutableStateFlow<PendingComplete?>(null)
     val pendingComplete: StateFlow<PendingComplete?> = _pendingComplete.asStateFlow()
@@ -53,18 +69,25 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
     /**
      * Entry point for the checkbox tap.
      *
-     * - On uncheck (done=false) the API call fires immediately with no
-     *   journal entry — the [x] marker doesn't make sense for backing
-     *   out of a completion.
-     * - On check (done=true) we stash the request as [pendingComplete]
-     *   so the UI can show the journal-note modal; the API call doesn't
-     *   fire until [confirmCompletion] or is dropped by
-     *   [cancelCompletion]. No optimistic flip — the checkbox stays
-     *   visually un-ticked until the user confirms.
+     * Branching:
+     * - `done = true` (ticking an unchecked row) → stash an [AddNote]
+     *   pending state; the UI opens the add-note dialog and the API
+     *   call doesn't fire until [confirmCompletion]. No optimistic flip.
+     * - `done = false` on a fully-complete *progress* task (`(K/N)`
+     *   with `K >= N`) → stash a [CompletedAction] pending state; the
+     *   UI opens the completed-task dialog with Add another / Reset /
+     *   Cancel. No optimistic flip — the row keeps its checked look
+     *   until the user picks Reset.
+     * - `done = false` on a plain task → fire `/complete` immediately,
+     *   no modal, no journal entry.
      */
     fun requestSetDone(text: String, done: Boolean) {
         if (done) {
-            _pendingComplete.value = PendingComplete(text)
+            _pendingComplete.value = PendingComplete.AddNote(text)
+            return
+        }
+        if (isCompleteProgressTask(text)) {
+            _pendingComplete.value = PendingComplete.CompletedAction(text)
             return
         }
         viewModelScope.launch {
@@ -77,8 +100,9 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    /** OK button on the add-note dialog. */
     fun confirmCompletion(note: String) {
-        val pending = _pendingComplete.value ?: return
+        val pending = _pendingComplete.value as? PendingComplete.AddNote ?: return
         _pendingComplete.value = null
         viewModelScope.launch {
             _tasks.value = _tasks.value.map { t ->
@@ -92,6 +116,46 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    /**
+     * Add another button on the completed-task dialog. Sends `done=true`
+     * — on the backend that advances `(K/N)` to `(K+1/N)` and keeps the
+     * row checked. The optional note flows through as a journal entry
+     * just like a normal tick.
+     */
+    fun confirmAddAnother(note: String) {
+        val pending = _pendingComplete.value as? PendingComplete.CompletedAction ?: return
+        _pendingComplete.value = null
+        viewModelScope.launch {
+            // Row stays visually checked; no optimistic change needed.
+            mutate { api ->
+                api.completeTodayTask(
+                    TaskCompleteRequest(pending.text, true, nowIso(), note)
+                )
+            }
+        }
+    }
+
+    /**
+     * Reset button on the completed-task dialog. Sends `done=false` —
+     * on the backend that returns `(K/N)` to pristine `(N)` and clears
+     * `Reflection.good`. No note, no journal entry.
+     */
+    fun confirmReset() {
+        val pending = _pendingComplete.value as? PendingComplete.CompletedAction ?: return
+        _pendingComplete.value = null
+        viewModelScope.launch {
+            _tasks.value = _tasks.value.map { t ->
+                if (t.text == pending.text) t.copy(done = false) else t
+            }
+            mutate { api ->
+                api.completeTodayTask(
+                    TaskCompleteRequest(pending.text, false, nowIso())
+                )
+            }
+        }
+    }
+
+    /** Cancel / backdrop dismiss on either dialog. */
     fun cancelCompletion() {
         _pendingComplete.value = null
     }
@@ -155,4 +219,27 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
     // the server can record the exact moment as the JournalAdded
     // published time, not a synthesized noon.
     private fun nowIso(): String = OffsetDateTime.now().toString()
+
+    companion object {
+        // Mirrors services/today/progress.py:PROGRESS_RE. Used only to
+        // decide which dialog to open on an "untick" tap — the server
+        // is still the source of truth for actual progression.
+        private val PROGRESS_RE = Regex("""\((\d+)(?:/(\d+))?\)""")
+
+        /**
+         * True when [text] carries a progress marker `(K/N)` whose
+         * current step is at or past its total — i.e. a state where the
+         * row is rendered as checked. `(N)` pristine markers and
+         * partial `(K/N)` (K<N) return false.
+         */
+        internal fun isCompleteProgressTask(text: String): Boolean {
+            val match = PROGRESS_RE.find(text) ?: return false
+            val current = match.groupValues[1].toIntOrNull() ?: return false
+            val totalRaw = match.groupValues[2]
+            if (totalRaw.isEmpty()) return false  // (N) form — never complete
+            val total = totalRaw.toIntOrNull() ?: return false
+            if (total < 1) return false
+            return current >= total
+        }
+    }
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -20,6 +20,10 @@
     <string name="today_note_ok">OK</string>
     <string name="today_note_cancel">Cancel</string>
 
+    <string name="today_done_dialog_title">Task complete</string>
+    <string name="today_done_add_another">Add another</string>
+    <string name="today_done_reset">Reset</string>
+
     <string name="server_url_label">Server URL</string>
     <string name="server_url_placeholder">https://tasks.example.com</string>
     <string name="api_token_label">API token</string>

--- a/docs/design-tasks-on-android.md
+++ b/docs/design-tasks-on-android.md
@@ -133,6 +133,43 @@ State transitions (see `_next_progress_step`):
 | `(N/N)`        | → `(N+1/N)`, stays done             | → `(N)`, clear Reflection        |
 | `(K/N)`, K>N   | → `(K+1/N)`, stays done             | → `(N)`, clear Reflection        |
 
+```mermaid
+stateDiagram-v2
+    direction LR
+
+    [*] --> Pristine: add task with "(N)" marker
+
+    state "Pristine\n(N)" as Pristine
+    state "Partial\n(K/N), 0<K<N" as Partial
+    state "Complete\n(N/N)" as Complete
+    state "Over-quota\n(K/N), K>N" as Overquota
+
+    Pristine --> Partial: tick (N≥2)
+    Pristine --> Complete: tick (N=1)
+
+    Partial --> Partial: tick (K+1<N)
+    Partial --> Complete: tick (K+1==N)\nadd line to Reflection.good
+
+    Complete --> Overquota: tick / "Add another"\nrename Reflection line
+    Complete --> Pristine: untick / "Reset"\nremove Reflection line
+
+    Overquota --> Overquota: tick / "Add another"\nrename Reflection line
+    Overquota --> Pristine: untick / "Reset"\nremove Reflection line
+
+    Pristine --> Pristine: untick (no-op)
+    Partial --> Partial: untick (no-op)
+
+    note right of Complete
+        Board: data.state=done, state.checked=true
+        Reflection.good contains the post-tick text
+    end note
+
+    note left of Partial
+        Board: data.state=open, state.checked=false
+        Reflection.good does NOT contain this line
+    end note
+```
+
 A task is "done" whenever `current >= total`, so over-quota states like
 `(4/3)` are still checked. The Reflection.good line is renamed in place
 on stayed-done transitions; added on the not-done → done transition;

--- a/docs/design-tasks-on-android.md
+++ b/docs/design-tasks-on-android.md
@@ -114,47 +114,79 @@ across all three records.
 Grammar: regex `\((\d+)(?:/(\d+))?\)`, first occurrence in the line wins.
 
 - `(N)` (no slash) → `current=0, total=N` (pristine)
-- `(K/N)` (slash) → `current=K, total=N`
+- `(K/N)` (slash) → `current=K, total=N`; `K` may exceed `N` (over-quota)
 - `total < 1` is rejected (not a progress marker)
 
 Render rules:
 
 - `current == 0` → emit `(total)` form
-- `0 < current ≤ total` → emit `(current/total)`
+- `current > 0` → emit `(current/total)` (over-quota is just printed
+  verbatim, e.g. `(4/3)`)
 
 State transitions (see `_next_progress_step`):
 
-| State          | done=True               | done=False                |
-|----------------|-------------------------|---------------------------|
-| `(N)`          | → `(1/N)` if N>1 else `(N/N)` | no-op                |
-| `(K/N)`, K<N-1 | → `(K+1/N)`             | no-op                     |
-| `(K/N)`, K==N-1| → `(N/N)`, mark done    | no-op                     |
-| `(N/N)`        | no-op (already done)    | → `(N)`, clear Reflection |
+| State          | done=True (tick / Add another)      | done=False (Reset)               |
+|----------------|-------------------------------------|----------------------------------|
+| `(N)`          | → `(1/N)` if N>1 else `(N/N)`       | no-op                            |
+| `(K/N)`, K<N-1 | → `(K+1/N)`                         | no-op                            |
+| `(K/N)`, K==N-1| → `(N/N)`, mark done                | no-op                            |
+| `(N/N)`        | → `(N+1/N)`, stays done             | → `(N)`, clear Reflection        |
+| `(K/N)`, K>N   | → `(K+1/N)`, stays done             | → `(N)`, clear Reflection        |
 
-The fully-complete form (`K==N`) is the only state that lands in
-`Reflection.good`. Untick is only meaningful from `(N/N)`; untick on
-pristine or partial states is a no-op so progress can only flow forward
-except for one explicit reversal.
+A task is "done" whenever `current >= total`, so over-quota states like
+`(4/3)` are still checked. The Reflection.good line is renamed in place
+on stayed-done transitions; added on the not-done → done transition;
+removed on the done → not-done transition.
+
+Untick on pristine or partial states (`current < total`) is a no-op —
+progress only flows forward, except for the explicit Reset.
 
 `_set_task_done_progress` renames the board node (`board_tree.rename`),
 replaces the Plan line (`text_lines.replace_line`), and updates
-`Reflection.good` only on the complete ↔ uncomplete transitions.
+`Reflection.good` based on the done-before/done-after pair.
 
-## Journal-note modal
+## Dialog flows
 
-On a check, the Android client shows a small modal with a multiline
-`OutlinedTextField` and OK / Cancel buttons. The `/complete` request
-fires only when the user taps OK; the `note` field carries whatever they
-typed (empty string allowed). On the server, `_maybe_add_journal`
-creates a `JournalAdded` like:
+Tapping a row's checkbox opens one of two dialogs (or fires `/complete`
+directly) depending on the task's current state.
+
+### Add-note dialog — on tick
+
+Triggered when the user ticks an *unchecked* row (`done = true` in the
+ViewModel's `requestSetDone`). The dialog shows a multiline
+`OutlinedTextField` with OK and Cancel buttons. `/complete` doesn't fire
+until OK; on confirm, the optional `note` flows through to the server.
+
+### Completed-task dialog — on tap of a fully-complete progress task
+
+Triggered when the user taps a checked progress task — `(K/N)` with
+`K >= N`. The dialog shows the task text, the note field, and three
+actions: **Add another**, **Reset**, **Cancel**.
+
+- **Add another** sends `done = true` with the note. The server advances
+  `(K/N) → (K+1/N)` (the row stays checked) and records a journal entry
+  for the over-quota advance.
+- **Reset** sends `done = false` with no note. The server returns the
+  task to pristine `(N)` and clears the `Reflection.good` line.
+- **Cancel** (button or backdrop dismiss) does nothing — no API call,
+  no row change.
+
+The ViewModel detects "checked progress task" via a small Kotlin mirror
+of the backend's progress regex (see
+`TodayViewModel.isCompleteProgressTask`). Plain boolean done tasks skip
+this path entirely and untick immediately on tap.
+
+### JournalAdded creation rules
+
+When the backend records a `JournalAdded`, the comment is:
 
 ```
 - [x] <post-tick text>
 <user-typed note (multi-line)>
 ```
 
-The marker uses markdown task-list syntax (`- [x] `) so the journal renders
-cleanly in the web view. **Crucially, this entry deliberately bypasses
+The marker uses markdown task-list syntax (`- [x] `) so the journal
+renders cleanly in the web view. **The entry deliberately bypasses
 `services.journalling.process_journal_entry`** — the `[x]` prefix would
 otherwise re-trigger `reflection_extraction.add_reflection_items`, which
 would duplicate the line in `Reflection.good` that `_set_task_done_*`
@@ -162,20 +194,16 @@ already wrote there.
 
 Rules:
 
-- Modal opens **only on check** (`done=True`). Untick fires `/complete`
-  directly with no modal and no journal entry — the `[x]` semantics
-  don't fit reversal.
-- Cancel: no API call, no checkbox flip, no journal entry.
-- Empty note (`""` from the modal): the `/complete` still fires and the
-  task is ticked, but **no `JournalAdded` is created** — confirming a
-  check without any text counts as "just tick the task".
-- Missing `note` field (e.g., pre-modal client builds): same as
-  empty note — no journal entry.
-- For progress tasks the marker carries the **post-tick text**: ticking
-  `Do tasks (2/3)` produces `- [x] Do tasks (3/3)`, matching the line in
-  `Reflection.good` for the same operation.
-- Idempotent operations (tick on already-complete, untick on pristine)
-  return early without creating a journal entry.
+- Created only on `done=True` (tick from the add-note dialog or Add
+  another from the completed-task dialog).
+- Reset (`done=False`) creates no journal entry.
+- Plain-task untick (no dialog) creates no journal entry.
+- Empty note (`""`) or missing `note` field: no `JournalAdded` —
+  confirming an action without typed text counts as "just do the
+  state change".
+- For progress tasks the `[x]` line carries the **post-tick text**:
+  ticking `Do tasks (2/3)` writes `- [x] Do tasks (3/3)`; "Add another"
+  on `(3/3)` writes `- [x] Do tasks (4/3)`.
 
 `JournalAdded.published` is the device's wall-clock timestamp from the
 request (`timezone.now()` is the safe fallback for callers that don't

--- a/tasks/apps/tree/services/today/operations.py
+++ b/tasks/apps/tree/services/today/operations.py
@@ -184,16 +184,15 @@ def _next_progress_step(progress, done):
     """Compute the next ``current`` value, or None if the request is a no-op.
 
     Per the agreed semantics:
-    - ``done=True`` on a non-complete task advances by 1.
-    - ``done=False`` on a fully-complete task resets to 0 (pristine).
-    - Any other combination (uncheck on partial, tick on complete) is a
-      no-op so the caller can return early.
+    - ``done=True`` always advances by 1 — including past full completion
+      (e.g. ``(3/3) → (4/3)`` via the "Add another" action on the
+      completed-task dialog).
+    - ``done=False`` resets to pristine ``(N)`` if the task was at or
+      past full completion, otherwise it's a no-op (unticking a
+      partially-progressed task is not meaningful).
     """
     if done:
-        if progress.current >= progress.total:
-            return None
         return progress.current + 1
-    # done=False: only meaningful when fully complete.
     if progress.current < progress.total:
         return None
     return 0
@@ -206,10 +205,10 @@ def _set_task_done_progress(user, text, done, progress, today, note, published):
 
     pub_date = _today(today, published)
     new_text = render_progress(text, progress, next_current)
-    became_complete = (
-        progress.current < progress.total and next_current == progress.total
-    )
-    left_complete = progress.current == progress.total and next_current < progress.total
+    # A task is "done" whenever its current step is at or past its total —
+    # this includes over-quota states like (4/3) reached via "Add another".
+    done_before = progress.current >= progress.total
+    done_after = next_current >= progress.total
 
     board = _current_board(user)
     hit = board_tree.find_task_by_text(board.state, text)
@@ -218,7 +217,7 @@ def _set_task_done_progress(user, text, done, progress, today, note, published):
     else:
         _, _, node = hit
         board_tree.rename(node, new_text)
-    board_tree.set_state(node, "done" if next_current == progress.total else "open")
+    board_tree.set_state(node, "done" if done_after else "open")
     board.save()
 
     daily = _daily_thread()
@@ -236,13 +235,18 @@ def _set_task_done_progress(user, text, done, progress, today, note, published):
     reflection, _created = Reflection.objects.get_or_create(
         pub_date=pub_date, thread=daily
     )
-    if became_complete:
-        # Drop any stale marker for this task (defensive) and add the new
-        # fully-complete text.
+    if not done_before and done_after:
+        # Transition into completion: drop any stale marker (defensive)
+        # and add the new fully-complete text.
         cleaned = text_lines.remove_line(reflection.good, text)
         new_good = text_lines.add_unique_line(cleaned, new_text)
-    elif left_complete:
+    elif done_before and not done_after:
+        # Transition out of completion (Reset): remove the old line.
         new_good = text_lines.remove_line(reflection.good, text)
+    elif done_before and done_after:
+        # Rename in place — (3/3) → (4/3) via "Add another", or any
+        # other over-quota advance.
+        new_good = text_lines.replace_line(reflection.good, text, new_text)
     else:
         new_good = reflection.good or ""
     if new_good != (reflection.good or ""):

--- a/tasks/apps/tree/services/today/progress.py
+++ b/tasks/apps/tree/services/today/progress.py
@@ -32,8 +32,10 @@ def parse_progress(text):
     """Return a Progress for the first marker in ``text``, or None if no
     valid marker is present.
 
-    ``current`` is normalized to ``min(current, total)``; ``total < 1``
-    yields None.
+    ``current`` is **not** clamped — over-quota markers like ``(4/3)`` are
+    legitimate states reachable via the "Add another" action on a
+    fully-completed task. ``total < 1`` is still rejected (a zero-step
+    task has no meaningful progression).
     """
     if not text:
         return None
@@ -50,8 +52,6 @@ def parse_progress(text):
         total = int(second)
     if total < 1:
         return None
-    if current > total:
-        current = total
     return Progress(current=current, total=total, span=match.span())
 
 
@@ -59,8 +59,9 @@ def render_progress(text, progress, new_current):
     """Replace the marker in ``text`` (at ``progress.span``) with the
     rendered form for ``new_current/progress.total``.
 
-    - ``new_current == 0`` → ``(total)`` (pristine)
-    - ``0 < new_current ≤ total`` → ``(new_current/total)``
+    - ``new_current <= 0`` → ``(total)`` (pristine)
+    - ``new_current > 0`` → ``(new_current/total)``; ``new_current`` may
+      exceed ``total`` (over-quota completion via "Add another").
     """
     start, end = progress.span
     if new_current <= 0:

--- a/tasks/apps/tree/tests/test_android_task_api.py
+++ b/tasks/apps/tree/tests/test_android_task_api.py
@@ -297,3 +297,39 @@ class AndroidTaskAPITestCase(APITestCase):
         entry = JournalAdded.objects.get(thread=self.daily)
         # Post-tick text in the [x] line, then the user's note.
         self.assertEqual(entry.comment, "- [x] Do tasks (1/3)\nstep one done")
+
+    def test_add_another_advances_past_full(self):
+        """End-to-end Add another flow: a /complete on a fully-completed
+        progress task bumps it to (N+1/N), keeps the row checked, and
+        records a journal entry with the new over-quota text."""
+        self._auth()
+        self._add("Do tasks (1)")
+        # First tick: (1) → (1/1), done.
+        self._complete("Do tasks (1)", True, note="first")
+        self.assertEqual(
+            self._list().json(),
+            {"items": [{"text": "Do tasks (1/1)", "done": True}]},
+        )
+        # "Add another" tick on the already-done task → (2/1), still done.
+        self._complete("Do tasks (1/1)", True, note="another one")
+
+        self.assertEqual(
+            self._list().json(),
+            {"items": [{"text": "Do tasks (2/1)", "done": True}]},
+        )
+        # Reflection.good renamed in place — single line, new text.
+        reflection = Reflection.objects.get(thread=self.daily)
+        self.assertEqual(reflection.good, "Do tasks (2/1)")
+        # Board row stays checked.
+        self.board.refresh_from_db()
+        self.assertTrue(self.board.state[0]["state"]["checked"])
+        # Two journal entries, one per tick.
+        self.assertEqual(
+            sorted(JournalAdded.objects.values_list("comment", flat=True)),
+            sorted(
+                [
+                    "- [x] Do tasks (1/1)\nfirst",
+                    "- [x] Do tasks (2/1)\nanother one",
+                ]
+            ),
+        )

--- a/tasks/apps/tree/tests/test_today_progress.py
+++ b/tasks/apps/tree/tests/test_today_progress.py
@@ -44,9 +44,11 @@ class ProgressParseTestCase(TestCase):
         self.assertIsNone(parse_progress("(foo) (bar)"))
         self.assertIsNone(parse_progress("Hello (world)"))
 
-    def test_clamps_current_above_total(self):
+    def test_preserves_overshoot(self):
+        # Over-quota states like (7/4) are now legitimate — they're how
+        # "Add another" tracks repeated completions past the plan.
         p = parse_progress("(7/4) overshoot")
-        self.assertEqual((p.current, p.total), (4, 4))
+        self.assertEqual((p.current, p.total), (7, 4))
 
 
 class ProgressRenderTestCase(TestCase):
@@ -194,20 +196,61 @@ class ProgressLifecycleTestCase(TestCase):
         self.assertEqual(self.board.state[0]["data"]["state"], "done")
         self.assertEqual(reflection.good, "Quick (1/1)")
 
-    # --- no-ops ------------------------------------------------------------
+    # --- "Add another" past full completion -------------------------------
 
-    def test_tick_on_complete_is_noop(self):
+    def test_add_another_from_full_advances_overquota(self):
+        """Tick on a fully-completed (N/N) task is no longer a no-op —
+        it advances to (N+1/N) and keeps the task marked done. This is the
+        backend half of the Add another button on the completed-task
+        dialog."""
         self._seed("Done (3/3)")
         Reflection.objects.create(pub_date=TODAY, thread=self.daily, good="Done (3/3)")
         self.board.state[0]["data"]["state"] = "done"
+        self.board.state[0]["state"] = {"checked": True}
         self.board.save()
 
         set_task_done(self.user, "Done (3/3)", True, today=TODAY)
 
         plan, reflection = self._reload()
-        self.assertEqual(plan.focus, "Done (3/3)")
-        self.assertEqual(reflection.good, "Done (3/3)")
+        self.assertEqual(plan.focus, "Done (4/3)")
+        # Still marked done — Add another bumps the count, doesn't reset.
         self.assertEqual(self.board.state[0]["data"]["state"], "done")
+        self.assertTrue(self.board.state[0]["state"]["checked"])
+        # Reflection line renamed in place — no duplicate, no removal.
+        self.assertEqual(reflection.good, "Done (4/3)")
+
+    def test_add_another_from_overquota_keeps_advancing(self):
+        self._seed("Done (4/3)")
+        Reflection.objects.create(pub_date=TODAY, thread=self.daily, good="Done (4/3)")
+        self.board.state[0]["data"]["state"] = "done"
+        self.board.state[0]["state"] = {"checked": True}
+        self.board.save()
+
+        set_task_done(self.user, "Done (4/3)", True, today=TODAY)
+
+        plan, reflection = self._reload()
+        self.assertEqual(plan.focus, "Done (5/3)")
+        self.assertEqual(self.board.state[0]["data"]["state"], "done")
+        self.assertEqual(reflection.good, "Done (5/3)")
+
+    def test_reset_from_overquota_returns_to_pristine(self):
+        """Reset on (4/3) — or any over-quota state — goes straight back
+        to the pristine (N) form and clears Reflection.good."""
+        self._seed("Done (4/3)")
+        Reflection.objects.create(pub_date=TODAY, thread=self.daily, good="Done (4/3)")
+        self.board.state[0]["data"]["state"] = "done"
+        self.board.state[0]["state"] = {"checked": True}
+        self.board.save()
+
+        set_task_done(self.user, "Done (4/3)", False, today=TODAY)
+
+        plan, reflection = self._reload()
+        self.assertEqual(plan.focus, "Done (3)")
+        self.assertEqual(self.board.state[0]["data"]["state"], "open")
+        self.assertFalse(self.board.state[0]["state"]["checked"])
+        self.assertEqual(reflection.good, "")
+
+    # --- no-ops ------------------------------------------------------------
 
     def test_untick_on_pristine_is_noop(self):
         self._seed("Fresh (3)")

--- a/tasks/apps/tree/tests/test_today_tasks_service.py
+++ b/tasks/apps/tree/tests/test_today_tasks_service.py
@@ -320,11 +320,14 @@ class TodayServiceTestCase(TestCase):
         reflection = Reflection.objects.get(thread=self.daily)
         self.assertEqual(reflection.good, "Do tasks (3/3)")
 
-    def test_idempotent_tick_on_complete_makes_no_journal_entry(self):
+    def test_add_another_from_complete_journals_with_overquota_text(self):
+        """Tick on a fully-completed progress task is the Add another
+        action — it advances to (N+1/N) and records a new journal entry
+        with the over-quota text."""
         add_task(self.user, "Do tasks (3)", today=TODAY)
         for old in ("Do tasks (3)", "Do tasks (1/3)", "Do tasks (2/3)"):
             set_task_done(self.user, old, True, today=TODAY)
-        # Already fully complete.
+        # Now at (3/3). The above ticks carried no note → no journal yet.
         self.assertFalse(JournalAdded.objects.exists())
 
         set_task_done(
@@ -332,10 +335,14 @@ class TodayServiceTestCase(TestCase):
             "Do tasks (3/3)",
             True,
             published=PUBLISHED_AT,
-            note="ignored — already done",
+            note="one more",
         )
 
-        self.assertFalse(JournalAdded.objects.exists())
+        entry = JournalAdded.objects.get(thread=self.daily)
+        self.assertEqual(entry.comment, "- [x] Do tasks (4/3)\none more")
+        # Reflection line is renamed in place — not duplicated.
+        reflection = Reflection.objects.get(thread=self.daily)
+        self.assertEqual(reflection.good, "Do tasks (4/3)")
 
     def test_journal_failure_rolls_back_reflection_and_board(self):
         add_task(self.user, "buy bread", today=TODAY)


### PR DESCRIPTION
## Summary

Tapping a completed progress task (e.g. `Do tasks (3/3)`, or any over-quota state like `Do tasks (4/3)`) now opens a second dialog with three actions:

- **Add another** — sends `done=true` with the optional note. Backend advances `(K/N) → (K+1/N)`; the row stays checked and a `JournalAdded` is recorded if the note is non-empty.
- **Reset** — sends `done=false`, no note. Backend returns the task to pristine `(N)` and clears `Reflection.good`.
- **Cancel** — closes the dialog, no API call, no row change.

Plain boolean done tasks still untick immediately on tap — the new dialog is progress-specific.

## Backend

- `progress.parse_progress` no longer clamps `current > total`. `(4/3)` is a legitimate "completed plus one" state.
- `_next_progress_step` always advances on `done=true` (no more no-op at full completion). Untick on at-or-past-full resets to pristine `(N)`; untick on pristine or partial is still a no-op.
- `_set_task_done_progress` now keys off `done_before` / `done_after` flags. The new branch — *stayed-done across the rename* — replaces the `Reflection.good` line in place (e.g. `(3/3) → (4/3)` updates the existing line; no duplicate, no removal). The transition table:

| State          | done=True (tick / Add another)      | done=False (Reset)               |
|----------------|-------------------------------------|----------------------------------|
| `(N)`          | → `(1/N)` if N>1 else `(N/N)`       | no-op                            |
| `(K/N)`, K<N-1 | → `(K+1/N)`                         | no-op                            |
| `(K/N)`, K==N-1| → `(N/N)`, mark done                | no-op                            |
| `(N/N)`        | → `(N+1/N)`, **stays done**         | → `(N)`, clear Reflection        |
| `(K/N)`, K>N   | → `(K+1/N)`, stays done             | → `(N)`, clear Reflection        |

## Android

- `PendingComplete` becomes a sealed class: `AddNote` (existing tick-modal flow) and `CompletedAction` (new tap-on-checked-progress flow).
- `requestSetDone` branches:
  - Tick (`done=true`) → `AddNote` pending state.
  - Untick (`done=false`) on a fully-complete-or-overquota progress task → `CompletedAction` pending state.
  - Untick on a plain task → fire `/complete` immediately, no modal.
- New ViewModel methods: `confirmAddAnother(note)` (sends `done=true` + note) and `confirmReset()` (sends `done=false`, no note).
- New `CompletedTaskDialog` Composable — task text, note field, and three buttons. The dismiss-button slot stacks Reset and Cancel side-by-side so all three actions sit on a single row.
- A small `PROGRESS_RE` mirror of the backend regex lives in the ViewModel's companion object so the client can detect over-quota state without an extra API call.

## Docs

`docs/design-tasks-on-android.md` updated: new state-transition table (over-quota rows included), new "Dialog flows" section describing both dialogs, journal rules updated for the Add another path.

## Tests

79 backend tests pass (3 new lifecycle tests covering Add another from `(N/N)`, Add another from over-quota, Reset from over-quota; the old idempotency test is now `test_add_another_from_complete_journals_with_overquota_text`; one new end-to-end API smoke drives the flow through HTTP). Android `gradle :app:compileDebugKotlin` clean.

## Test plan

- [x] Add `Do tasks (1)` → tick → note → OK. Row becomes `(1/1)`, checked.
- [x] Tap the checked row → **completed-task dialog** appears with task text + note field + Add another / Reset / Cancel.
- [x] Type a note → Add another → row becomes `(2/1)`, **still checked**; web admin shows `JournalAdded` with `- [x] Do tasks (2/1)\n<note>`; `Reflection.good` line is `Do tasks (2/1)` (single line, renamed in place).
- [ ] Tap the row again → Reset → row reverts to `Do tasks (1)`, unchecked; `Reflection.good` cleared; no new journal entry.
- [x] Tap a checked progress task → Cancel → dialog closes, no API call, row unchanged.
- [ ] Tap a plain done task (no progress marker) → row unticks immediately, no dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)