### PR TITLE
feat(observations): mark complex observations on list page

### DIFF
--- a/tasks/apps/tree/models.py
+++ b/tasks/apps/tree/models.py
@@ -219,6 +219,48 @@ class ObservationQuerySet(models.QuerySet):
 
         return self.annotate(last_event_published=Subquery(last_event_subquery))
 
+    def with_attached_count(self):
+        """
+        Annotate each observation with ``attached_count``: the number of
+        observations currently attached to it (i.e. how "complex" it is).
+
+        Mirrors ComplexPresenter's latest-event-wins replay in SQL: an
+        ObservationAttached row represents a currently-attached pair only when
+        no later attach and no later-or-equal detach exist for the same
+        (event_stream_id, other_event_stream_id) pair. Counting the distinct
+        surviving pairs in one correlated subquery avoids a per-row presenter.
+        """
+        from django.db.models import Count, Exists, OuterRef, Subquery
+        from django.db.models.functions import Coalesce
+
+        later_attach = ObservationAttached.objects.filter(
+            event_stream_id=OuterRef("event_stream_id"),
+            other_event_stream_id=OuterRef("other_event_stream_id"),
+            published__gt=OuterRef("published"),
+        )
+        later_or_equal_detach = ObservationDetached.objects.filter(
+            event_stream_id=OuterRef("event_stream_id"),
+            other_event_stream_id=OuterRef("other_event_stream_id"),
+            published__gte=OuterRef("published"),
+        )
+
+        currently_attached = (
+            ObservationAttached.objects.filter(
+                event_stream_id=OuterRef("event_stream_id")
+            )
+            .annotate(
+                superseded_by_attach=Exists(later_attach),
+                superseded_by_detach=Exists(later_or_equal_detach),
+            )
+            .filter(superseded_by_attach=False, superseded_by_detach=False)
+            .order_by()
+            .values("event_stream_id")
+            .annotate(count=Count("other_event_stream_id", distinct=True))
+            .values("count")
+        )
+
+        return self.annotate(attached_count=Coalesce(Subquery(currently_attached), 0))
+
 
 class ObservationManager(models.Manager):
     def get_queryset(self):
@@ -226,6 +268,9 @@ class ObservationManager(models.Manager):
 
     def with_last_event_published(self):
         return self.get_queryset().with_last_event_published()
+
+    def with_attached_count(self):
+        return self.get_queryset().with_attached_count()
 
 
 class Observation(models.Model):

--- a/tasks/apps/tree/views_observation.py
+++ b/tasks/apps/tree/views_observation.py
@@ -146,8 +146,10 @@ class ObservationEventViewSet(viewsets.ModelViewSet):
 
 class ObservationListView(LoginRequiredMixin, ListView):
     model = Observation
-    queryset = Observation.objects.select_related("thread", "type").prefetch_related(
-        "observationupdated_set"
+    queryset = (
+        Observation.objects.with_attached_count()
+        .select_related("thread", "type")
+        .prefetch_related("observationupdated_set")
     )
 
     paginate_by = 200
@@ -177,7 +179,8 @@ class ObservationMineListView(LoginRequiredMixin, ListView):
 
     def get_queryset(self):
         return (
-            Observation.objects.filter(user=self.request.user)
+            Observation.objects.with_attached_count()
+            .filter(user=self.request.user)
             .select_related("thread", "type")
             .prefetch_related("observationupdated_set")
             .order_by("-pub_date", "-pk")

--- a/tasks/assets/styles/example.scss
+++ b/tasks/assets/styles/example.scss
@@ -556,6 +556,26 @@ article.quest {
             }
         }
 
+        &.is-complex {
+            border-left: 3px solid #4a7dfb;
+        }
+
+    }
+
+    .complex-badge {
+        display: inline-block;
+
+        margin-left: 0.25rem;
+        padding: 0 0.45rem;
+
+        border-radius: 10px;
+
+        background: #4a7dfb;
+        color: #fff;
+
+        font-size: 0.8rem;
+        font-style: normal;
+        white-space: nowrap;
     }
 
     .strong {

--- a/tasks/templates/tree/observation_list.html
+++ b/tasks/templates/tree/observation_list.html
@@ -20,7 +20,7 @@
         {% observation_menu attach_mode=attach_mode %}
     </div>
         {% for observation in object_list %}
-        <article class="observation" id="observation-{{ observation.pk }}">
+        <article class="observation{% if observation.attached_count %} is-complex{% endif %}" id="observation-{{ observation.pk }}">
             {% if attach_mode and not attach_observation_id|stringformat:"s" == observation.pk|stringformat:"s" %}
                 <div class="attach-checkbox">
                     <input type="checkbox" 
@@ -32,7 +32,7 @@
                 </div>
             {% endif %}
 
-            <div class="meta">{{ observation.pub_date }} (<span class="type" style="color: {{ observation.type.color }};">{{ observation.type }}</span>; <span class="thread">{{ observation.thread }}</span> <a href="{% url 'public-observation-edit' observation.pk %}">#{{ observation.pk }}</a>)</div>
+            <div class="meta">{{ observation.pub_date }} (<span class="type" style="color: {{ observation.type.color }};">{{ observation.type }}</span>; <span class="thread">{{ observation.thread }}</span> <a href="{% url 'public-observation-edit' observation.pk %}">#{{ observation.pk }}</a>){% if observation.attached_count %} <span class="complex-badge" title="{{ observation.attached_count }} attached observation{{ observation.attached_count|pluralize }}">&#128206; {{ observation.attached_count }}</span>{% endif %}</div>
             <div class="strong">{{ observation.situation|linebreaks }}</div>
 
             <div class="expand">


### PR DESCRIPTION
## Summary

The `/observations/` list now flags **complex observations** — those that have other observations attached — so it's clear at a glance which ones are complex and which aren't.

- **Left-border accent** + a **📎 count badge** in the meta line of each complex observation card.
- Applies to both `/observations/` (`ObservationMineListView`) and `/observations/all/` (`ObservationListView`), which share the template.

## Implementation

Added `ObservationQuerySet.with_attached_count()` (with an `ObservationManager` passthrough), alongside the existing `with_last_event_published()`. It annotates each observation with `attached_count` in a **single correlated subquery**, mirroring `ComplexPresenter`'s latest-event-wins replay in SQL: an `ObservationAttached` row counts as a live attachment only when no later attach and no later-or-equal detach exist for the same `(event_stream_id, other_event_stream_id)` pair.

This keeps the list at a **constant query count** rather than running one presenter query per row.

## Verification (against local dev DB)

- **Correctness:** the annotation matched `ComplexPresenter.total_unique_observations_count()` for all **174 observations, 0 mismatches** (3 complex).
- **Performance:** the list loads in **3 queries total** (main + 2 prefetch_related), independent of row count — versus ~175 with a per-observation presenter.

## Note

The badge/border styling lives in `tasks/assets/styles/example.scss` and needs a frontend asset rebuild (`npm run build`) to take effect; the badge text/markup renders regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)