### PR TITLE
feat(observations): add client-side filter with Polish/English stemming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "bootstrap": "^4.6.2",
         "deep-equal": "^2.2.3",
+        "lunr": "^2.3.9",
+        "lunr-languages": "^1.20.0",
         "moment": "^2.30.1",
         "vue": "^2.7.8",
         "vue-context": "^5.2.0",
@@ -2461,6 +2463,18 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "license": "MIT"
+    },
+    "node_modules/lunr-languages": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lunr-languages/-/lunr-languages-1.20.0.tgz",
+      "integrity": "sha512-3LVgE7ekWXt04NBci/hjm+NXJxXZeRXuyClL0kA0HONyBOjxhP3ZQkuWIM4Ok3pbeptUW/rj3XcJcJuJVPwPYA==",
+      "license": "MPL-1.1"
     },
     "node_modules/merge-source-map": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   "dependencies": {
     "bootstrap": "^4.6.2",
     "deep-equal": "^2.2.3",
+    "lunr": "^2.3.9",
+    "lunr-languages": "^1.20.0",
     "moment": "^2.30.1",
     "vue": "^2.7.8",
     "vue-context": "^5.2.0",

--- a/tasks/assets/app.js
+++ b/tasks/assets/app.js
@@ -5,6 +5,7 @@
 // see scoped CSS.
 import "./scripts/shared.js";
 import "./app.scss";
+import "./observation_search.js";
 
 const nodeList = document.querySelectorAll(
     'article.observation'

--- a/tasks/assets/observation_search.js
+++ b/tasks/assets/observation_search.js
@@ -1,0 +1,116 @@
+// Client-side filter for the observation list (/observations/).
+//
+// All searchable text (situation, interpretation, approach and every update
+// comment) is already rendered into each article's `data-search` attribute by
+// the template, so this builds small in-memory stem indexes from the DOM and
+// hides the articles that don't match the query.
+//
+// Stemming handles both Polish and English: every token is reduced by both the
+// Polish (lunr-languages) and English (lunr core) stemmers. Polish is only
+// lightly stemmed by the rule-based stemmer (it folds declensions such as
+// "park"/"parku" but not whole verb families), so we additionally match on a
+// shared stem prefix — this conflates families like "bieganie"/"biegania"/
+// "biegał" that differ only past a common root. Words are AND-ed together.
+
+import lunr from "lunr";
+import stemmerSupport from "lunr-languages/lunr.stemmer.support";
+import polish from "lunr-languages/lunr.pl";
+
+stemmerSupport(lunr);
+polish(lunr);
+
+const plStemmer = lunr.pl.stemmer;
+const enStemmer = lunr.stemmer;
+
+// Minimum stem length before a prefix counts as a match, to avoid very short
+// stems matching almost everything.
+const MIN_PREFIX = 3;
+
+const stemWord = (word) => ({
+    pl: plStemmer(new lunr.Token(word)).toString(),
+    en: enStemmer(new lunr.Token(word)).toString(),
+});
+
+const tokenize = (text) =>
+    text
+        .toLowerCase()
+        .split(/[^0-9a-ząćęłńóśźż]+/i)
+        .filter(Boolean);
+
+// True when either stem is a prefix of the other (and long enough to be safe).
+const sharedPrefix = (a, b) => {
+    const min = Math.min(a.length, b.length);
+    return min >= MIN_PREFIX && (a.startsWith(b) || b.startsWith(a));
+};
+
+const initObservationSearch = () => {
+    const input = document.getElementById("observation-filter");
+
+    // Only the observation list page has the filter input; bail everywhere else.
+    if (!input) {
+        return;
+    }
+
+    const articles = [
+        ...document.querySelectorAll("article.observation[data-search]"),
+    ];
+
+    if (articles.length === 0) {
+        return;
+    }
+
+    const counter = document.getElementById("observation-filter-count");
+
+    // Pre-compute the stems for each article once.
+    const indexed = articles.map((el) => {
+        const stems = [];
+        tokenize(el.dataset.search).forEach((token) => {
+            const { pl, en } = stemWord(token);
+            stems.push(pl, en);
+        });
+        return { el, stems, set: new Set(stems) };
+    });
+
+    const matchesWord = (doc, word) => {
+        if (doc.set.has(word.pl) || doc.set.has(word.en)) {
+            return true;
+        }
+        return doc.stems.some(
+            (stem) => sharedPrefix(stem, word.pl) || sharedPrefix(stem, word.en)
+        );
+    };
+
+    const setCount = (visible) => {
+        if (!counter) {
+            return;
+        }
+        counter.textContent =
+            visible === null ? "" : `${visible} / ${articles.length}`;
+    };
+
+    const filter = () => {
+        const words = tokenize(input.value).map(stemWord);
+
+        if (words.length === 0) {
+            indexed.forEach((doc) => {
+                doc.el.style.display = "";
+            });
+            setCount(null);
+            return;
+        }
+
+        let visible = 0;
+        indexed.forEach((doc) => {
+            const hit = words.every((word) => matchesWord(doc, word));
+            doc.el.style.display = hit ? "" : "none";
+            if (hit) {
+                visible += 1;
+            }
+        });
+        setCount(visible);
+    };
+
+    input.addEventListener("input", filter);
+};
+
+initObservationSearch();

--- a/tasks/assets/styles/example.scss
+++ b/tasks/assets/styles/example.scss
@@ -489,6 +489,46 @@ article.quest {
 
     margin: auto;
 
+    .observation-filter-bar {
+        margin-bottom: 1.5rem;
+
+        .observation-filter-input {
+            display: block;
+            width: 100%;
+
+            padding: 0.65rem 0.95rem;
+
+            font-size: 1rem;
+            line-height: 1.5;
+            color: #343434;
+
+            background: #fff;
+            border: 1px solid #d3d8de;
+            border-radius: 4px;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+
+            transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+
+            &::placeholder {
+                color: #aab1ba;
+            }
+
+            &:focus {
+                outline: 0;
+                border-color: #4a7dfb;
+                box-shadow: 0 0 0 0.18rem rgba(74, 125, 251, 0.2);
+            }
+        }
+
+        .observation-filter-count {
+            display: block;
+            margin-top: 0.35rem;
+
+            font-size: 0.8rem;
+            color: #999;
+            text-align: right;
+        }
+    }
 
     .empty {
         margin-top: 2rem;

--- a/tasks/templates/tree/observation_list.html
+++ b/tasks/templates/tree/observation_list.html
@@ -13,6 +13,16 @@
 {% csrf_token %}
 <div class="observations">
     <div class="cont">
+        <div class="observation-filter-bar">
+            <input type="search"
+                   id="observation-filter"
+                   class="observation-filter-input"
+                   placeholder="Filter observations (Polish/English)…"
+                   autocomplete="off"
+                   aria-label="Filter observations">
+            <span id="observation-filter-count" class="observation-filter-count" aria-live="polite"></span>
+        </div>
+
         {% include "menu.html" %}
 
         {% observation_calendar %}
@@ -20,7 +30,9 @@
         {% observation_menu attach_mode=attach_mode %}
     </div>
         {% for observation in object_list %}
-        <article class="observation{% if observation.attached_count %} is-complex{% endif %}" id="observation-{{ observation.pk }}">
+        <article class="observation{% if observation.attached_count %} is-complex{% endif %}"
+                 id="observation-{{ observation.pk }}"
+                 data-search="{{ observation.situation|default:'' }} {{ observation.interpretation|default:'' }} {{ observation.approach|default:'' }}{% for update in observation.observationupdated_set.all %} {{ update.comment|default:'' }}{% endfor %}">
             {% if attach_mode and not attach_observation_id|stringformat:"s" == observation.pk|stringformat:"s" %}
                 <div class="attach-checkbox">
                     <input type="checkbox" 


### PR DESCRIPTION
## Summary
Adds an instant, client-side filter to the `/observations/` list. Type a word and the list narrows to observations whose **situation, interpretation, approach, or update comments** contain it — with **Polish + English stemming**.

The page is server-rendered and already contains all the text, so this needs **no API, no search index, and no migration**. Each `<article>` gets a `data-search` attribute; a small module builds in-memory stem indexes from the DOM and toggles visibility on input.

## Polish/English stemming
- Every token is reduced by **both** the [lunr-languages](https://www.npmjs.com/package/lunr-languages) Polish stemmer and the lunr English stemmer.
- `lunr.pl` is a *light* rule-based stemmer: it folds declensions (`park`/`parku`, `energia`/`energii`) but not whole verb families. To recover that recall, the matcher **also matches on a shared stem prefix**, conflating families like `bieganie` / `biegania` / `biegał`.
- Multiple words are AND-ed together.

True dictionary-based lemmatization (Morfologik/Stempel) was considered but rejected — it's a ~MB browser payload, overkill for a personal filter.

## Changes
- `tasks/templates/tree/observation_list.html` — `data-search` attribute per article; filter input + result counter added **above the menu**.
- `tasks/assets/observation_search.js` *(new)* — stem + shared-prefix matcher, self-guards so it's a no-op on other pages.
- `tasks/assets/app.js` — imports the module (loaded on every page).
- `tasks/assets/styles/example.scss` — scoped styling for the input/counter.
- `package.json` / `package-lock.json` — add `lunr` + `lunr-languages`.

## Verification
- ✅ `npm run build` clean; lunr chunk + filter JS in `app-js-tags.html`, styles in `app-css-tags.html`.
- ✅ Django template compiles (`get_template`).
- ✅ Matcher logic tested against real PL/EN inflections in-container (`biegania`→`bieganie`, `running`→`running`, `park`/`parku`, multi-word AND).
- ⚠️ Not yet click-tested live in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)