### PR TITLE
ci: exclude cli directory from deploy and test pipelines

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
       - 'docker/**'
       - '**.md'
       - 'android/**'
+      - 'cli/**'
       - 'tasks/apps/tree/tests/**'
       - 'tasks/settings/local.py'
       - 'requirements/local.txt'

--- a/.github/workflows/rsync.exclude
+++ b/.github/workflows/rsync.exclude
@@ -2,7 +2,7 @@
 /android
 /docker
 /docs
-/tools
+/cli
 /manage.py
 /package.json
 /package-lock.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
       - 'docker/**'
       - '**.md'
       - 'android/**'
+      - 'cli/**'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

The `tasks-collector-tools` repo history was moved into the `cli/` directory. This PR ensures changes confined to `cli/` do not affect the existing CI/CD pipelines.

## Changes

- **`deploy.yml`** — add `cli/**` to `paths-ignore`. Pushes to `main` that only touch `cli/` no longer trigger a production deploy.
- **`test.yml`** — add `cli/**` to `paths-ignore`. PRs that only touch `cli/` no longer run the Django/test workflow.
- **`rsync.exclude`** — replace the stale `/tools` entry with `/cli` (the directory was renamed `tools` → `cli`), so the CLI tools aren't rsynced to the production server even when a deploy is triggered by other changes.

`android-test.yml` needed no change — it uses a `paths:` allowlist (`android/**` + its own workflow file), so `cli/` changes already never trigger it.

> Note: `paths-ignore` is diff-based — a commit touching both `cli/` and backend code will still trigger the workflows, as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)