### PR TITLE
feat(android): show this week's plan on Today and add items to today

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/data/TasksApi.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/TasksApi.kt
@@ -70,6 +70,23 @@ data class TodayTasksResponse(
 )
 
 @Serializable
+data class PlanItem(
+    @SerialName("id") val id: Long,
+    @SerialName("pub_date") val pubDate: String,
+    // Newline-joined task lines. May be null/blank when the plan exists
+    // but has no focus set yet.
+    @SerialName("focus") val focus: String? = null,
+)
+
+// DRF PageNumberPagination envelope for GET /plans/. We only ever read
+// the first page for a single (thread, pub_date) pair, so `results` holds
+// at most one plan, but the envelope shape is fixed by the framework.
+@Serializable
+data class PlanListResponse(
+    @SerialName("results") val results: List<PlanItem> = emptyList(),
+)
+
+@Serializable
 data class TripSummary(
     @SerialName("id") val id: Long,
     @SerialName("type") val type: String,
@@ -164,6 +181,16 @@ interface TasksApi {
 
     @POST("api/v1/android/task/delete/")
     suspend fun deleteTodayTask(@Body body: TaskTextRequest): OkResponse
+
+    // Generic DRF Plan endpoint shared with the web frontend. Filtered by
+    // thread name (e.g. "Weekly") and the plan's canonical pub_date (for
+    // Weekly that's the Sunday ending the week). Token-authenticated like
+    // the rest of the client.
+    @GET("plans/")
+    suspend fun listPlans(
+        @Query("thread") thread: String,
+        @Query("pub_date") pubDate: String,
+    ): PlanListResponse
 
     @POST("api/v1/android/trip/start/")
     suspend fun startTrip(@Body body: TripStartRequest): TripResponse

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -46,6 +47,7 @@ import org.polybrain.tasks.health.data.TodayTask
 @Composable
 fun TodayScreen(vm: TodayViewModel = viewModel()) {
     val tasks by vm.tasks.collectAsState()
+    val weekPlan by vm.weekPlan.collectAsState()
     val loading by vm.loading.collectAsState()
     val error by vm.error.collectAsState()
     val configured by vm.configured.collectAsState()
@@ -63,13 +65,38 @@ fun TodayScreen(vm: TodayViewModel = viewModel()) {
             onRefresh = vm::refresh,
             modifier = Modifier.fillMaxSize(),
         ) {
+            // This week's plan items that aren't already on today's list.
+            // Adding one copies it onto today, after which it drops out here.
+            val todayTexts = tasks.map { it.text }.toSet()
+            val pendingWeekPlan = weekPlan.filterNot { it in todayTexts }
             when {
                 !configured -> EmptyState(stringResource(R.string.today_not_configured))
-                tasks.isEmpty() -> EmptyState(stringResource(R.string.today_empty))
-                else -> LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    verticalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
+                tasks.isEmpty() && pendingWeekPlan.isEmpty() ->
+                    EmptyState(stringResource(R.string.today_empty))
+                else -> LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    if (pendingWeekPlan.isNotEmpty()) {
+                        item(key = "week-plan-header") {
+                            Text(
+                                text = stringResource(R.string.today_week_plan_heading),
+                                style = MaterialTheme.typography.titleSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.padding(bottom = 4.dp),
+                            )
+                        }
+                        items(items = pendingWeekPlan, key = { "week:$it" }) { line ->
+                            WeekPlanRow(
+                                text = line,
+                                onAddToToday = { vm.addPlanItemToToday(line) },
+                            )
+                        }
+                    }
+                    // Divider only when both sections are present, so it
+                    // genuinely separates weekly from daily.
+                    if (pendingWeekPlan.isNotEmpty() && tasks.isNotEmpty()) {
+                        item(key = "week-plan-divider") {
+                            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                        }
+                    }
                     items(items = tasks, key = TodayTask::text) { task ->
                         TaskRow(
                             task = task,
@@ -234,20 +261,16 @@ private fun TaskRow(
                 text = task.text,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .heightIn(min = 40.dp)
+                    .heightIn(min = 36.dp)
                     .combinedClickable(
                         onClick = {},
                         onLongClick = { menuExpanded = true },
                     )
-                    .padding(vertical = 8.dp),
+                    .padding(vertical = 4.dp),
                 style = MaterialTheme.typography.bodyLarge.copy(
                     textDecoration = if (task.done) TextDecoration.LineThrough else null,
                 ),
-                color = if (task.done) {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                } else {
-                    MaterialTheme.colorScheme.onSurface
-                },
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             DropdownMenu(
                 expanded = menuExpanded,
@@ -258,6 +281,49 @@ private fun TaskRow(
                     onClick = {
                         menuExpanded = false
                         onDelete()
+                    },
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun WeekPlanRow(
+    text: String,
+    onAddToToday: () -> Unit,
+) {
+    var menuExpanded by remember { mutableStateOf(false) }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Mirrors TaskRow: long-pressing the text opens a contextual menu,
+        // here with the single "Add to today" action.
+        Box(modifier = Modifier.weight(1f)) {
+            Text(
+                text = text,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 36.dp)
+                    .combinedClickable(
+                        onClick = {},
+                        onLongClick = { menuExpanded = true },
+                    )
+                    .padding(vertical = 4.dp),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            DropdownMenu(
+                expanded = menuExpanded,
+                onDismissRequest = { menuExpanded = false },
+            ) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.today_week_plan_add)) },
+                    onClick = {
+                        menuExpanded = false
+                        onAddToToday()
                     },
                 )
             }

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayViewModel.kt
@@ -3,8 +3,10 @@ package org.polybrain.tasks.health.ui
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.time.temporal.TemporalAdjusters
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -23,6 +25,10 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
 
     private val _tasks = MutableStateFlow<List<TodayTask>>(emptyList())
     val tasks: StateFlow<List<TodayTask>> = _tasks.asStateFlow()
+
+    /** This week's plan focus lines (Weekly thread, current week). */
+    private val _weekPlan = MutableStateFlow<List<String>>(emptyList())
+    val weekPlan: StateFlow<List<String>> = _weekPlan.asStateFlow()
 
     private val _loading = MutableStateFlow(false)
     val loading: StateFlow<Boolean> = _loading.asStateFlow()
@@ -59,6 +65,22 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun add(text: String) {
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) return
+        viewModelScope.launch {
+            mutate { api -> api.addTodayTask(TaskTextRequest(trimmed, today())) }
+        }
+    }
+
+    /**
+     * Pull a line from this week's plan into today's tasks. Reuses the
+     * same /add path as a manually typed task — the weekly plan line stays
+     * put (it's the source for the week), the text is copied onto today's
+     * Daily plan. `mutate`'s reload then refreshes both lists, so the item
+     * appears under today's tasks and drops out of the week-plan section
+     * (which filters out lines already on today).
+     */
+    fun addPlanItemToToday(text: String) {
         val trimmed = text.trim()
         if (trimmed.isEmpty()) return
         viewModelScope.launch {
@@ -176,12 +198,21 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
         _configured.value = snapshot.isConfigured
         if (!snapshot.isConfigured) {
             _tasks.value = emptyList()
+            _weekPlan.value = emptyList()
             return
         }
         _loading.value = true
         try {
             val api = buildApi(snapshot)
             _tasks.value = api.listTodayTasks(today()).items
+            _weekPlan.value = api.listPlans("Weekly", endOfWeek()).results
+                .firstOrNull()
+                ?.focus
+                ?.lineSequence()
+                ?.map { it.trim() }
+                ?.filter { it.isNotEmpty() }
+                ?.toList()
+                ?: emptyList()
             _error.value = null
         } catch (t: Throwable) {
             _error.value = t.message ?: t.javaClass.simpleName
@@ -213,6 +244,14 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
     // Used by /add, /delete, /list — they only need to know which day
     // the user means.
     private fun today(): String = LocalDate.now().toString()
+
+    // Canonical pub_date of the current Weekly plan: the Sunday ending this
+    // week. Mirrors the server's make_last_day_of_the_week (utils/datetime.py),
+    // which is also what /plans/add-task/ uses for the "this_week" timeframe.
+    private fun endOfWeek(): String =
+        LocalDate.now()
+            .with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY))
+            .toString()
 
     // Full wall-clock timestamp with the device's current offset, ISO
     // 8601 (e.g. 2026-05-21T15:42:33.123+02:00). Used by /complete so

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -50,6 +50,9 @@
     <string name="today_done_add_another">Add another</string>
     <string name="today_done_reset">Reset</string>
 
+    <string name="today_week_plan_heading">Plan for this week</string>
+    <string name="today_week_plan_add">Add to today</string>
+
     <string name="server_url_label">Server URL</string>
     <string name="server_url_placeholder">https://tasks.example.com</string>
     <string name="api_token_label">API token</string>


### PR DESCRIPTION
## Summary

Adds a **"Plan for this week"** section to the Android Today screen and the ability to pull a weekly plan item into today's tasks via a long-press contextual menu — all using endpoints that already exist (no backend changes).

## What changed

- **`TasksApi.kt`** — `PlanItem` / `PlanListResponse` DTOs and a `listPlans(thread, pubDate)` call against the generic, token-authenticated `GET /plans/` endpoint (the same one the web frontend uses).
- **`TodayViewModel.kt`** — fetches the current Weekly plan in `reload()` (keyed on the Sunday ending the week, mirroring the server's `make_last_day_of_the_week`), exposes it as `weekPlan`, and adds `addPlanItemToToday()` which reuses the existing `/api/v1/android/task/add/` path.
- **`TodayScreen.kt`** — renders the weekly section on top, a `HorizontalDivider` between weekly and daily, gray (`onSurfaceVariant`) task text, tighter row spacing, and a long-press "Add to today" menu on weekly rows.
- **`strings.xml`** — `today_week_plan_heading`, `today_week_plan_add`.

## Behavior notes

- Weekly lines whose exact text is already on today's list are filtered out, so an item disappears from the weekly section once added. This relies on exact text-equality matching (the same string join the rest of the app uses); progress-marker edits to the daily copy could make a line reappear.
- No new backend endpoints — `GET /plans/` and `POST /api/v1/android/task/add/` both accept the client's `Authorization: Token` header (DRF default auth).

## Testing

⚠️ Not compiled — this environment has no Gradle wrapper (`android/gradlew`) or system `gradle`. Changes are self-contained and add no new dependencies (`HorizontalDivider` and the long-press menu are already used elsewhere in the app). Please build with Android Studio / `gradle` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)