### PR TITLE
feat(android): long-press context menu replaces trash icon

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayScreen.kt
@@ -1,25 +1,26 @@
 package org.polybrain.tasks.health.ui
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -211,34 +212,55 @@ private fun AddTaskRow(onAdd: (String) -> Unit, enabled: Boolean) {
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun TaskRow(
     task: TodayTask,
     onToggle: (Boolean) -> Unit,
     onDelete: () -> Unit,
 ) {
+    var menuExpanded by remember { mutableStateOf(false) }
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Checkbox(checked = task.done, onCheckedChange = onToggle)
-        Text(
-            text = task.text,
-            modifier = Modifier.weight(1f),
-            style = MaterialTheme.typography.bodyLarge.copy(
-                textDecoration = if (task.done) TextDecoration.LineThrough else null,
-            ),
-            color = if (task.done) {
-                MaterialTheme.colorScheme.onSurfaceVariant
-            } else {
-                MaterialTheme.colorScheme.onSurface
-            },
-        )
-        IconButton(onClick = onDelete) {
-            Icon(
-                imageVector = Icons.Filled.Delete,
-                contentDescription = stringResource(R.string.today_delete_description),
+        // Anchoring the DropdownMenu inside this Box positions it near
+        // the task text. combinedClickable on the Box makes the whole
+        // text area a long-press target — a short tap is a no-op so it
+        // doesn't compete with the Checkbox.
+        Box(modifier = Modifier.weight(1f)) {
+            Text(
+                text = task.text,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 40.dp)
+                    .combinedClickable(
+                        onClick = {},
+                        onLongClick = { menuExpanded = true },
+                    )
+                    .padding(vertical = 8.dp),
+                style = MaterialTheme.typography.bodyLarge.copy(
+                    textDecoration = if (task.done) TextDecoration.LineThrough else null,
+                ),
+                color = if (task.done) {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                } else {
+                    MaterialTheme.colorScheme.onSurface
+                },
             )
+            DropdownMenu(
+                expanded = menuExpanded,
+                onDismissRequest = { menuExpanded = false },
+            ) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.today_remove_menu)) },
+                    onClick = {
+                        menuExpanded = false
+                        onDelete()
+                    },
+                )
+            }
         }
     }
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="today_empty">Nothing on today\'s plan yet.</string>
     <string name="today_add_hint">Add a task</string>
     <string name="today_add_button">Add</string>
-    <string name="today_delete_description">Delete task</string>
+    <string name="today_remove_menu">Remove</string>
     <string name="today_not_configured">Configure server URL and API token in Settings first.</string>
     <string name="today_error_format">Error: %1$s</string>
     <string name="today_dismiss_error">Dismiss</string>


### PR DESCRIPTION
## Summary

Replaces the per-row trash `IconButton` with a long-press context menu containing a single **Remove** action. Same backend call (`delete_task`), cleaner row layout — the text claims the freed horizontal space and the checkbox stays on the left.

## Behavior

- Long-press anywhere on a task's text area → small `DropdownMenu` opens with a Remove item.
- Tap Remove → existing `vm::delete` flow runs.
- Short taps on the text area are intentionally a no-op so the Checkbox keeps owning the tap-to-toggle gesture (no accidental toggling from text taps).
- The text gets `Modifier.heightIn(min = 40.dp)` to keep the long-press target comfortable now that no icon stretches the row vertically.

## Changes

- `ui/TodayScreen.kt` — `TaskRow` rewritten: dropped the `IconButton` + Delete icon; wrapped the text in a `Box` with `Modifier.combinedClickable(onLongClick = …)` anchoring a `DropdownMenu`. Imports cleaned up.
- `res/values/strings.xml` — removed `today_delete_description`, added `today_remove_menu` = "Remove".

`gradle :app:compileDebugKotlin` clean.

## Test plan

- [ ] Long-press a task → menu pops up next to the task with a Remove item.
- [ ] Tap Remove → task disappears from the list (and from the web `/todo/` board for leaf tasks).
- [ ] Tap outside the menu → it dismisses; task unchanged.
- [ ] Short tap on the text → nothing happens (no accidental check/uncheck).
- [ ] Checkbox still toggles tasks as before.
- [ ] Long-press still works on rows showing the strikethrough/completed state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)