### PR TITLE
feat(trips): timestamp trip photos with capture time

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripDetailViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripDetailViewModel.kt
@@ -2,10 +2,13 @@ package org.polybrain.tasks.health.ui.trip
 
 import android.app.Application
 import android.net.Uri
+import android.provider.MediaStore
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import java.io.IOException
+import java.time.Instant
 import java.time.OffsetDateTime
+import java.time.ZoneId
 import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -196,7 +199,6 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
         if (fix == null && !_allowNoLocation.value) return
 
         val comment = composeComment(fix, text)
-        val published = OffsetDateTime.now().toString()
         _uploading.value = true
 
         viewModelScope.launch {
@@ -211,6 +213,10 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
                 val bytes = withContext(Dispatchers.IO) {
                     resolver.openInputStream(uri)?.use { it.readBytes() }
                 } ?: throw IOException("could not read the selected photo")
+                // Timestamp the photo with when it was taken, not now. The
+                // backend further overrides this with the original's EXIF
+                // DateTimeOriginal when present.
+                val published = withContext(Dispatchers.IO) { captureTimeFor(uri) }
 
                 val api = buildApi(snapshot)
                 val presign = api.presignPhoto(
@@ -238,6 +244,39 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
             } finally {
                 _uploading.value = false
             }
+        }
+    }
+
+    /**
+     * Best-effort capture time of a picked image: the gallery's DATE_TAKEN
+     * (epoch millis, UTC) when present, else now. The backend overrides this
+     * with the original's EXIF DateTimeOriginal when the file carries one.
+     */
+    private fun captureTimeFor(uri: Uri): String {
+        val resolver = getApplication<Application>().contentResolver
+        val millis = runCatching {
+            resolver.query(
+                uri,
+                arrayOf(MediaStore.Images.Media.DATE_TAKEN),
+                null,
+                null,
+                null,
+            )?.use { cursor ->
+                val index = cursor.getColumnIndex(MediaStore.Images.Media.DATE_TAKEN)
+                if (index >= 0 && cursor.moveToFirst() && !cursor.isNull(index)) {
+                    cursor.getLong(index)
+                } else {
+                    null
+                }
+            }
+        }.getOrNull()
+        return if (millis != null && millis > 0) {
+            OffsetDateTime.ofInstant(
+                Instant.ofEpochMilli(millis),
+                ZoneId.systemDefault(),
+            ).toString()
+        } else {
+            OffsetDateTime.now().toString()
         }
     }
 

--- a/tasks/apps/tree/services/photos/__init__.py
+++ b/tasks/apps/tree/services/photos/__init__.py
@@ -6,6 +6,7 @@ from .keys import (
     original_key,
     thumbnail_key_for,
 )
+from .metadata import read_capture_datetime
 
 __all__ = [
     "storage",
@@ -14,4 +15,5 @@ __all__ = [
     "key_belongs_to",
     "original_key",
     "thumbnail_key_for",
+    "read_capture_datetime",
 ]

--- a/tasks/apps/tree/services/photos/metadata.py
+++ b/tasks/apps/tree/services/photos/metadata.py
@@ -1,0 +1,73 @@
+"""Read capture metadata (the time a photo was taken) from image bytes.
+
+Trip photos should be timestamped with when they were *taken*, not when they
+were uploaded. The Android client sends its best guess (the gallery's
+DATE_TAKEN); on confirm the backend re-derives the timestamp from the
+original's EXIF and overrides it when present, so EXIF DateTimeOriginal is the
+authoritative source regardless of client.
+"""
+
+import io
+from datetime import datetime, timedelta
+from datetime import timezone as dt_timezone
+
+from django.utils import timezone
+
+from PIL import Image
+
+# EXIF tag numbers (see the EXIF spec).
+_EXIF_IFD = 0x8769
+_DATETIME_ORIGINAL = 0x9003  # in the Exif sub-IFD: "YYYY:MM:DD HH:MM:SS"
+_OFFSET_TIME_ORIGINAL = 0x9011  # in the Exif sub-IFD: "+02:00"
+_DATETIME = 0x0132  # in the main IFD; fallback when no DateTimeOriginal
+
+
+def _parse_offset(value):
+    """Parse an EXIF offset string like ``+02:00`` into a tzinfo, or None."""
+    if not value:
+        return None
+    text = str(value).strip()
+    if len(text) < 6 or text[0] not in "+-":
+        return None
+    try:
+        hours = int(text[1:3])
+        minutes = int(text[4:6])
+    except ValueError:
+        return None
+    delta = timedelta(hours=hours, minutes=minutes)
+    return dt_timezone(delta if text[0] == "+" else -delta)
+
+
+def read_capture_datetime(raw):
+    """Return the tz-aware capture time from an image's EXIF, or None.
+
+    Prefers DateTimeOriginal (with OffsetTimeOriginal when present), falling
+    back to the main-IFD DateTime tag. When EXIF records no UTC offset, the
+    naive value is interpreted in the server's default timezone. Any failure
+    (non-image bytes, absent or malformed EXIF) returns None.
+    """
+    try:
+        exif = Image.open(io.BytesIO(raw)).getexif()
+    except Exception:  # noqa: BLE001 - a bad image must never raise here
+        return None
+    if not exif:
+        return None
+
+    try:
+        sub = exif.get_ifd(_EXIF_IFD)
+    except Exception:  # noqa: BLE001
+        sub = {}
+
+    dt_str = (sub or {}).get(_DATETIME_ORIGINAL) or exif.get(_DATETIME)
+    if not dt_str:
+        return None
+
+    try:
+        naive = datetime.strptime(str(dt_str).strip(), "%Y:%m:%d %H:%M:%S")
+    except (ValueError, TypeError):
+        return None
+
+    tz = _parse_offset((sub or {}).get(_OFFSET_TIME_ORIGINAL))
+    if tz is not None:
+        return naive.replace(tzinfo=tz)
+    return timezone.make_aware(naive)

--- a/tasks/apps/tree/services/trips/operations.py
+++ b/tasks/apps/tree/services/trips/operations.py
@@ -13,7 +13,7 @@ from django.utils import timezone
 
 from ...models import JournalAdded, PhotoAdded, Profile, Story, StoryEvent, Thread
 from ..journalling import process_journal_entry
-from ..photos import key_belongs_to, original_key
+from ..photos import key_belongs_to, original_key, read_capture_datetime
 from ..photos import storage as photo_storage
 from .titles import default_title
 
@@ -132,6 +132,20 @@ def presign_photo_upload(user, story_id, content_type):
     return {"key": key, "upload_url": url, "expires_at": expires_at.isoformat()}
 
 
+def _capture_datetime_from_storage(key):
+    """Best-effort EXIF capture time of the just-uploaded original.
+
+    Returns None on any failure (download error, non-image, no EXIF date) so a
+    missing or unreadable timestamp never blocks the confirm — the caller then
+    falls back to the client-supplied ``published``.
+    """
+    try:
+        raw = photo_storage.download_bytes(key)
+    except Exception:  # noqa: BLE001 - storage hiccups must not fail confirm
+        return None
+    return read_capture_datetime(raw)
+
+
 @transaction.atomic
 def add_trip_photo(user, story_id, key, comment, content_type, published=None):
     """Confirm an uploaded photo: create a PhotoAdded linked to ``story`` and
@@ -149,12 +163,18 @@ def add_trip_photo(user, story_id, key, comment, content_type, published=None):
     if not photo_storage.object_exists(key):
         raise PhotoObjectMissingError(f"no uploaded object at {key!r}")
 
+    # Prefer the time the photo was taken (EXIF) over upload time. Falls back
+    # to the client-supplied ``published`` (the gallery's DATE_TAKEN) and then
+    # to now. Done here so the pre_save signal computes event_stream_id from
+    # the correct date.
+    captured = _capture_datetime_from_storage(key)
+
     photo = PhotoAdded.objects.create(
         thread=_journal_thread_for(user),
         comment=comment,
         original_key=key,
         content_type=content_type,
-        published=published or timezone.now(),
+        published=captured or published or timezone.now(),
     )
     process_journal_entry(photo, story=story)
 

--- a/tasks/apps/tree/tests/test_trip_service.py
+++ b/tasks/apps/tree/tests/test_trip_service.py
@@ -1,3 +1,4 @@
+import io
 from datetime import datetime as datetime_cls
 from datetime import timezone as dt_timezone
 from unittest import mock
@@ -5,6 +6,8 @@ from unittest import mock
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.utils import timezone
+
+from PIL import Image
 
 from ..models import (
     HabitTracked,
@@ -184,6 +187,15 @@ class TripPhotoServiceTestCase(TestCase):
         Profile.objects.create(user=cls.alice, default_board_thread=cls.daily)
         Profile.objects.create(user=cls.bob, default_board_thread=cls.daily)
 
+    def setUp(self):
+        # Confirm reads the uploaded original's EXIF for the capture time; keep
+        # that download hermetic by default (no real S3, empty bytes -> no EXIF
+        # -> the provided ``published`` is used unchanged). Individual tests
+        # override ``download_bytes`` to supply EXIF-bearing image bytes.
+        patcher = mock.patch(f"{STORAGE}.download_bytes", return_value=b"")
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     @mock.patch(f"{STORAGE}.presign_put", return_value="https://put.example/x")
     def test_presign_allocates_key_under_user_story_prefix(self, _put):
         story = start_trip(self.alice)
@@ -331,3 +343,46 @@ class TripPhotoServiceTestCase(TestCase):
         self.assertEqual(result["url"], "https://get.example/orig")
         with self.assertRaises(StoryNotFoundError):
             presign_photo_original(self.bob, photo.pk)
+
+    @staticmethod
+    def _jpeg_with_exif_datetime(dt_str):
+        """A tiny JPEG carrying ``dt_str`` as its EXIF DateTime."""
+        img = Image.new("RGB", (4, 4), "red")
+        exif = img.getexif()
+        exif[0x0132] = dt_str  # DateTime
+        buf = io.BytesIO()
+        img.save(buf, "JPEG", exif=exif)
+        return buf.getvalue()
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_add_trip_photo_uses_exif_capture_time(self, _exists):
+        story = start_trip(self.alice)
+        upload_time = timezone.now()
+        jpeg = self._jpeg_with_exif_datetime("2021:07:15 09:30:00")
+        with mock.patch(f"{STORAGE}.download_bytes", return_value=jpeg):
+            photo = add_trip_photo(
+                self.alice,
+                story.pk,
+                key=f"trips/{self.alice.pk}/{story.pk}/abc.jpg",
+                comment="sunset",
+                content_type="image/jpeg",
+                published=upload_time,
+            )
+        # The EXIF capture time wins over the upload time.
+        expected = datetime_cls(2021, 7, 15, 9, 30, 0, tzinfo=dt_timezone.utc)
+        self.assertEqual(photo.published, expected)
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_add_trip_photo_falls_back_to_published_without_exif(self, _exists):
+        story = start_trip(self.alice)
+        upload_time = timezone.now()
+        # Default setUp patch returns b"" -> no EXIF -> provided time is kept.
+        photo = add_trip_photo(
+            self.alice,
+            story.pk,
+            key=f"trips/{self.alice.pk}/{story.pk}/abc.jpg",
+            comment="no exif here",
+            content_type="image/jpeg",
+            published=upload_time,
+        )
+        self.assertEqual(photo.published, upload_time)


### PR DESCRIPTION
## Summary

A trip photo was published at **upload time**. This makes `published` reflect **when the photo was taken**, sourced in two layers (Android sends, backend confirms):

- **Backend (authoritative)** — on confirm, `add_trip_photo` downloads the just-uploaded original and reads its EXIF via the new `services/photos/metadata.py::read_capture_datetime` (prefers `DateTimeOriginal` + `OffsetTimeOriginal`, falls back to the main-IFD `DateTime`). When EXIF carries a capture time it **overrides** the client value; otherwise it falls back to the client-supplied `published`, then `now()`.
  - Read at confirm (not in the Celery thumbnail task) so the `pre_save` signal computes `event_stream_id` from the correct date.
  - Any download/parse failure is swallowed, so a missing or unreadable EXIF never blocks the confirm.
- **Android** — `sendPhoto` now sends the gallery's `MediaStore.Images.Media.DATE_TAKEN` (epoch-millis UTC → exact instant) instead of `OffsetDateTime.now()`, falling back to `now()` when absent.

## Tests

- `test_add_trip_photo_uses_exif_capture_time` — EXIF capture time wins over upload time.
- `test_add_trip_photo_falls_back_to_published_without_exif` — provided timestamp kept when the original has no EXIF.
- The photo service test class now mocks `download_bytes` so the confirm path stays hermetic.
- Full `tasks.apps.tree` suite: **174 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)