### PR TITLE
feat(android): sync bike rides to #workout habit

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/data/HealthRepository.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/HealthRepository.kt
@@ -25,6 +25,15 @@ data class DailyMetrics(
     val kcal: Double,
 )
 
+data class BikeSession(
+    // Health Connect's stable per-record ID (Metadata.id). Used as a
+    // dedup key so the 7-day re-sync window doesn't post the same ride
+    // twice.
+    val id: String,
+    val start: java.time.Instant,
+    val durationMinutes: Long,
+)
+
 /**
  * The string constant for Health Connect's background-read permission. Spelled
  * out here (rather than imported from [HealthPermission]) because the SDK
@@ -90,6 +99,43 @@ class HealthRepository(private val context: Context) {
             activeMinutes = activeMinutes,
             kcal = kcal,
         )
+    }
+
+    /**
+     * Reads completed bike rides for the day. Filters [ExerciseSessionRecord]
+     * by [ExerciseSessionRecord.EXERCISE_TYPE_BIKING] and returns each
+     * session with its Health Connect record ID (for client-side dedup
+     * across the rolling re-sync window) and rounded-minute duration.
+     */
+    suspend fun bikeSessions(date: LocalDate, zone: ZoneId = ZoneId.systemDefault()): List<BikeSession> {
+        val client = client()
+        val startInstant = date.atStartOfDay(zone).toInstant()
+        val endInstant = date.plusDays(1).atStartOfDay(zone).toInstant()
+        val range = TimeRangeFilter.between(startInstant, endInstant)
+
+        val sessions = client.readRecords(
+            ReadRecordsRequest(
+                recordType = ExerciseSessionRecord::class,
+                timeRangeFilter = range,
+            )
+        ).records
+
+        val results = ArrayList<BikeSession>()
+        for (session in sessions) {
+            if (session.exerciseType != ExerciseSessionRecord.EXERCISE_TYPE_BIKING) continue
+            val duration = Duration.between(session.startTime, session.endTime)
+            if (duration.isZero || duration.isNegative) continue
+            val minutes = (duration.seconds + 30) / 60
+            if (minutes <= 0) continue
+            results.add(
+                BikeSession(
+                    id = session.metadata.id,
+                    start = session.startTime,
+                    durationMinutes = minutes,
+                )
+            )
+        }
+        return results
     }
 
     /**

--- a/android/app/src/main/java/org/polybrain/tasks/health/data/Settings.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/Settings.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -62,10 +63,28 @@ class Settings(private val context: Context) {
         }
     }
 
+    /**
+     * IDs of bike-ride sessions already posted to the server. Used by
+     * [HealthSyncWorker] to avoid re-posting the same ride on each 7-day
+     * window re-sync. Kept as an opaque set — we don't need ordering or
+     * timestamps because sessions don't mutate after they finish.
+     */
+    suspend fun syncedBikeSessionIds(): Set<String> =
+        context.dataStore.data.first()[SYNCED_BIKE_SESSION_IDS].orEmpty()
+
+    suspend fun addSyncedBikeSessionIds(ids: Collection<String>) {
+        if (ids.isEmpty()) return
+        context.dataStore.edit { prefs ->
+            val existing = prefs[SYNCED_BIKE_SESSION_IDS].orEmpty()
+            prefs[SYNCED_BIKE_SESSION_IDS] = existing + ids
+        }
+    }
+
     private companion object {
         val SERVER_URL = stringPreferencesKey("server_url")
         val API_TOKEN = stringPreferencesKey("api_token")
         val LAST_SYNC_MS = longPreferencesKey("last_sync_ms")
         val LAST_SYNC_ERROR = stringPreferencesKey("last_sync_error")
+        val SYNCED_BIKE_SESSION_IDS = stringSetPreferencesKey("synced_bike_session_ids")
     }
 }

--- a/android/app/src/main/java/org/polybrain/tasks/health/data/TasksApi.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/TasksApi.kt
@@ -21,6 +21,18 @@ data class TrackHabitResponse(
 )
 
 @Serializable
+data class TrackHabitTextRequest(
+    // Single line starting with '#' or '!'. The server parses out the
+    // hashtag and creates one HabitTracked per tag found, so multiple
+    // entries per day for the same habit are supported (unlike the
+    // idempotent /api/v1/habit/track/).
+    @SerialName("text") val text: String,
+    // ISO 8601 timestamp; the server uses this as the event's published
+    // time so the entry lands on the day the activity actually happened.
+    @SerialName("published") val published: String,
+)
+
+@Serializable
 data class OkResponse(
     @SerialName("ok") val ok: Boolean = false,
 )
@@ -132,6 +144,14 @@ data class TripDetailResponse(
 interface TasksApi {
     @POST("api/v1/habit/track/")
     suspend fun trackHabit(@Body body: TrackHabitRequest): TrackHabitResponse
+
+    // Non-API web endpoint (no /api/v1/ prefix) that accepts a free-form
+    // habit line and creates one HabitTracked per parsed hashtag. Used for
+    // per-event activities like individual bike rides, where the
+    // upsert-by-(habit, date) behavior of /api/v1/habit/track/ would
+    // collapse multiple events into one.
+    @POST("habit/track/")
+    suspend fun trackHabitText(@Body body: TrackHabitTextRequest): OkResponse
 
     @GET("api/v1/android/task/today/")
     suspend fun listTodayTasks(@Query("date") date: String): TodayTasksResponse

--- a/android/app/src/main/java/org/polybrain/tasks/health/sync/HealthSyncWorker.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/sync/HealthSyncWorker.kt
@@ -3,11 +3,17 @@ package org.polybrain.tasks.health.sync
 import android.content.Context
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.polybrain.tasks.health.data.BikeSession
 import org.polybrain.tasks.health.data.HealthRepository
 import org.polybrain.tasks.health.data.Settings
+import org.polybrain.tasks.health.data.TasksApi
 import org.polybrain.tasks.health.data.TasksClient
 import org.polybrain.tasks.health.data.TrackHabitRequest
+import org.polybrain.tasks.health.data.TrackHabitTextRequest
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.time.ZoneId
 
 class HealthSyncWorker(
@@ -32,22 +38,44 @@ class HealthSyncWorker(
             }
 
             val api = TasksClient.build(snapshot.serverUrl, snapshot.apiToken)
-            val today = LocalDate.now(ZoneId.systemDefault())
+            val zone = ZoneId.systemDefault()
+            val today = LocalDate.now(zone)
 
-            // Re-sync the trailing window from oldest to newest. Wearables
-            // sometimes back-fill earlier days after re-connecting, so a
-            // single sync per day isn't enough — older days can still change.
-            for (offset in (SYNC_WINDOW_DAYS - 1) downTo 0) {
-                val day = today.minusDays(offset.toLong())
-                val metrics = health.aggregateDay(day)
-                val note = NoteFormatter.format(metrics)
-                api.trackHabit(
-                    TrackHabitRequest(
-                        keyword = HABIT_KEYWORD,
-                        date = day.toString(),
-                        note = note,
+            // The hourly and daily WorkManager jobs use distinct unique-work
+            // names, so they can run concurrently in the same process. The
+            // health-metrics POST is idempotent on (habit, date) and doesn't
+            // care, but per-ride bike entries would duplicate if two workers
+            // both saw the same ride before either persisted the dedup key.
+            // A single process-wide mutex serializes the bike-ride section
+            // so the read/post/persist sequence is atomic across workers.
+            bikeSyncMutex.withLock {
+                val alreadySyncedBikeIds = settings.syncedBikeSessionIds().toHashSet()
+
+                // Re-sync the trailing window from oldest to newest. Wearables
+                // sometimes back-fill earlier days after re-connecting, so a
+                // single sync per day isn't enough — older days can still change.
+                for (offset in (SYNC_WINDOW_DAYS - 1) downTo 0) {
+                    val day = today.minusDays(offset.toLong())
+                    val metrics = health.aggregateDay(day)
+                    val note = NoteFormatter.format(metrics)
+                    api.trackHabit(
+                        TrackHabitRequest(
+                            keyword = HABIT_KEYWORD,
+                            date = day.toString(),
+                            note = note,
+                        )
                     )
-                )
+
+                    val rides = health.bikeSessions(day, zone)
+                    for (ride in rides) {
+                        if (ride.id in alreadySyncedBikeIds) continue
+                        postBikeRide(api, ride, zone)
+                        // Persist the dedup key immediately so a worker crash
+                        // mid-window doesn't re-post the same ride next run.
+                        alreadySyncedBikeIds.add(ride.id)
+                        settings.addSyncedBikeSessionIds(listOf(ride.id))
+                    }
+                }
             }
 
             settings.recordSyncSuccess(System.currentTimeMillis())
@@ -58,10 +86,26 @@ class HealthSyncWorker(
         }
     }
 
+    private suspend fun postBikeRide(api: TasksApi, ride: BikeSession, zone: ZoneId) {
+        val text = NoteFormatter.formatBikeRide(WORKOUT_KEYWORD, ride.durationMinutes)
+        // Use the ride's actual start time so the entry lands on the day
+        // the ride happened, not the day the sync ran.
+        val published = OffsetDateTime.ofInstant(ride.start, zone).toString()
+        api.trackHabitText(
+            TrackHabitTextRequest(
+                text = text,
+                published = published,
+            )
+        )
+    }
+
     companion object {
         const val HABIT_KEYWORD = "health-metrics"
+        const val WORKOUT_KEYWORD = "workout"
 
         /** Days re-synced per run, counting today. Covers late wearable back-fills. */
         const val SYNC_WINDOW_DAYS = 7
+
+        private val bikeSyncMutex = Mutex()
     }
 }

--- a/android/app/src/main/java/org/polybrain/tasks/health/sync/NoteFormatter.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/sync/NoteFormatter.kt
@@ -14,4 +14,14 @@ object NoteFormatter {
             "active=${metrics.activeMinutes}min " +
             "kcal=$kcalStr"
     }
+
+    /**
+     * Formats a bike ride as a habit-line that the server's hashtag parser
+     * will turn into a HabitTracked under the [keyword] habit. Distance is
+     * deliberately omitted — phone-only rides have no reliable distance
+     * (no GPS track from the watch).
+     */
+    fun formatBikeRide(keyword: String, durationMinutes: Long): String {
+        return "#$keyword Bike ride (duration=$durationMinutes min)"
+    }
 }

--- a/android/app/src/test/java/org/polybrain/tasks/health/sync/NoteFormatterTest.kt
+++ b/android/app/src/test/java/org/polybrain/tasks/health/sync/NoteFormatterTest.kt
@@ -52,6 +52,12 @@ class NoteFormatterTest {
     }
 
     @Test
+    fun `bike ride note carries hashtag duration and no distance`() {
+        val text = NoteFormatter.formatBikeRide("workout", 45)
+        assertEquals("#workout Bike ride (duration=45 min)", text)
+    }
+
+    @Test
     fun `kcal is rounded to whole number`() {
         val note = NoteFormatter.format(
             DailyMetrics(


### PR DESCRIPTION
## Summary

- Reads `ExerciseSessionRecord`s with `EXERCISE_TYPE_BIKING` and posts each ride as `#workout Bike ride (duration=N min)` via the existing `/habit/track/` hashtag endpoint, so multiple rides per day are preserved and your manual `#workout` entries aren't clobbered. Distance is omitted because phone-only rides have no reliable GPS track.
- Persists posted session IDs (`Metadata.id`) in DataStore so the rolling 7-day re-sync doesn't duplicate, and the bike-ride section runs under a process-wide `Mutex` to prevent the hourly and daily WorkManager jobs from racing the dedup check.
- Zero backend changes — `/habit/track/` already accepts `TokenAuthentication` and parses hashtags into one `HabitTracked` per tag.

## Test plan

- [x] Install on device, complete a bike ride that lands in Health Connect, tap **Sync now**, confirm a single `#workout Bike ride (duration=N min)` `HabitTracked` appears on the correct day.
- [x] Tap **Sync now** again, confirm no duplicate is created (DataStore dedup).
- [ ] Confirm an existing manual `#workout` entry on the same day is untouched.
- [x] `./gradlew :app:test` — `NoteFormatterTest` includes a new bike-ride formatting case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)