### PR TITLE
fix(trips): post trip notes and photos to Daily, not the board thread

### DIFF
--- a/tasks/apps/tree/services/trips/operations.py
+++ b/tasks/apps/tree/services/trips/operations.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
 
-from ...models import JournalAdded, PhotoAdded, Profile, Story, StoryEvent, Thread
+from ...models import JournalAdded, PhotoAdded, Story, StoryEvent, Thread
 from ..journalling import process_journal_entry
 from ..photos import key_belongs_to, original_key, read_capture_datetime
 from ..photos import storage as photo_storage
@@ -35,18 +35,12 @@ def _daily_thread():
 
 
 def _journal_thread_for(user):
-    """Resolve the Thread used for a trip note's JournalAdded.
+    """Resolve the Thread used for a trip note's/photo's JournalAdded.
 
-    Mirrors the Today flow: prefer ``Profile.default_board_thread``,
-    fall back to the Daily thread so the operation never silently
-    no-ops on users without a configured default.
+    Trip notes are diary-style entries, so they always go to the Daily
+    thread — deliberately *not* the user's ``Profile.default_board_thread``
+    (which targets boards/tasks and may be the Inbox).
     """
-    try:
-        profile = Profile.objects.select_related("default_board_thread").get(user=user)
-    except Profile.DoesNotExist:
-        return _daily_thread()
-    if profile.default_board_thread is not None:
-        return profile.default_board_thread
     return _daily_thread()
 
 

--- a/tasks/apps/tree/tests/test_trip_service.py
+++ b/tasks/apps/tree/tests/test_trip_service.py
@@ -92,6 +92,17 @@ class TripServiceTestCase(TestCase):
         link = StoryEvent.objects.get(story=story, event=journal)
         self.assertIsNotNone(link)
 
+    def test_add_trip_note_uses_daily_thread_not_board_default(self):
+        # Diary-style trip notes always land on the Daily thread, even when the
+        # user's default *board* thread is something else (e.g. the Inbox).
+        inbox, _ = Thread.objects.get_or_create(name="Inbox")
+        Profile.objects.filter(user=self.alice).update(default_board_thread=inbox)
+        story = start_trip(self.alice)
+        journal = add_trip_note(
+            self.alice, story.pk, comment="walking", published=timezone.now()
+        )
+        self.assertEqual(journal.thread, self.daily)
+
     def test_add_trip_note_with_poi_creates_habittracked_linked_to_story(self):
         story = start_trip(self.alice)
         comment = "#poi lat=40.7128 lng=-74.0060\nCoffee at the corner"


### PR DESCRIPTION
## Summary

Trip notes and photos from Android were landing on the **Inbox** instead of the diary. They resolved their `JournalAdded` thread via `Profile.default_board_thread`, which is the default **Board** thread (for boards/tasks) — the Inbox for some users — not the journal/diary thread.

`_journal_thread_for` now always returns the **Daily** thread, so both `add_trip_note` and `add_trip_photo` post there. The Today task-done note flow already wrote to Daily directly, so it was unaffected.

## Changes

- `services/trips/operations.py` — `_journal_thread_for` returns Daily unconditionally; dropped the now-unused `Profile` import.
- `tests/test_trip_service.py` — `test_add_trip_note_uses_daily_thread_not_board_default`: sets the user's default board thread to Inbox and asserts the note still lands on Daily.

Trip + photo suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)