### PR TITLE
feat(android): browse Today by date with prev/next navigation

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/MainActivity.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/MainActivity.kt
@@ -102,7 +102,17 @@ private fun MainScaffold(vm: MainViewModel = viewModel()) {
         Scaffold(
             topBar = {
                 TopAppBar(
-                    title = { Text(stringResource(current.titleRes)) },
+                    // The Today screen's top bar carries the product name
+                    // ("Tasks Collector"); the drawer item stays "Today".
+                    // Other destinations show their own nav title.
+                    title = {
+                        val titleRes = if (current == Destination.Today) {
+                            R.string.today_top_bar_title
+                        } else {
+                            current.titleRes
+                        }
+                        Text(stringResource(titleRes))
+                    },
                     navigationIcon = {
                         IconButton(onClick = { scope.launch { drawerState.open() } }) {
                             Icon(

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayScreen.kt
@@ -2,6 +2,7 @@ package org.polybrain.tasks.health.ui
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -22,6 +23,7 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -37,9 +39,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import org.polybrain.tasks.health.R
 import org.polybrain.tasks.health.data.TodayTask
 
@@ -52,10 +57,18 @@ fun TodayScreen(vm: TodayViewModel = viewModel()) {
     val error by vm.error.collectAsState()
     val configured by vm.configured.collectAsState()
     val pendingComplete by vm.pendingComplete.collectAsState()
+    val selectedDate by vm.selectedDate.collectAsState()
 
     LaunchedEffect(Unit) { vm.refresh() }
 
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        DateNavBar(
+            selectedDate = selectedDate,
+            onPrevious = vm::previousDay,
+            onNext = vm::nextDay,
+            onToday = vm::goToToday,
+        )
+
         AddTaskRow(onAdd = vm::add, enabled = configured)
 
         error?.let { ErrorBanner(message = it, onDismiss = vm::clearError) }
@@ -209,6 +222,51 @@ private fun CompletedTaskDialog(
             }
         },
     )
+}
+
+// Date label like "Wed, May 28"; the year is omitted to keep the bar
+// compact since most navigation stays within the current year.
+private val DATE_NAV_FORMAT = DateTimeFormatter.ofPattern("EEE, MMM d")
+
+@Composable
+private fun DateNavBar(
+    selectedDate: LocalDate,
+    onPrevious: () -> Unit,
+    onNext: () -> Unit,
+    onToday: () -> Unit,
+) {
+    val label = if (selectedDate == LocalDate.now()) {
+        stringResource(R.string.today_date_today)
+    } else {
+        selectedDate.format(DATE_NAV_FORMAT)
+    }
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onPrevious) {
+            Text(
+                text = "‹", // ‹
+                style = MaterialTheme.typography.headlineMedium,
+            )
+        }
+        // Tapping the label jumps back to the current day.
+        Text(
+            text = label,
+            style = MaterialTheme.typography.titleMedium,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .weight(1f)
+                .clickable(onClick = onToday)
+                .padding(vertical = 4.dp),
+        )
+        IconButton(onClick = onNext) {
+            Text(
+                text = "›", // ›
+                style = MaterialTheme.typography.headlineMedium,
+            )
+        }
+    }
 }
 
 @Composable

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayViewModel.kt
@@ -40,6 +40,16 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
     val configured: StateFlow<Boolean> = _configured.asStateFlow()
 
     /**
+     * Which day the Today view is showing. Defaults to the device's current
+     * day; the prev/next chevrons move it backward/forward. Every endpoint
+     * the screen talks to (list / add / complete / delete and the weekly
+     * plan lookup) is keyed off this date, so past days are browsable and
+     * future days are pre-fillable — no day is special-cased.
+     */
+    private val _selectedDate = MutableStateFlow(LocalDate.now())
+    val selectedDate: StateFlow<LocalDate> = _selectedDate.asStateFlow()
+
+    /**
      * What the user just initiated by tapping a row's checkbox. Drives
      * which dialog (if any) is shown. ``null`` = no pending interaction.
      */
@@ -61,6 +71,23 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
     val pendingComplete: StateFlow<PendingComplete?> = _pendingComplete.asStateFlow()
 
     fun refresh() {
+        viewModelScope.launch { reload() }
+    }
+
+    /** Chevron-left: step the view back one day and reload. */
+    fun previousDay() = goToDate(_selectedDate.value.minusDays(1))
+
+    /** Chevron-right: step the view forward one day and reload. */
+    fun nextDay() = goToDate(_selectedDate.value.plusDays(1))
+
+    /** Tap on the date label: jump straight back to the current day. */
+    fun goToToday() = goToDate(LocalDate.now())
+
+    private fun goToDate(date: LocalDate) {
+        if (date == _selectedDate.value) return
+        _selectedDate.value = date
+        // Any pending dialog refers to a task on the previous day's list.
+        _pendingComplete.value = null
         viewModelScope.launch { reload() }
     }
 
@@ -240,24 +267,37 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
     private fun buildApi(snapshot: SettingsSnapshot): TasksApi =
         TasksClient.build(snapshot.serverUrl, snapshot.apiToken)
 
-    // Local date in the device's current timezone, ISO 8601 (YYYY-MM-DD).
-    // Used by /add, /delete, /list — they only need to know which day
-    // the user means.
-    private fun today(): String = LocalDate.now().toString()
+    // The selected day in ISO 8601 (YYYY-MM-DD). Used by /add, /delete,
+    // /list — they only need to know which day the user means.
+    private fun today(): String = _selectedDate.value.toString()
 
-    // Canonical pub_date of the current Weekly plan: the Sunday ending this
-    // week. Mirrors the server's make_last_day_of_the_week (utils/datetime.py),
-    // which is also what /plans/add-task/ uses for the "this_week" timeframe.
+    // Canonical pub_date of the Weekly plan covering the selected day: the
+    // Sunday ending that week. Mirrors the server's make_last_day_of_the_week
+    // (utils/datetime.py), which is also what /plans/add-task/ uses for the
+    // "this_week" timeframe. Keyed off the selected day so the week-plan
+    // section follows the date you're browsing.
     private fun endOfWeek(): String =
-        LocalDate.now()
+        _selectedDate.value
             .with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY))
             .toString()
 
     // Full wall-clock timestamp with the device's current offset, ISO
-    // 8601 (e.g. 2026-05-21T15:42:33.123+02:00). Used by /complete so
-    // the server can record the exact moment as the JournalAdded
-    // published time, not a synthesized noon.
-    private fun nowIso(): String = OffsetDateTime.now().toString()
+    // 8601 (e.g. 2026-05-21T15:42:33.123+02:00). Used by /complete so the
+    // server records the exact moment as the JournalAdded published time.
+    // When browsing a different day, we keep the current time-of-day but
+    // swap the date to the selected one, so the server's
+    // pub_date = published.date() lands the Plan/Reflection write on the
+    // day being viewed rather than on the real today.
+    private fun nowIso(): String {
+        val now = OffsetDateTime.now()
+        val selected = _selectedDate.value
+        if (selected == now.toLocalDate()) return now.toString()
+        return now
+            .withYear(selected.year)
+            .withMonth(selected.monthValue)
+            .withDayOfMonth(selected.dayOfMonth)
+            .toString()
+    }
 
     companion object {
         // Mirrors services/today/progress.py:PROGRESS_RE. Used only to

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -59,6 +59,9 @@
     <string name="today_week_plan_heading">Plan for this week</string>
     <string name="today_week_plan_add">Add to today</string>
 
+    <string name="today_date_today">Today</string>
+    <string name="today_top_bar_title">Tasks Collector</string>
+
     <string name="server_url_label">Server URL</string>
     <string name="server_url_placeholder">https://tasks.example.com</string>
     <string name="api_token_label">API token</string>


### PR DESCRIPTION
## Summary

Adds date navigation to the Android **Today** screen so days other than the current one can be browsed and edited.

- New **date nav bar** above the add-task row: `‹` / `›` chevrons step the view back/forward one day, and the centered date label (e.g. `Wed, May 28`) is tappable to jump straight back to today.
- The selected day drives **every endpoint the screen talks to** — list, add, complete, delete, and the weekly-plan lookup — so past days are browsable and future days pre-fillable. No day is special-cased.
- `endOfWeek()` is keyed off the selected day, so the "Plan for this week" section follows the date being browsed.
- `/complete` keeps the current wall-clock time-of-day but swaps in the selected date, so the server's `pub_date = published.date()` lands the `Plan`/`Reflection` write on the day being viewed rather than the real today.
- The Today screen's top bar now shows the product name (**Tasks Collector**) while the drawer item stays **Today**.

## Notes

- The date label omits the year to keep the bar compact (most navigation stays within the current year).
- Changing the day clears any pending complete-dialog state, since the dialog refers to a task on the previously shown list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)