### PR TITLE
feat(android): add FAB to register gym/workout habit activities

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/HealthScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/HealthScreen.kt
@@ -2,19 +2,34 @@ package org.polybrain.tasks.health.ui
 
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -31,6 +46,7 @@ fun HealthScreen(vm: MainViewModel) {
     val state by vm.settingsState.collectAsState()
     val permissionsGranted by vm.permissionsGranted.collectAsState()
     val todayMetrics by vm.todayMetrics.collectAsState()
+    val activityDialogOpen by vm.activityDialogOpen.collectAsState()
     val scope = rememberCoroutineScope()
 
     val permissionLauncher = rememberLauncherForActivityResult(
@@ -39,67 +55,144 @@ fun HealthScreen(vm: MainViewModel) {
         scope.launch { vm.refreshPermissionState() }
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(24.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        when (vm.healthConnectStatus) {
-            HealthConnectClient.SDK_UNAVAILABLE -> {
-                Text(stringResource(R.string.hc_unavailable))
-            }
-            HealthConnectClient.SDK_UNAVAILABLE_PROVIDER_UPDATE_REQUIRED -> {
-                Text(stringResource(R.string.hc_needs_update))
-            }
-            else -> {
-                if (!permissionsGranted) {
-                    Button(onClick = { permissionLauncher.launch(vm.requiredPermissions) }) {
-                        Text(stringResource(R.string.grant_permissions))
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                // Bottom padding clears the FAB so the last row stays tappable.
+                .padding(start = 24.dp, top = 24.dp, end = 24.dp, bottom = 96.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            when (vm.healthConnectStatus) {
+                HealthConnectClient.SDK_UNAVAILABLE -> {
+                    Text(stringResource(R.string.hc_unavailable))
+                }
+                HealthConnectClient.SDK_UNAVAILABLE_PROVIDER_UPDATE_REQUIRED -> {
+                    Text(stringResource(R.string.hc_needs_update))
+                }
+                else -> {
+                    if (!permissionsGranted) {
+                        Button(onClick = { permissionLauncher.launch(vm.requiredPermissions) }) {
+                            Text(stringResource(R.string.grant_permissions))
+                        }
                     }
+                }
+            }
+
+            Button(
+                onClick = { vm.syncNow() },
+                enabled = state.isConfigured && permissionsGranted,
+            ) {
+                Text(stringResource(R.string.sync_now))
+            }
+
+            Text(
+                text = when {
+                    state.lastSyncError.isNotEmpty() ->
+                        stringResource(R.string.sync_failed_format).format(state.lastSyncError)
+                    state.lastSyncEpochMs == 0L ->
+                        stringResource(R.string.last_sync_never)
+                    else ->
+                        stringResource(R.string.last_sync_format).format(formatInstant(state.lastSyncEpochMs))
+                },
+            )
+
+            if (permissionsGranted) {
+                HorizontalDivider()
+                Text(
+                    text = stringResource(R.string.today_metrics_heading),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                val metrics = todayMetrics
+                if (metrics == null) {
+                    Text(stringResource(R.string.metric_loading))
+                } else {
+                    Text(stringResource(R.string.metric_steps_format).format(metrics.steps))
+                    Text(
+                        stringResource(R.string.metric_distance_format)
+                            .format(metrics.distanceMeters / 1000.0)
+                    )
+                    Text(stringResource(R.string.metric_active_format).format(metrics.activeMinutes))
+                    Text(stringResource(R.string.metric_kcal_format).format(metrics.kcal))
                 }
             }
         }
 
-        Button(
-            onClick = { vm.syncNow() },
-            enabled = state.isConfigured && permissionsGranted,
+        FloatingActionButton(
+            onClick = { vm.openActivityDialog() },
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(24.dp),
         ) {
-            Text(stringResource(R.string.sync_now))
-        }
-
-        Text(
-            text = when {
-                state.lastSyncError.isNotEmpty() ->
-                    stringResource(R.string.sync_failed_format).format(state.lastSyncError)
-                state.lastSyncEpochMs == 0L ->
-                    stringResource(R.string.last_sync_never)
-                else ->
-                    stringResource(R.string.last_sync_format).format(formatInstant(state.lastSyncEpochMs))
-            },
-        )
-
-        if (permissionsGranted) {
-            HorizontalDivider()
-            Text(
-                text = stringResource(R.string.today_metrics_heading),
-                style = MaterialTheme.typography.titleMedium,
+            Icon(
+                imageVector = Icons.Filled.Add,
+                contentDescription = stringResource(R.string.activity_fab_label),
             )
-            val metrics = todayMetrics
-            if (metrics == null) {
-                Text(stringResource(R.string.metric_loading))
-            } else {
-                Text(stringResource(R.string.metric_steps_format).format(metrics.steps))
-                Text(
-                    stringResource(R.string.metric_distance_format)
-                        .format(metrics.distanceMeters / 1000.0)
-                )
-                Text(stringResource(R.string.metric_active_format).format(metrics.activeMinutes))
-                Text(stringResource(R.string.metric_kcal_format).format(metrics.kcal))
-            }
         }
     }
+
+    if (activityDialogOpen) {
+        TrackActivityDialog(vm)
+    }
+}
+
+@Composable
+private fun TrackActivityDialog(vm: MainViewModel) {
+    val saving by vm.activitySaving.collectAsState()
+    val error by vm.activityError.collectAsState()
+
+    var selectedType by remember { mutableStateOf(ActivityType.Gym) }
+    var note by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = { vm.closeActivityDialog() },
+        title = { Text(stringResource(R.string.activity_dialog_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    ActivityType.entries.forEach { type ->
+                        FilterChip(
+                            selected = type == selectedType,
+                            onClick = { selectedType = type },
+                            label = { Text("#${type.keyword}") },
+                        )
+                    }
+                }
+                OutlinedTextField(
+                    value = note,
+                    onValueChange = { note = it },
+                    placeholder = { Text(stringResource(R.string.activity_note_hint)) },
+                    singleLine = false,
+                    minLines = 3,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                error?.let {
+                    Text(
+                        text = it,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { vm.trackActivity(selectedType, note) },
+                enabled = !saving,
+            ) {
+                Text(stringResource(R.string.activity_send))
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = { vm.closeActivityDialog() },
+                enabled = !saving,
+            ) {
+                Text(stringResource(R.string.activity_cancel))
+            }
+        },
+    )
 }
 
 private val displayFormatter: DateTimeFormatter =

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/MainViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/MainViewModel.kt
@@ -8,8 +8,11 @@ import org.polybrain.tasks.health.data.DailyMetrics
 import org.polybrain.tasks.health.data.HealthRepository
 import org.polybrain.tasks.health.data.Settings
 import org.polybrain.tasks.health.data.SettingsSnapshot
+import org.polybrain.tasks.health.data.TasksClient
+import org.polybrain.tasks.health.data.TrackHabitTextRequest
 import org.polybrain.tasks.health.sync.SyncScheduler
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.time.ZoneId
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -17,6 +20,16 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+
+/**
+ * The activities the FAB on the Health screen can register, each mapped to the
+ * hashtag the backend parses into a [HabitTracked]. [Gym] is the default
+ * subtype. The keyword is sent verbatim (Unicode is fine) prefixed with '#'.
+ */
+enum class ActivityType(val keyword: String) {
+    Gym("siłka"),
+    Workout("workout"),
+}
 
 class MainViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -34,6 +47,18 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     private val _todayMetrics = MutableStateFlow<DailyMetrics?>(null)
     val todayMetrics: StateFlow<DailyMetrics?> = _todayMetrics.asStateFlow()
+
+    /** Open/closed state for the "register activity" dialog opened from the FAB. */
+    private val _activityDialogOpen = MutableStateFlow(false)
+    val activityDialogOpen: StateFlow<Boolean> = _activityDialogOpen.asStateFlow()
+
+    /** True while an activity is being posted; gates the dialog buttons. */
+    private val _activitySaving = MutableStateFlow(false)
+    val activitySaving: StateFlow<Boolean> = _activitySaving.asStateFlow()
+
+    /** Last activity-post error, shown inline in the dialog (null = none). */
+    private val _activityError = MutableStateFlow<String?>(null)
+    val activityError: StateFlow<String?> = _activityError.asStateFlow()
 
     val healthConnectStatus: Int = health.availability()
     val requiredPermissions: Set<String> = health.permissions
@@ -73,5 +98,48 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     fun syncNow() {
         SyncScheduler.runOnce(getApplication())
         refreshMetricsAsync()
+    }
+
+    fun openActivityDialog() {
+        _activityError.value = null
+        _activityDialogOpen.value = true
+    }
+
+    fun closeActivityDialog() {
+        if (_activitySaving.value) return
+        _activityDialogOpen.value = false
+    }
+
+    /**
+     * Posts a single `#keyword note` line through the non-idempotent text
+     * endpoint, which creates one [HabitTracked] per parsed hashtag. Unlike a
+     * trip note this records no JournalAdded — it is purely the habit entry.
+     * Multiple posts on the same day are intentional (e.g. two gym visits).
+     */
+    fun trackActivity(type: ActivityType, note: String) {
+        if (_activitySaving.value) return
+        val trimmed = note.trim()
+        val text = if (trimmed.isEmpty()) "#${type.keyword}" else "#${type.keyword} $trimmed"
+        // Wall-clock moment of the tap, so the entry lands on today.
+        val published = OffsetDateTime.now().toString()
+        _activitySaving.value = true
+        _activityError.value = null
+        viewModelScope.launch {
+            val snapshot = settings.snapshot()
+            if (!snapshot.isConfigured) {
+                _activityError.value = "Configure server URL and API token first."
+                _activitySaving.value = false
+                return@launch
+            }
+            try {
+                val api = TasksClient.build(snapshot.serverUrl, snapshot.apiToken)
+                api.trackHabitText(TrackHabitTextRequest(text = text, published = published))
+                _activityDialogOpen.value = false
+            } catch (t: Throwable) {
+                _activityError.value = t.message ?: t.javaClass.simpleName
+            } finally {
+                _activitySaving.value = false
+            }
+        }
     }
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -74,6 +74,12 @@
     <string name="hc_unavailable">Health Connect is not available on this device.</string>
     <string name="hc_needs_update">Health Connect needs to be updated from the Play Store.</string>
 
+    <string name="activity_fab_label">Register activity</string>
+    <string name="activity_dialog_title">Register activity</string>
+    <string name="activity_note_hint">Add a note (optional)</string>
+    <string name="activity_send">Track</string>
+    <string name="activity_cancel">Cancel</string>
+
     <string name="today_metrics_heading">Today</string>
     <string name="metric_steps_format">Steps: %1$d</string>
     <string name="metric_distance_format">Distance: %1$.1f km</string>


### PR DESCRIPTION
## Summary

Adds the ability to register a **gym attendance (`#siłka`)** or a **workout (`#workout`)** from the Android app, as requested.

A floating action button on the **Health** screen opens a dialog to register an activity:

- **Subtype chips** — `#siłka` (selected by default) and `#workout`.
- **Note field** — optional multi-line note passed to the habit.
- **Track / Cancel** — buttons gate while the post is in flight; failures show inline in the dialog.

## How it works

The activity is posted as a `#keyword note` line through the existing non-idempotent text endpoint (`POST habit/track/` via `trackHabitText`). The server parses the hashtag and creates **one `HabitTracked` per tag, with no `JournalAdded`** — exactly the requested behavior. Because the text endpoint isn't idempotent on `(habit, date)`, multiple entries per day are allowed (e.g. two gym visits). This mirrors the bike-ride sync path already in `HealthSyncWorker`.

## Changes

- `MainViewModel.kt` — `ActivityType` enum (`Gym → siłka`, `Workout → workout`), dialog state (`activityDialogOpen` / `activitySaving` / `activityError`), and `trackActivity()` posting via `trackHabitText`.
- `HealthScreen.kt` — FAB + `AlertDialog` with subtype `FilterChip`s and a note `OutlinedTextField`.
- `strings.xml` — five new UI strings.

## Testing

⚠️ Not compiled locally — this environment has no Android SDK / Gradle wrapper (the wrapper jar isn't committed; build is via Android Studio). Code targets Material3 1.3.1 (Compose BOM `2024.12.01`), where `FilterChip` and the `AlertDialog` overload used are stable. Please build/run in Android Studio to confirm on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)