### PR TITLE
feat(android): add board item picker to Today screen

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/MainActivity.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/MainActivity.kt
@@ -33,7 +33,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import java.time.LocalDate
 import kotlinx.coroutines.launch
+import org.polybrain.tasks.health.ui.BoardPickerScreen
 import org.polybrain.tasks.health.ui.HealthScreen
 import org.polybrain.tasks.health.ui.MainViewModel
 import org.polybrain.tasks.health.ui.SettingsScreen
@@ -67,11 +69,18 @@ class MainActivity : ComponentActivity() {
 private fun MainScaffold(vm: MainViewModel = viewModel()) {
     var current by remember { mutableStateOf(Destination.Today) }
     var tripDetailId by remember { mutableStateOf<Long?>(null) }
+    // Non-null while the board picker is open; holds the Today day the picked
+    // items will be added to.
+    var boardPickerDate by remember { mutableStateOf<LocalDate?>(null) }
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val scope = rememberCoroutineScope()
 
     BackHandler(enabled = tripDetailId != null) {
         tripDetailId = null
+    }
+
+    BackHandler(enabled = boardPickerDate != null) {
+        boardPickerDate = null
     }
 
     ModalNavigationDrawer(
@@ -91,6 +100,7 @@ private fun MainScaffold(vm: MainViewModel = viewModel()) {
                         onClick = {
                             current = dest
                             tripDetailId = null
+                            boardPickerDate = null
                             scope.launch { drawerState.close() }
                         },
                         modifier = Modifier.padding(horizontal = 12.dp),
@@ -131,7 +141,18 @@ private fun MainScaffold(vm: MainViewModel = viewModel()) {
                 color = MaterialTheme.colorScheme.background,
             ) {
                 when (current) {
-                    Destination.Today -> TodayScreen()
+                    Destination.Today -> {
+                        val pickerDate = boardPickerDate
+                        if (pickerDate != null) {
+                            BoardPickerScreen(
+                                selectedDate = pickerDate,
+                                onDone = { boardPickerDate = null },
+                                onCancel = { boardPickerDate = null },
+                            )
+                        } else {
+                            TodayScreen(onAddFromBoard = { boardPickerDate = it })
+                        }
+                    }
                     Destination.Trips -> {
                         val detailId = tripDetailId
                         if (detailId != null) {

--- a/android/app/src/main/java/org/polybrain/tasks/health/data/TasksApi.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/TasksApi.kt
@@ -70,6 +70,22 @@ data class TodayTasksResponse(
 )
 
 @Serializable
+data class BoardItem(
+    @SerialName("text") val text: String,
+    // MoSCoW bucket id: "must" | "should" | "could" | "wont", or null when
+    // the item is unclassified.
+    @SerialName("moscow") val moscow: String? = null,
+    // Nesting level in the board tree (0 = root), used to indent the row.
+    @SerialName("depth") val depth: Int = 0,
+    @SerialName("done") val done: Boolean = false,
+)
+
+@Serializable
+data class BoardItemsResponse(
+    @SerialName("items") val items: List<BoardItem> = emptyList(),
+)
+
+@Serializable
 data class PlanItem(
     @SerialName("id") val id: Long,
     @SerialName("pub_date") val pubDate: String,
@@ -210,6 +226,11 @@ interface TasksApi {
 
     @GET("api/v1/android/task/today/")
     suspend fun listTodayTasks(@Query("date") date: String): TodayTasksResponse
+
+    // Flattened current board (pre-order, depth-annotated) for the
+    // "add from board" picker. Date-independent.
+    @GET("api/v1/android/board/items/")
+    suspend fun listBoardItems(): BoardItemsResponse
 
     @POST("api/v1/android/task/add/")
     suspend fun addTodayTask(@Body body: TaskTextRequest): OkResponse

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/BoardPickerScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/BoardPickerScreen.kt
@@ -1,0 +1,226 @@
+package org.polybrain.tasks.health.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import java.time.LocalDate
+import org.polybrain.tasks.health.R
+import org.polybrain.tasks.health.data.BoardItem
+
+// MoSCoW buckets in priority order. Ids and colors mirror the web frontend
+// (tasks/assets/components/Moscow.vue); the "Unclassified" pseudo-bucket maps
+// to BoardPickerViewModel.FILTER_NONE and catches items with no moscow marker.
+private data class MoscowBucket(val id: String, val labelRes: Int, val color: Color)
+
+private val MOSCOW_BUCKETS = listOf(
+    MoscowBucket("must", R.string.board_picker_filter_must, Color(0xFFB91C1C)),
+    MoscowBucket("should", R.string.board_picker_filter_should, Color(0xFFD97706)),
+    MoscowBucket("could", R.string.board_picker_filter_could, Color(0xFF0D9488)),
+    MoscowBucket("wont", R.string.board_picker_filter_wont, Color(0xFF64748B)),
+    MoscowBucket(
+        BoardPickerViewModel.FILTER_NONE,
+        R.string.board_picker_filter_none,
+        Color(0xFFBDBDBD),
+    ),
+)
+
+private val BUCKET_BY_ID = MOSCOW_BUCKETS.associateBy { it.id }
+
+// Depth indentation step (dp per level); capped so deeply-nested items keep
+// readable width.
+private const val MAX_INDENT_DEPTH = 6
+private const val INDENT_STEP_DP = 16
+
+@Composable
+fun BoardPickerScreen(
+    selectedDate: LocalDate,
+    onDone: () -> Unit,
+    onCancel: () -> Unit,
+    vm: BoardPickerViewModel = viewModel(),
+) {
+    val items by vm.items.collectAsState()
+    val loading by vm.loading.collectAsState()
+    val error by vm.error.collectAsState()
+    val configured by vm.configured.collectAsState()
+    val selected by vm.selected.collectAsState()
+    val filter by vm.moscowFilter.collectAsState()
+
+    LaunchedEffect(Unit) { vm.refresh() }
+
+    val visibleItems = BoardPickerViewModel.applyFilter(items, filter)
+
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        error?.let { ErrorBanner(message = it, onDismiss = vm::clearError) }
+
+        FilterChipRow(
+            active = filter,
+            onToggle = vm::toggleFilter,
+        )
+
+        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+        Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+            when {
+                !configured -> CenteredMessage(stringResource(R.string.today_not_configured))
+                loading && items.isEmpty() ->
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                items.isEmpty() -> CenteredMessage(stringResource(R.string.board_picker_empty))
+                // No item key: a board can hold duplicate texts across nodes,
+                // which would collide as LazyColumn keys. Positional keys are
+                // fine — rows are stateless (checked state lives in the VM).
+                else -> LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    items(items = visibleItems) { item ->
+                        BoardItemRow(
+                            item = item,
+                            checked = item.text in selected,
+                            onToggle = { vm.toggleSelection(item.text) },
+                        )
+                    }
+                }
+            }
+        }
+
+        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Button(
+                onClick = { vm.addSelected(selectedDate.toString(), onDone) },
+                enabled = selected.isNotEmpty(),
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(stringResource(R.string.board_picker_add_button, selected.size))
+            }
+            TextButton(onClick = onCancel) {
+                Text(stringResource(R.string.board_picker_cancel))
+            }
+        }
+    }
+}
+
+@Composable
+private fun FilterChipRow(active: Set<String>, onToggle: (String) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        MOSCOW_BUCKETS.forEach { bucket ->
+            FilterChip(
+                selected = bucket.id in active,
+                onClick = { onToggle(bucket.id) },
+                label = { Text(stringResource(bucket.labelRes)) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun BoardItemRow(
+    item: BoardItem,
+    checked: Boolean,
+    onToggle: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Checkbox(checked = checked, onCheckedChange = { onToggle() })
+        Text(
+            text = item.text,
+            modifier = Modifier
+                .weight(1f)
+                .heightIn(min = 36.dp)
+                .padding(
+                    // Indent by tree depth (capped) to reflect nesting.
+                    start = (minOf(item.depth, MAX_INDENT_DEPTH) * INDENT_STEP_DP).dp,
+                    top = 4.dp,
+                    bottom = 4.dp,
+                ),
+            style = MaterialTheme.typography.bodyLarge.copy(
+                textDecoration = if (item.done) TextDecoration.LineThrough else null,
+            ),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        MoscowBadge(item.moscow)
+    }
+}
+
+@Composable
+private fun MoscowBadge(moscow: String?) {
+    // null moscow is shown as the "Unclassified" pseudo-bucket dot.
+    val bucket = BUCKET_BY_ID[moscow ?: BoardPickerViewModel.FILTER_NONE] ?: return
+    Box(
+        modifier = Modifier
+            .padding(start = 8.dp, end = 4.dp)
+            .size(12.dp)
+            .clip(CircleShape)
+            .background(bucket.color),
+    )
+}
+
+@Composable
+private fun CenteredMessage(text: String) {
+    Box(
+        modifier = Modifier.fillMaxSize().padding(24.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(text)
+    }
+}
+
+@Composable
+private fun ErrorBanner(message: String, onDismiss: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.errorContainer)
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stringResource(R.string.today_error_format).format(message),
+            color = MaterialTheme.colorScheme.onErrorContainer,
+            modifier = Modifier.weight(1f),
+        )
+        TextButton(onClick = onDismiss) {
+            Text(stringResource(R.string.today_dismiss_error))
+        }
+    }
+}

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/BoardPickerScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/BoardPickerScreen.kt
@@ -77,7 +77,13 @@ fun BoardPickerScreen(
     val selected by vm.selected.collectAsState()
     val filter by vm.moscowFilter.collectAsState()
 
-    LaunchedEffect(Unit) { vm.refresh() }
+    // Clear any selection carried over from a prior session (the VM is
+    // Activity-scoped and reused) so a fresh open always starts unchecked —
+    // this also covers dismissal via the system back button.
+    LaunchedEffect(Unit) {
+        vm.clearSelection()
+        vm.refresh()
+    }
 
     val visibleItems = BoardPickerViewModel.applyFilter(items, filter)
 
@@ -126,7 +132,12 @@ fun BoardPickerScreen(
             ) {
                 Text(stringResource(R.string.board_picker_add_button, selected.size))
             }
-            TextButton(onClick = onCancel) {
+            TextButton(
+                onClick = {
+                    vm.clearSelection()
+                    onCancel()
+                },
+            ) {
                 Text(stringResource(R.string.board_picker_cancel))
             }
         }

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/BoardPickerViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/BoardPickerViewModel.kt
@@ -75,6 +75,12 @@ class BoardPickerViewModel(application: Application) : AndroidViewModel(applicat
         }
     }
 
+    /** Drop the whole multi-selection — used on cancel and on each fresh open
+     * so a new picker session never inherits the previous one's checks. */
+    fun clearSelection() {
+        _selected.value = emptySet()
+    }
+
     fun toggleFilter(id: String) {
         _moscowFilter.value = _moscowFilter.value.toMutableSet().apply {
             if (!add(id)) remove(id)
@@ -115,6 +121,7 @@ class BoardPickerViewModel(application: Application) : AndroidViewModel(applicat
                 }
             }
             if (failures.isEmpty()) {
+                _selected.value = emptySet()
                 onDone()
             } else {
                 _error.value = "Failed to add ${failures.size} of ${texts.size} item(s)."

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/BoardPickerViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/BoardPickerViewModel.kt
@@ -1,0 +1,142 @@
+package org.polybrain.tasks.health.ui
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.polybrain.tasks.health.data.BoardItem
+import org.polybrain.tasks.health.data.Settings
+import org.polybrain.tasks.health.data.SettingsSnapshot
+import org.polybrain.tasks.health.data.TaskTextRequest
+import org.polybrain.tasks.health.data.TasksApi
+import org.polybrain.tasks.health.data.TasksClient
+
+/**
+ * Backs the "add from board" picker: loads the flattened board, tracks the
+ * MoSCoW filter and the multi-selection, and copies the selected items onto
+ * a given day's Today list by reusing the existing /task/add/ endpoint.
+ *
+ * Mirrors [TodayViewModel]'s settings / buildApi / reload / error handling.
+ */
+class BoardPickerViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val settings = Settings(application)
+
+    private val _items = MutableStateFlow<List<BoardItem>>(emptyList())
+    val items: StateFlow<List<BoardItem>> = _items.asStateFlow()
+
+    private val _loading = MutableStateFlow(false)
+    val loading: StateFlow<Boolean> = _loading.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    private val _configured = MutableStateFlow(false)
+    val configured: StateFlow<Boolean> = _configured.asStateFlow()
+
+    /** Texts of the currently-selected items. Keyed by text to match the rest
+     * of the system (TodayTask, board lookups by text). */
+    private val _selected = MutableStateFlow<Set<String>>(emptySet())
+    val selected: StateFlow<Set<String>> = _selected.asStateFlow()
+
+    /** Active MoSCoW filter chips (bucket ids, or [FILTER_NONE]). Empty set
+     * means "no filter" — show everything. */
+    private val _moscowFilter = MutableStateFlow<Set<String>>(emptySet())
+    val moscowFilter: StateFlow<Set<String>> = _moscowFilter.asStateFlow()
+
+    fun refresh() {
+        viewModelScope.launch { reload() }
+    }
+
+    private suspend fun reload() {
+        val snapshot = settings.snapshot()
+        _configured.value = snapshot.isConfigured
+        if (!snapshot.isConfigured) {
+            _items.value = emptyList()
+            return
+        }
+        _loading.value = true
+        try {
+            _items.value = buildApi(snapshot).listBoardItems().items
+            _error.value = null
+        } catch (t: Throwable) {
+            _error.value = t.message ?: t.javaClass.simpleName
+        } finally {
+            _loading.value = false
+        }
+    }
+
+    fun toggleSelection(text: String) {
+        _selected.value = _selected.value.toMutableSet().apply {
+            if (!add(text)) remove(text)
+        }
+    }
+
+    fun toggleFilter(id: String) {
+        _moscowFilter.value = _moscowFilter.value.toMutableSet().apply {
+            if (!add(id)) remove(id)
+        }
+    }
+
+    fun clearError() {
+        _error.value = null
+    }
+
+    /**
+     * Add every selected item to [date]'s Today list, then invoke [onDone].
+     *
+     * Items are sent sequentially in board order via the existing /task/add/
+     * endpoint (idempotent on the server via add_unique_line, so a retry that
+     * re-adds an already-present line is harmless). On full success we call
+     * [onDone] so the caller can pop back to Today; on partial failure we
+     * surface an error and keep the failed items selected for retry.
+     */
+    fun addSelected(date: String, onDone: () -> Unit) {
+        val texts = _selected.value
+        if (texts.isEmpty()) return
+        viewModelScope.launch {
+            val snapshot = settings.snapshot()
+            _configured.value = snapshot.isConfigured
+            if (!snapshot.isConfigured) {
+                _error.value = "Configure server URL and API token first."
+                return@launch
+            }
+            val api = buildApi(snapshot)
+            val failures = mutableListOf<String>()
+            // Preserve board order so the lines land deterministically.
+            for (item in _items.value.filter { it.text in texts }) {
+                try {
+                    api.addTodayTask(TaskTextRequest(item.text, date))
+                } catch (t: Throwable) {
+                    failures.add(item.text)
+                }
+            }
+            if (failures.isEmpty()) {
+                onDone()
+            } else {
+                _error.value = "Failed to add ${failures.size} of ${texts.size} item(s)."
+                _selected.value = failures.toSet()
+            }
+        }
+    }
+
+    private fun buildApi(snapshot: SettingsSnapshot): TasksApi =
+        TasksClient.build(snapshot.serverUrl, snapshot.apiToken)
+
+    companion object {
+        /** Sentinel filter id for items with no MoSCoW classification. */
+        const val FILTER_NONE = "none"
+
+        /**
+         * Keep only items matching [filter]. Empty filter = pass everything.
+         * An item's bucket is its `moscow` id, or [FILTER_NONE] when null.
+         */
+        fun applyFilter(items: List<BoardItem>, filter: Set<String>): List<BoardItem> {
+            if (filter.isEmpty()) return items
+            return items.filter { (it.moscow ?: FILTER_NONE) in filter }
+        }
+    }
+}

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -16,13 +17,17 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -50,7 +55,10 @@ import org.polybrain.tasks.health.data.TodayTask
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TodayScreen(vm: TodayViewModel = viewModel()) {
+fun TodayScreen(
+    vm: TodayViewModel = viewModel(),
+    onAddFromBoard: (LocalDate) -> Unit = {},
+) {
     val tasks by vm.tasks.collectAsState()
     val weekPlan by vm.weekPlan.collectAsState()
     val loading by vm.loading.collectAsState()
@@ -61,63 +69,85 @@ fun TodayScreen(vm: TodayViewModel = viewModel()) {
 
     LaunchedEffect(Unit) { vm.refresh() }
 
-    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-        DateNavBar(
-            selectedDate = selectedDate,
-            onPrevious = vm::previousDay,
-            onNext = vm::nextDay,
-            onToday = vm::goToToday,
-        )
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+            DateNavBar(
+                selectedDate = selectedDate,
+                onPrevious = vm::previousDay,
+                onNext = vm::nextDay,
+                onToday = vm::goToToday,
+            )
 
-        AddTaskRow(onAdd = vm::add, enabled = configured)
+            AddTaskRow(onAdd = vm::add, enabled = configured)
 
-        error?.let { ErrorBanner(message = it, onDismiss = vm::clearError) }
+            error?.let { ErrorBanner(message = it, onDismiss = vm::clearError) }
 
-        PullToRefreshBox(
-            isRefreshing = loading,
-            onRefresh = vm::refresh,
-            modifier = Modifier.fillMaxSize(),
-        ) {
-            // This week's plan items that aren't already on today's list.
-            // Adding one copies it onto today, after which it drops out here.
-            val todayTexts = tasks.map { it.text }.toSet()
-            val pendingWeekPlan = weekPlan.filterNot { it in todayTexts }
-            when {
-                !configured -> EmptyState(stringResource(R.string.today_not_configured))
-                tasks.isEmpty() && pendingWeekPlan.isEmpty() ->
-                    EmptyState(stringResource(R.string.today_empty))
-                else -> LazyColumn(modifier = Modifier.fillMaxSize()) {
-                    if (pendingWeekPlan.isNotEmpty()) {
-                        item(key = "week-plan-header") {
-                            Text(
-                                text = stringResource(R.string.today_week_plan_heading),
-                                style = MaterialTheme.typography.titleSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.padding(bottom = 4.dp),
+            PullToRefreshBox(
+                isRefreshing = loading,
+                onRefresh = vm::refresh,
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                // This week's plan items that aren't already on today's list.
+                // Adding one copies it onto today, after which it drops out here.
+                val todayTexts = tasks.map { it.text }.toSet()
+                val pendingWeekPlan = weekPlan.filterNot { it in todayTexts }
+                when {
+                    !configured -> EmptyState(stringResource(R.string.today_not_configured))
+                    tasks.isEmpty() && pendingWeekPlan.isEmpty() ->
+                        EmptyState(stringResource(R.string.today_empty))
+                    // Bottom padding clears the FAB so the last row stays tappable.
+                    else -> LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(bottom = 88.dp),
+                    ) {
+                        if (pendingWeekPlan.isNotEmpty()) {
+                            item(key = "week-plan-header") {
+                                Text(
+                                    text = stringResource(R.string.today_week_plan_heading),
+                                    style = MaterialTheme.typography.titleSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(bottom = 4.dp),
+                                )
+                            }
+                            items(items = pendingWeekPlan, key = { "week:$it" }) { line ->
+                                WeekPlanRow(
+                                    text = line,
+                                    onAddToToday = { vm.addPlanItemToToday(line) },
+                                )
+                            }
+                        }
+                        // Divider only when both sections are present, so it
+                        // genuinely separates weekly from daily.
+                        if (pendingWeekPlan.isNotEmpty() && tasks.isNotEmpty()) {
+                            item(key = "week-plan-divider") {
+                                HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                            }
+                        }
+                        items(items = tasks, key = TodayTask::text) { task ->
+                            TaskRow(
+                                task = task,
+                                onToggle = { done -> vm.requestSetDone(task.text, done) },
+                                onDelete = { vm.delete(task.text) },
                             )
                         }
-                        items(items = pendingWeekPlan, key = { "week:$it" }) { line ->
-                            WeekPlanRow(
-                                text = line,
-                                onAddToToday = { vm.addPlanItemToToday(line) },
-                            )
-                        }
-                    }
-                    // Divider only when both sections are present, so it
-                    // genuinely separates weekly from daily.
-                    if (pendingWeekPlan.isNotEmpty() && tasks.isNotEmpty()) {
-                        item(key = "week-plan-divider") {
-                            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
-                        }
-                    }
-                    items(items = tasks, key = TodayTask::text) { task ->
-                        TaskRow(
-                            task = task,
-                            onToggle = { done -> vm.requestSetDone(task.text, done) },
-                            onDelete = { vm.delete(task.text) },
-                        )
                     }
                 }
+            }
+        }
+
+        // FAB opens the board picker for the currently-viewed day. Hidden
+        // until configured, matching the disabled add-task row above.
+        if (configured) {
+            FloatingActionButton(
+                onClick = { onAddFromBoard(selectedDate) },
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(24.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Add,
+                    contentDescription = stringResource(R.string.today_board_fab_label),
+                )
             }
         }
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -62,6 +62,16 @@
     <string name="today_date_today">Today</string>
     <string name="today_top_bar_title">Tasks Collector</string>
 
+    <string name="today_board_fab_label">Add from board</string>
+    <string name="board_picker_add_button">Add %1$d</string>
+    <string name="board_picker_cancel">Cancel</string>
+    <string name="board_picker_empty">This board has no items.</string>
+    <string name="board_picker_filter_must">Must</string>
+    <string name="board_picker_filter_should">Should</string>
+    <string name="board_picker_filter_could">Could</string>
+    <string name="board_picker_filter_wont">Won\'t</string>
+    <string name="board_picker_filter_none">Unclassified</string>
+
     <string name="server_url_label">Server URL</string>
     <string name="server_url_placeholder">https://tasks.example.com</string>
     <string name="api_token_label">API token</string>

--- a/tasks/apps/tree/services/today/__init__.py
+++ b/tasks/apps/tree/services/today/__init__.py
@@ -1,17 +1,21 @@
 from .operations import (
+    BoardItem,
     NoBoardError,
     TodayTask,
     add_task,
     delete_task,
+    list_board_items,
     list_today_tasks,
     set_task_done,
 )
 
 __all__ = [
+    "BoardItem",
     "NoBoardError",
     "TodayTask",
     "add_task",
     "delete_task",
+    "list_board_items",
     "list_today_tasks",
     "set_task_done",
 ]

--- a/tasks/apps/tree/services/today/operations.py
+++ b/tasks/apps/tree/services/today/operations.py
@@ -26,6 +26,14 @@ class TodayTask:
     done: bool
 
 
+@dataclass(frozen=True)
+class BoardItem:
+    text: str
+    moscow: str | None
+    depth: int
+    done: bool
+
+
 def _today(today, published=None):
     if today is not None:
         return today
@@ -107,6 +115,32 @@ def list_today_tasks(user, today=None):
     items = [TodayTask(text=line, done=line in good) for line in plan_lines]
     items.sort(key=lambda it: it.done)  # False (not done) sorts before True
     return items
+
+
+def _flatten_board(nodes, depth, out):
+    """Pre-order DFS over the Board.state tree, appending one BoardItem per
+    node so parents precede their children and ``depth`` reflects nesting.
+    """
+    for node in nodes or []:
+        markers = (node.get("data") or {}).get("meaningfulMarkers") or {}
+        out.append(
+            BoardItem(
+                text=board_tree._node_text(node),
+                moscow=markers.get("moscow"),
+                depth=depth,
+                done=board_tree.get_state(node) == "done",
+            )
+        )
+        _flatten_board(node.get("children") or [], depth + 1, out)
+    return out
+
+
+def list_board_items(user):
+    """Flatten the user's current board into depth-annotated rows for the
+    Android 'add from board' picker. Read-only — no transaction needed.
+    """
+    board = _current_board(user)
+    return _flatten_board(board.state, 0, [])
 
 
 @transaction.atomic

--- a/tasks/apps/tree/tests/test_android_task_api.py
+++ b/tasks/apps/tree/tests/test_android_task_api.py
@@ -10,6 +10,7 @@ from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APITestCase
 
+from ..board_operations import create_task_item
 from ..models import Board, JournalAdded, Plan, Profile, Reflection, Thread
 
 TODAY = date_cls(2026, 5, 21)
@@ -67,6 +68,20 @@ class AndroidTaskAPITestCase(APITestCase):
         if date is None:
             return self.client.get(url)
         return self.client.get(url, {"date": date})
+
+    def _board_items(self):
+        return self.client.get(reverse("android-board-items"))
+
+    @staticmethod
+    def _node(text, moscow=None, state="open", children=None):
+        """Build a Board.state node mirroring create_task_item's shape, with
+        an optional MoSCoW marker, work state, and children.
+        """
+        node = create_task_item(text)
+        node["data"]["state"] = state
+        node["data"]["meaningfulMarkers"]["moscow"] = moscow
+        node["children"] = children or []
+        return node
 
     def test_add_creates_board_node_and_plan_line(self):
         self._auth()
@@ -187,6 +202,76 @@ class AndroidTaskAPITestCase(APITestCase):
         self._auth()
         response = self._add("x")
         self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+    def test_board_items_flatten_order_and_depth(self):
+        # root -> child -> grandchild, plus a second root sibling.
+        self.board.state = [
+            self._node(
+                "root",
+                children=[
+                    self._node("child", children=[self._node("grandchild")]),
+                ],
+            ),
+            self._node("root2"),
+        ]
+        self.board.save()
+        self._auth()
+
+        response = self._board_items()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        items = response.json()["items"]
+        self.assertEqual(
+            [(it["text"], it["depth"]) for it in items],
+            [("root", 0), ("child", 1), ("grandchild", 2), ("root2", 0)],
+        )
+
+    def test_board_items_moscow_passthrough(self):
+        self.board.state = [
+            self._node("must task", moscow="must"),
+            self._node("wont task", moscow="wont"),
+            self._node("unclassified task", moscow=None),
+        ]
+        self.board.save()
+        self._auth()
+
+        items = self._board_items().json()["items"]
+        by_text = {it["text"]: it["moscow"] for it in items}
+        self.assertEqual(by_text["must task"], "must")
+        # Explicitly guard the "wont" bucket id against a "would" typo.
+        self.assertEqual(by_text["wont task"], "wont")
+        self.assertIsNone(by_text["unclassified task"])
+
+    def test_board_items_done_flag(self):
+        self.board.state = [
+            self._node("finished", state="done"),
+            self._node("open one", state="open"),
+        ]
+        self.board.save()
+        self._auth()
+
+        items = self._board_items().json()["items"]
+        by_text = {it["text"]: it["done"] for it in items}
+        self.assertTrue(by_text["finished"])
+        self.assertFalse(by_text["open one"])
+
+    def test_board_items_empty_board(self):
+        self.board.state = []
+        self.board.save()
+        self._auth()
+
+        response = self._board_items()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"items": []})
+
+    def test_board_items_no_board_returns_409(self):
+        Board.objects.all().delete()
+        self._auth()
+        response = self._board_items()
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+    def test_board_items_missing_token_returns_401(self):
+        response = self._board_items()
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_progress_task_advances_via_repeated_complete(self):
         """Three POSTs to /complete on a (3) task should advance it to (3/3)

--- a/tasks/apps/tree/urls.py
+++ b/tasks/apps/tree/urls.py
@@ -91,6 +91,11 @@ urlpatterns = [
         name="android-task-delete",
     ),
     path(
+        "api/v1/android/board/items/",
+        views_android_api.AndroidBoardListView.as_view(),
+        name="android-board-items",
+    ),
+    path(
         "api/v1/android/trip/start/",
         views_android_trip.AndroidTripStartView.as_view(),
         name="android-trip-start",

--- a/tasks/apps/tree/views_android_api.py
+++ b/tasks/apps/tree/views_android_api.py
@@ -15,6 +15,7 @@ from .services.today import (
     NoBoardError,
     add_task,
     delete_task,
+    list_board_items,
     list_today_tasks,
     set_task_done,
 )
@@ -95,6 +96,38 @@ class AndroidTaskListView(APIView):
             return _no_board_response()
         return Response(
             {"items": [{"text": it.text, "done": it.done} for it in items]},
+            status=status.HTTP_200_OK,
+        )
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class AndroidBoardListView(APIView):
+    """Return the user's current board flattened to a depth-annotated list:
+    every node in pre-order, with its MoSCoW marker and done flag. Source for
+    the Android 'add from board' picker. The board is date-independent, so no
+    ``date`` parameter is required.
+    """
+
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        try:
+            items = list_board_items(request.user)
+        except NoBoardError:
+            return _no_board_response()
+        return Response(
+            {
+                "items": [
+                    {
+                        "text": it.text,
+                        "moscow": it.moscow,
+                        "depth": it.depth,
+                        "done": it.done,
+                    }
+                    for it in items
+                ]
+            },
             status=status.HTTP_200_OK,
         )
 


### PR DESCRIPTION
## Summary

Adds a Floating Action Button on the Android **Today** screen that opens a full-screen picker for pulling items off the current **Board** into today's task list.

The picker:
- Lists **all** board items as a flat list, **indented to reflect the tree structure** (depth-capped so deep nesting stays readable).
- Tags each item with its **MoSCoW status** (colored dot: must/should/could/won't, plus an "Unclassified" pseudo-bucket).
- Supports **multi-select** via checkboxes; done items render struck-through but stay selectable.
- Has **MoSCoW filter chips** at the top (no chip = show all; selecting chips narrows to those buckets).
- Has a bottom bar: **"Add N"** (adds to the currently-viewed day) and **"Cancel"**.

## Backend

- New `GET api/v1/android/board/items/` returns the user's current board flattened to a depth-annotated list `{text, moscow, depth, done}`.
- Implemented via `list_board_items(user)` in `services/today/operations.py`, reusing the existing `_current_board()` lookup and `board_tree` helpers. Read-only.
- Adding reuses the existing `api/v1/android/task/add/` endpoint (idempotent), so no new add endpoint.

## Android

- New `BoardPickerScreen` + `BoardPickerViewModel` (mirrors `TodayViewModel`'s settings/reload/error scaffolding).
- FAB wired into `TodayScreen`; the picker is hosted in `MainActivity` via a `boardPickerDate` state + `BackHandler`, mirroring the existing trip-detail sub-screen pattern.

## Testing

- Backend: **27/27** tests pass in `tasks.apps.tree.tests.test_android_task_api`, including 6 new board-items cases (flatten/depth ordering, MoSCoW passthrough incl. null + `wont`, done flag, empty board, 409 no-board, 401 no-token).
- Android: written but **not built** in this change (per request) — to be built/verified separately.

## Notes

- Selection is keyed by text (consistent with the rest of the system); duplicate-text nodes select together and add as a single deduped line. The `LazyColumn` uses positional keys to avoid duplicate-key crashes.
- Items are added to the **currently-viewed** Today date (the screen has prev/next/today nav).

🤖 Generated with [Claude Code](https://claude.com/claude-code)