### PR TITLE
feat(stories): link journal entries to a story and expose stories API

### DIFF
--- a/tasks/apps/tree/serializers.py
+++ b/tasks/apps/tree/serializers.py
@@ -169,9 +169,35 @@ class JournalAddedSerializer(serializers.ModelSerializer):
         slug_field="slug",
     )
 
+    # JournalAdded has no `story` attribute; the link is created via a
+    # StoryEvent in the viewset. Write-only so output never tries to read
+    # a non-existent attribute and the POST response stays unchanged.
+    story = serializers.PrimaryKeyRelatedField(
+        queryset=Story.objects.all(),
+        required=False,
+        allow_null=True,
+        write_only=True,
+    )
+
     class Meta:
         model = JournalAdded
-        fields = ["id", "comment", "published", "thread", "tags"]
+        fields = ["id", "comment", "published", "thread", "tags", "story"]
+
+    def validate_story(self, story):
+        request = self.context.get("request")
+        if (
+            story is not None
+            and request is not None
+            and story.user_id != request.user.id
+        ):
+            raise serializers.ValidationError("Story not found for this user.")
+        return story
+
+    def create(self, validated_data):
+        # `story` is not a model field; it is linked via StoryEvent in
+        # JournalAddedViewSet.perform_create using serializer.validated_data.
+        validated_data.pop("story", None)
+        return super().create(validated_data)
 
 
 class PhotoAddedSerializer(JournalAddedSerializer):
@@ -188,6 +214,12 @@ class QuickNoteSerializer(serializers.ModelSerializer):
     class Meta:
         model = QuickNote
         fields = ["id", "published", "note"]
+
+
+class StorySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Story
+        fields = ["id", "type", "title", "started", "stopped"]
 
 
 class ObservationMadeSerializer(AbsoluteURLSerializerMixin, BaseTypeThreadSerializer):

--- a/tasks/apps/tree/tests/test_journal_story_api.py
+++ b/tasks/apps/tree/tests/test_journal_story_api.py
@@ -1,0 +1,64 @@
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from ..models import HabitTracked, JournalAdded, Story, StoryEvent, Thread
+
+
+class JournalStoryAPITestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        User = get_user_model()
+        cls.user = User.objects.create_user(username="u", password="x")
+        cls.other = User.objects.create_user(username="other", password="x")
+        cls.daily, _ = Thread.objects.get_or_create(name="Daily")
+
+    def setUp(self):
+        self.client.force_authenticate(user=self.user)
+
+    def _post(self, **extra):
+        payload = {"comment": "hello", "thread": "Daily", "tags": []}
+        payload.update(extra)
+        return self.client.post(reverse("journaladded-list"), payload, format="json")
+
+    def test_post_with_owned_story_links_story_event(self):
+        story = Story.objects.create(user=self.user, title="t")
+        resp = self._post(story=story.pk)
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        journal = JournalAdded.objects.get(pk=resp.data["id"])
+        self.assertEqual(
+            StoryEvent.objects.filter(story=story, event=journal).count(), 1
+        )
+
+    def test_post_with_owned_story_links_extracted_habit(self):
+        story = Story.objects.create(user=self.user, title="t")
+        resp = self._post(comment="#poi lat=10 lng=20\nseaside", story=story.pk)
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        # 1 journal + 1 habit-tracked = 2 story_event rows
+        self.assertEqual(StoryEvent.objects.filter(story=story).count(), 2)
+        habit = HabitTracked.objects.get(habit__slug="poi")
+        self.assertTrue(StoryEvent.objects.filter(story=story, event=habit).exists())
+
+    def test_post_with_other_users_story_is_rejected(self):
+        story = Story.objects.create(user=self.other, title="t")
+        resp = self._post(story=story.pk)
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(StoryEvent.objects.filter(story=story).exists())
+        self.assertFalse(JournalAdded.objects.exists())
+
+    def test_post_without_story_creates_no_story_event(self):
+        resp = self._post()
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(StoryEvent.objects.count(), 0)
+
+    def test_active_story_endpoint_scopes_to_user_and_active(self):
+        active = Story.objects.create(user=self.user, title="active")
+        Story.objects.create(user=self.user, title="stopped", stopped=timezone.now())
+        Story.objects.create(user=self.other, title="other-active")
+        resp = self.client.get(reverse("stories-list"), {"active": "true"})
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        ids = [s["id"] for s in resp.data["results"]]
+        self.assertEqual(ids, [active.pk])

--- a/tasks/apps/tree/urls.py
+++ b/tasks/apps/tree/urls.py
@@ -39,6 +39,7 @@ router.register(r"habit-api", views_habit.HabitViewSet)
 # Core
 router.register(r"threads", views.ThreadViewSet)
 router.register(r"profile", views.ProfileViewSet, basename="profile")
+router.register(r"stories", views.StoryViewSet, basename="stories")
 
 
 urlpatterns = [

--- a/tasks/apps/tree/views.py
+++ b/tasks/apps/tree/views.py
@@ -57,7 +57,8 @@ class JournalAddedViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         journal_added = serializer.save()
         skip_habits = "reflection" in self.request.data
-        process_journal_entry(journal_added, skip_habits=skip_habits)
+        story = serializer.validated_data.get("story")
+        process_journal_entry(journal_added, skip_habits=skip_habits, story=story)
 
 
 class QuickNoteViewSet(viewsets.ModelViewSet):
@@ -83,6 +84,17 @@ class ProfileViewSet(viewsets.ReadOnlyModelViewSet):
     def get_queryset(self):
         # Only return the current user's profile
         return Profile.objects.filter(user=self.request.user)
+
+
+class StoryViewSet(viewsets.ReadOnlyModelViewSet):
+    serializer_class = StorySerializer
+
+    def get_queryset(self):
+        # Only the current user's stories; `?active=true` limits to unstopped.
+        qs = Story.objects.filter(user=self.request.user)
+        if self.request.query_params.get("active") in ("1", "true", "True", "yes"):
+            qs = qs.filter(stopped__isnull=True)
+        return qs
 
 
 def _get_current_plans():


### PR DESCRIPTION
## Summary

Lets a journal entry optionally be attached to a `Story`, and adds a read-only API to list the current user's stories.

- **Journal → Story linking**: `JournalAddedSerializer` gains a write-only `story` field (PK reference). Because `JournalAdded` has no `story` attribute, the link is created as a `StoryEvent` in `JournalAddedViewSet.perform_create` via `process_journal_entry(..., story=story)`. This also links habits extracted from the journal comment to the same story.
- **Ownership check**: posting a story owned by another user returns `400`.
- **Stories endpoint**: new read-only `StoryViewSet` at `/stories`, scoped to the current user, with an `?active=true` filter that limits results to unstopped stories.

## Implementation notes

- The `story` field is `write_only`, so POST responses are unchanged and serialization never reads a non-existent attribute.
- `story` is popped in `create()` since it is not a model field; the actual linking happens in the viewset.

## Tests

Adds `test_journal_story_api.py` covering:
- posting with an owned story creates a `StoryEvent`
- extracted habits are also linked to the story
- posting another user's story is rejected (no journal/story-event created)
- posting without a story creates no `StoryEvent`
- `/stories?active=true` is scoped to the user and to active (unstopped) stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)