### PR TITLE
feat(trips): offline sending outbox for notes and photos

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/data/Outbox.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/Outbox.kt
@@ -1,0 +1,125 @@
+package org.polybrain.tasks.health.data
+
+import android.content.Context
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.util.UUID
+import kotlinx.serialization.json.Json
+
+/**
+ * Durable, file-backed queue of trip writes (see [OutboxItem]).
+ *
+ * Each item is one JSON file in [dir]; a photo's bytes live in a sibling file.
+ * Filenames are prefixed with a zero-padded `createdAt`, so a plain
+ * lexicographic sort of the directory yields chronological (oldest-first)
+ * delivery order. The directory is the single source of truth — no in-memory
+ * index — so it survives process death and is read fresh on every drain.
+ *
+ * Takes a [File] root (not a `Context`) so it is unit-testable on the JVM with
+ * a temp dir; [Context] callers use the convenience constructor.
+ */
+class Outbox(private val dir: File) {
+
+    constructor(context: Context) : this(File(context.filesDir, "outbox"))
+
+    init {
+        dir.mkdirs()
+    }
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    fun enqueueNote(storyId: Long, comment: String, published: String): OutboxItem {
+        val item = OutboxItem(
+            id = UUID.randomUUID().toString(),
+            kind = OutboxItem.Kind.NOTE,
+            storyId = storyId,
+            comment = comment,
+            published = published,
+            createdAt = System.currentTimeMillis(),
+        )
+        write(item)
+        return item
+    }
+
+    fun enqueuePhoto(
+        storyId: Long,
+        comment: String,
+        published: String,
+        contentType: String,
+        bytes: ByteArray,
+    ): OutboxItem {
+        val id = UUID.randomUUID().toString()
+        val createdAt = System.currentTimeMillis()
+        val photoName = baseName(createdAt, id) + "." + extFor(contentType)
+        File(dir, photoName).writeBytes(bytes)
+        val item = OutboxItem(
+            id = id,
+            kind = OutboxItem.Kind.PHOTO,
+            storyId = storyId,
+            comment = comment,
+            published = published,
+            createdAt = createdAt,
+            contentType = contentType,
+            photoFile = photoName,
+        )
+        write(item)
+        return item
+    }
+
+    /** All queued items, oldest first. */
+    fun all(): List<OutboxItem> =
+        (dir.listFiles { f -> f.isFile && f.name.endsWith(".json") } ?: emptyArray())
+            .sortedBy { it.name }
+            .mapNotNull { read(it) }
+
+    fun forStory(storyId: Long): List<OutboxItem> = all().filter { it.storyId == storyId }
+
+    /** Persist a mutated item back to its file (same name — id/createdAt are immutable). */
+    fun update(item: OutboxItem) = write(item)
+
+    /** Remove an item's JSON and its photo file (if any). */
+    fun remove(item: OutboxItem) {
+        File(dir, jsonName(item)).delete()
+        photoFile(item)?.delete()
+    }
+
+    fun photoFile(item: OutboxItem): File? = item.photoFile?.let { File(dir, it) }
+
+    fun photoBytes(item: OutboxItem): ByteArray? =
+        photoFile(item)?.takeIf { it.exists() }?.readBytes()
+
+    private fun write(item: OutboxItem) {
+        val target = File(dir, jsonName(item))
+        val tmp = File(dir, jsonName(item) + ".tmp")
+        tmp.writeText(json.encodeToString(OutboxItem.serializer(), item))
+        // Atomic replace so a crash mid-write never leaves a half-written item.
+        Files.move(
+            tmp.toPath(),
+            target.toPath(),
+            StandardCopyOption.REPLACE_EXISTING,
+        )
+    }
+
+    private fun read(file: File): OutboxItem? = runCatching {
+        json.decodeFromString(OutboxItem.serializer(), file.readText())
+    }.getOrNull()
+
+    private fun jsonName(item: OutboxItem) = baseName(item.createdAt, item.id) + ".json"
+
+    private companion object {
+        fun baseName(createdAt: Long, id: String) =
+            "%016d-%s".format(createdAt, id.take(8))
+
+        fun extFor(contentType: String): String = when (contentType.lowercase()) {
+            "image/jpeg", "image/jpg" -> "jpg"
+            "image/png" -> "png"
+            "image/webp" -> "webp"
+            "image/heic", "image/heif" -> "heic"
+            else -> "img"
+        }
+    }
+}

--- a/android/app/src/main/java/org/polybrain/tasks/health/data/OutboxItem.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/OutboxItem.kt
@@ -1,0 +1,43 @@
+package org.polybrain.tasks.health.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * One queued trip write awaiting delivery to the server.
+ *
+ * Everything needed to send is frozen at enqueue time so the entry survives an
+ * offline period, an app kill, or a reboot: the [comment] already carries the
+ * `#poi lat=… lng=…` line (so the GPS fix is captured even with no network),
+ * [published] is the moment the user acted (not the moment of eventual upload),
+ * and for photos the bytes are copied into the outbox dir ([photoFile]) because
+ * the picker's content `Uri` is only readable for the current session.
+ *
+ * [id] doubles as the server `idempotency_key`, so a retry whose first response
+ * was lost re-uses the existing event instead of creating a duplicate.
+ */
+@Serializable
+data class OutboxItem(
+    val id: String,
+    val kind: Kind,
+    val storyId: Long,
+    val comment: String,
+    val published: String,
+    val createdAt: Long,
+    // Photos only:
+    val contentType: String? = null,
+    val photoFile: String? = null,
+    // Photo resume guards: set together only after a successful S3 PUT, so a
+    // confirm-failure retry skips straight to confirm and never re-uploads.
+    val presignedKey: String? = null,
+    val uploaded: Boolean = false,
+    // Delivery bookkeeping, surfaced in the timeline.
+    val attempts: Int = 0,
+    val lastError: String? = null,
+    // A 4xx the worker won't auto-retry (e.g. trip stopped); kept visible so
+    // the user can manually retry or discard.
+    val failedPermanently: Boolean = false,
+) {
+    enum class Kind { NOTE, PHOTO }
+
+    val isPhoto: Boolean get() = kind == Kind.PHOTO
+}

--- a/android/app/src/main/java/org/polybrain/tasks/health/data/TasksApi.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/TasksApi.kt
@@ -134,6 +134,10 @@ data class TripNoteRequest(
     @SerialName("comment") val comment: String,
     // Full ISO 8601 timestamp (OffsetDateTime.now().toString()).
     @SerialName("published") val published: String,
+    // Client-generated UUID for exactly-once delivery. The outbox retries on
+    // failure, so a request whose response was lost must not create a second
+    // note — the server dedupes on this key.
+    @SerialName("idempotency_key") val idempotencyKey: String,
 )
 
 @Serializable
@@ -193,6 +197,8 @@ data class PhotoConfirmRequest(
     @SerialName("content_type") val contentType: String,
     // Full ISO 8601 timestamp (OffsetDateTime.now().toString()).
     @SerialName("published") val published: String,
+    // Client-generated UUID for exactly-once delivery (see TripNoteRequest).
+    @SerialName("idempotency_key") val idempotencyKey: String,
 )
 
 @Serializable

--- a/android/app/src/main/java/org/polybrain/tasks/health/sync/OutboxDrainer.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/sync/OutboxDrainer.kt
@@ -1,0 +1,123 @@
+package org.polybrain.tasks.health.sync
+
+import java.io.IOException
+import org.polybrain.tasks.health.data.Outbox
+import org.polybrain.tasks.health.data.OutboxItem
+import org.polybrain.tasks.health.data.PhotoConfirmRequest
+import org.polybrain.tasks.health.data.PhotoPresignRequest
+import org.polybrain.tasks.health.data.TasksApi
+import org.polybrain.tasks.health.data.TripNoteRequest
+import retrofit2.HttpException
+
+/**
+ * Pure per-item delivery logic, factored out of [OutboxWorker] so it can be
+ * unit-tested with a fake [TasksApi] and PUT function (no Android, no network).
+ *
+ * Each item's [OutboxItem.id] is sent as the server `idempotency_key`, so a
+ * retry after a lost response is exactly-once.
+ */
+object OutboxDrainer {
+
+    /** Result of attempting to deliver one item; carries the latest item state. */
+    sealed class Outcome {
+        abstract val item: OutboxItem
+
+        /** Delivered — caller should remove the item. */
+        data class Sent(override val item: OutboxItem) : Outcome()
+
+        /** Transient failure (network / 5xx / 401 / 429) — keep and retry later. */
+        data class Retry(override val item: OutboxItem, val error: String) : Outcome()
+
+        /** Permanent failure (4xx) — keep but stop auto-retrying; surface to the user. */
+        data class Permanent(override val item: OutboxItem, val error: String) : Outcome()
+    }
+
+    /** Abstracts the raw S3 PUT so tests don't hit the network. Throws on failure. */
+    fun interface PhotoPutter {
+        fun put(url: String, bytes: ByteArray, contentType: String)
+    }
+
+    /** Thrown for unrecoverable problems that should not be retried. */
+    private class PermanentFailure(message: String) : Exception(message)
+
+    suspend fun process(
+        item: OutboxItem,
+        api: TasksApi,
+        outbox: Outbox,
+        put: PhotoPutter,
+    ): Outcome {
+        var current = item
+        return try {
+            when (item.kind) {
+                OutboxItem.Kind.NOTE -> {
+                    api.addTripNote(
+                        TripNoteRequest(
+                            storyId = item.storyId,
+                            comment = item.comment,
+                            published = item.published,
+                            idempotencyKey = item.id,
+                        )
+                    )
+                }
+                OutboxItem.Kind.PHOTO -> {
+                    current = sendPhoto(current, api, outbox, put)
+                }
+            }
+            Outcome.Sent(current)
+        } catch (e: PermanentFailure) {
+            Outcome.Permanent(current, e.message ?: "permanent failure")
+        } catch (e: HttpException) {
+            val msg = "HTTP ${e.code()}"
+            if (isRetryable(e.code())) Outcome.Retry(current, msg)
+            else Outcome.Permanent(current, msg)
+        } catch (e: IOException) {
+            Outcome.Retry(current, e.message ?: "network error")
+        } catch (e: Throwable) {
+            // Unexpected (e.g. malformed response) — don't spin forever on it.
+            Outcome.Permanent(current, e.message ?: e.javaClass.simpleName)
+        }
+    }
+
+    /**
+     * Presign → PUT → confirm, resumable. The `uploaded`/`presignedKey` pair is
+     * persisted only *after* a successful PUT, so a confirm-failure retry skips
+     * straight to confirm and a PUT-failure retry re-presigns fresh. Returns the
+     * (possibly updated) item so the caller's bookkeeping won't clobber the
+     * resume flags.
+     */
+    private suspend fun sendPhoto(
+        item: OutboxItem,
+        api: TasksApi,
+        outbox: Outbox,
+        put: PhotoPutter,
+    ): OutboxItem {
+        var current = item
+        val contentType = current.contentType ?: "image/jpeg"
+        if (!current.uploaded) {
+            val bytes = outbox.photoBytes(current)
+                ?: throw PermanentFailure("photo file missing for ${current.id}")
+            val presign = api.presignPhoto(
+                PhotoPresignRequest(storyId = current.storyId, contentType = contentType)
+            )
+            put.put(presign.uploadUrl, bytes, contentType)
+            // Persist immediately so a process kill after PUT still resumes at confirm.
+            current = current.copy(presignedKey = presign.key, uploaded = true)
+            outbox.update(current)
+        }
+        api.addTripPhoto(
+            PhotoConfirmRequest(
+                storyId = current.storyId,
+                key = current.presignedKey!!,
+                comment = current.comment,
+                contentType = contentType,
+                published = current.published,
+                idempotencyKey = current.id,
+            )
+        )
+        return current
+    }
+
+    /** 401/408/429 and 5xx are worth retrying; other 4xx are permanent. */
+    private fun isRetryable(code: Int): Boolean =
+        code == 401 || code == 408 || code == 429 || code >= 500
+}

--- a/android/app/src/main/java/org/polybrain/tasks/health/sync/OutboxWorker.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/sync/OutboxWorker.kt
@@ -1,0 +1,63 @@
+package org.polybrain.tasks.health.sync
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import org.polybrain.tasks.health.data.Outbox
+import org.polybrain.tasks.health.data.Settings
+import org.polybrain.tasks.health.data.TasksClient
+
+/**
+ * Drains the [Outbox] queue: delivers each pending trip note/photo to the
+ * server, retrying transient failures. Scheduled with a network constraint by
+ * [SyncScheduler.drainOutbox], so it only runs when connectivity is available
+ * and WorkManager re-runs it (with backoff) after a [androidx.work.ListenableWorker.Result.retry].
+ */
+class OutboxWorker(
+    appContext: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(appContext, params) {
+
+    private val settings = Settings(applicationContext)
+    private val outbox = Outbox(applicationContext)
+
+    override suspend fun doWork(): Result {
+        val snapshot = settings.snapshot()
+        // Nothing we can do without a server/token; leave items queued for a
+        // later trigger (a save in Settings re-kicks the drain).
+        if (!snapshot.isConfigured) return Result.success()
+
+        val api = TasksClient.build(snapshot.serverUrl, snapshot.apiToken)
+        val put = OutboxDrainer.PhotoPutter { url, bytes, contentType ->
+            TasksClient.putToPresignedUrl(url, bytes, contentType)
+        }
+
+        var hadRetryable = false
+        for (item in outbox.all()) {
+            if (item.failedPermanently) continue
+            when (val outcome = OutboxDrainer.process(item, api, outbox, put)) {
+                is OutboxDrainer.Outcome.Sent -> outbox.remove(outcome.item)
+                is OutboxDrainer.Outcome.Retry -> {
+                    outbox.update(
+                        outcome.item.copy(
+                            attempts = outcome.item.attempts + 1,
+                            lastError = outcome.error,
+                        )
+                    )
+                    hadRetryable = true
+                }
+                is OutboxDrainer.Outcome.Permanent -> outbox.update(
+                    outcome.item.copy(
+                        attempts = outcome.item.attempts + 1,
+                        lastError = outcome.error,
+                        failedPermanently = true,
+                    )
+                )
+            }
+        }
+
+        // Ask WorkManager to re-run (with exponential backoff) while anything
+        // still needs delivery; otherwise we're done.
+        return if (hadRetryable) Result.retry() else Result.success()
+    }
+}

--- a/android/app/src/main/java/org/polybrain/tasks/health/sync/SyncScheduler.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/sync/SyncScheduler.kt
@@ -18,6 +18,9 @@ object SyncScheduler {
     private const val DAILY = "health-sync-daily"
     private const val ONE_OFF = "health-sync-once"
 
+    /** Unique-work name for the trip-outbox drain (see [OutboxWorker]). */
+    const val OUTBOX = "outbox-drain"
+
     private val networkConstraints = Constraints.Builder()
         .setRequiredNetworkType(NetworkType.CONNECTED)
         .build()
@@ -72,10 +75,32 @@ object SyncScheduler {
         )
     }
 
+    /**
+     * Kick the trip-outbox drain. Network-constrained so it waits for
+     * connectivity, with exponential backoff between retries. Enqueued as
+     * APPEND_OR_REPLACE so an item added while a drain is mid-flight still gets
+     * a fresh pass afterwards; the worker is idempotent (re-reads the queue,
+     * server dedupes on the idempotency key), so an extra pass is harmless.
+     *
+     * Safe to call on app start to resume after a reboot/kill.
+     */
+    fun drainOutbox(context: Context) {
+        val request = OneTimeWorkRequestBuilder<OutboxWorker>()
+            .setConstraints(networkConstraints)
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+            .build()
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            OUTBOX,
+            ExistingWorkPolicy.APPEND_OR_REPLACE,
+            request,
+        )
+    }
+
     fun cancelAll(context: Context) {
         val wm = WorkManager.getInstance(context)
         wm.cancelUniqueWork(PERIODIC)
         wm.cancelUniqueWork(DAILY)
         wm.cancelUniqueWork(ONE_OFF)
+        wm.cancelUniqueWork(OUTBOX)
     }
 }

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/MainViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/MainViewModel.kt
@@ -64,6 +64,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     val requiredPermissions: Set<String> = health.permissions
 
     init {
+        // Resume any trip notes/photos queued offline in a previous session.
+        // The worker no-ops when unconfigured, so this is safe to call always.
+        SyncScheduler.drainOutbox(application)
         viewModelScope.launch {
             refreshPermissionState()
             if (_permissionsGranted.value) refreshMetrics()

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/AddPhotoDialog.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/AddPhotoDialog.kt
@@ -8,10 +8,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.size
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -34,7 +32,6 @@ fun AddPhotoDialog(vm: TripDetailViewModel) {
     val gps by vm.gps.collectAsState()
     val allowNoLocation by vm.allowNoLocation.collectAsState()
     val selectedPhoto by vm.selectedPhoto.collectAsState()
-    val uploading by vm.uploading.collectAsState()
 
     var draft by remember { mutableStateOf("") }
 
@@ -42,10 +39,10 @@ fun AddPhotoDialog(vm: TripDetailViewModel) {
         ActivityResultContracts.RequestPermission(),
     ) { granted -> vm.onLocationPermissionResult(granted) }
 
-    val canSend = !uploading && (
-        gps is TripDetailViewModel.GpsState.Ready ||
-            (allowNoLocation && gps !is TripDetailViewModel.GpsState.Waiting)
-        )
+    // Sending now just queues the photo to the outbox and closes the dialog —
+    // the upload happens in the background, so there's no in-dialog spinner.
+    val canSend = gps is TripDetailViewModel.GpsState.Ready ||
+        (allowNoLocation && gps !is TripDetailViewModel.GpsState.Waiting)
 
     AlertDialog(
         onDismissRequest = { vm.closeAddPhoto() },
@@ -85,28 +82,20 @@ fun AddPhotoDialog(vm: TripDetailViewModel) {
                     placeholder = { Text(stringResource(R.string.trip_photo_hint)) },
                     singleLine = false,
                     minLines = 2,
-                    enabled = !uploading,
                     modifier = Modifier.fillMaxWidth(),
                 )
             }
         },
         confirmButton = {
-            if (uploading) {
-                CircularProgressIndicator(modifier = Modifier.size(24.dp))
-            } else {
-                TextButton(
-                    onClick = { vm.sendPhoto(draft) },
-                    enabled = canSend,
-                ) {
-                    Text(stringResource(R.string.trip_photo_send))
-                }
+            TextButton(
+                onClick = { vm.sendPhoto(draft) },
+                enabled = canSend,
+            ) {
+                Text(stringResource(R.string.trip_photo_send))
             }
         },
         dismissButton = {
-            TextButton(
-                onClick = { vm.closeAddPhoto() },
-                enabled = !uploading,
-            ) {
+            TextButton(onClick = { vm.closeAddPhoto() }) {
                 Text(stringResource(R.string.trip_note_cancel))
             }
         },

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripDetailScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripDetailScreen.kt
@@ -46,13 +46,16 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
+import java.io.File
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import org.polybrain.tasks.health.R
+import org.polybrain.tasks.health.data.OutboxItem
 import org.polybrain.tasks.health.data.TripEvent
+import org.polybrain.tasks.health.ui.trip.TripDetailViewModel.TimelineRow
 
-// Fallback only used during the brief window where events have loaded
+// Fallback only used during the brief window where rows have loaded
 // but the story object hasn't yet — pickEventFormatter needs both.
 private val FALLBACK_FORMATTER: DateTimeFormatter =
     DateTimeFormatter.ofPattern("HH:mm", Locale.US).withZone(ZoneId.systemDefault())
@@ -64,7 +67,9 @@ fun TripDetailScreen(
     vm: TripDetailViewModel = viewModel(),
 ) {
     val story by vm.story.collectAsState()
-    val events by vm.events.collectAsState()
+    val timeline by vm.timeline.collectAsState()
+    val pending by vm.pending.collectAsState()
+    val syncing by vm.syncing.collectAsState()
     val loading by vm.loading.collectAsState()
     val error by vm.error.collectAsState()
     val noteOpen by vm.noteDialogOpen.collectAsState()
@@ -85,7 +90,7 @@ fun TripDetailScreen(
         pickEventFormatter(
             startedIso = it.started,
             stoppedIso = it.stopped,
-            eventIsos = events.map { e -> e.published },
+            eventIsos = timeline.map { row -> row.publishedIso },
         )
     }
 
@@ -131,24 +136,40 @@ fun TripDetailScreen(
             }
         }
 
+        SyncBadge(
+            pending = pending,
+            syncing = syncing,
+            onRetryAll = { pending.filter { it.failedPermanently }.forEach(vm::retry) },
+        )
+
         PullToRefreshBox(
             isRefreshing = loading,
             onRefresh = vm::refresh,
             modifier = Modifier.fillMaxSize(),
         ) {
-            if (events.isEmpty()) {
+            if (timeline.isEmpty()) {
                 EmptyState(stringResource(R.string.trip_detail_empty))
             } else {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    items(items = events, key = { "${it.type}-${it.id}" }) { event ->
-                        EventRow(
-                            event = event,
-                            formatter = formatter ?: FALLBACK_FORMATTER,
-                            onOpenPhoto = vm::openPhoto,
-                        )
+                    items(items = timeline, key = ::rowKey) { row ->
+                        when (row) {
+                            is TimelineRow.Synced -> EventRow(
+                                event = row.event,
+                                formatter = formatter ?: FALLBACK_FORMATTER,
+                                onOpenPhoto = vm::openPhoto,
+                            )
+                            is TimelineRow.Pending -> PendingRow(
+                                item = row.item,
+                                formatter = formatter ?: FALLBACK_FORMATTER,
+                                syncing = syncing,
+                                photoFile = vm.pendingPhotoFile(row.item),
+                                onRetry = { vm.retry(row.item) },
+                                onDiscard = { vm.discard(row.item) },
+                            )
+                        }
                     }
                 }
             }
@@ -170,6 +191,55 @@ fun TripDetailScreen(
     }
     viewerUrl?.let { url ->
         PhotoViewerDialog(url = url, onDismiss = vm::closeViewer)
+    }
+}
+
+private fun rowKey(row: TimelineRow): String = when (row) {
+    is TimelineRow.Synced -> "s-${row.event.type}-${row.event.id}"
+    is TimelineRow.Pending -> "p-${row.item.id}"
+}
+
+@Composable
+private fun SyncBadge(
+    pending: List<OutboxItem>,
+    syncing: Boolean,
+    onRetryAll: () -> Unit,
+) {
+    val waiting = pending.count { !it.failedPermanently }
+    val failed = pending.count { it.failedPermanently }
+    if (waiting == 0 && failed == 0) return
+
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        if (waiting > 0) {
+            Text(
+                text = stringResource(
+                    if (syncing) R.string.trip_sync_badge_syncing
+                    else R.string.trip_sync_badge_waiting,
+                    waiting,
+                ),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (failed > 0) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(R.string.trip_sync_badge_failed, failed),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.weight(1f),
+                )
+                TextButton(onClick = onRetryAll) {
+                    Text(stringResource(R.string.trip_sync_retry_all))
+                }
+            }
+        }
     }
 }
 
@@ -340,6 +410,101 @@ private fun PhotoEventBody(
                     }
                 }
             }
+        }
+    }
+}
+
+/**
+ * A queued (not-yet-synced) note or photo. Mirrors [EventRow]'s layout so the
+ * timeline reads consistently, but loads the photo from the local outbox file
+ * and shows a sync-status line (with retry/discard once it has failed).
+ */
+@Composable
+private fun PendingRow(
+    item: OutboxItem,
+    formatter: DateTimeFormatter,
+    syncing: Boolean,
+    photoFile: File?,
+    onRetry: () -> Unit,
+    onDiscard: () -> Unit,
+) {
+    val context = LocalContext.current
+    val parsed = remember(item.id, item.comment) { parseTripNote(item.comment) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Text(
+            text = formatInstant(item.published, formatter),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+        if (item.isPhoto && photoFile != null) {
+            AsyncImage(
+                model = photoFile,
+                contentDescription = parsed.text,
+                contentScale = ContentScale.Fit,
+                alignment = Alignment.CenterEnd,
+                modifier = Modifier
+                    .align(Alignment.End)
+                    .fillMaxWidth(0.6f)
+                    .heightIn(max = 240.dp),
+            )
+        }
+
+        val body = parsed.text
+        val poi = parsed.poi
+        if (body.isNotBlank() || poi != null) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = body,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                if (poi != null) {
+                    IconButton(onClick = { openPoiInMaps(context, poi) }) {
+                        Icon(
+                            imageVector = Icons.Filled.Place,
+                            contentDescription = stringResource(
+                                R.string.trip_detail_open_in_maps
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+
+        if (item.failedPermanently) {
+            Text(
+                text = stringResource(R.string.trip_sync_failed, item.lastError.orEmpty()),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.error,
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                TextButton(onClick = onRetry) {
+                    Text(stringResource(R.string.trip_sync_retry))
+                }
+                TextButton(onClick = onDiscard) {
+                    Text(stringResource(R.string.trip_sync_discard))
+                }
+            }
+        } else {
+            Text(
+                text = stringResource(
+                    if (syncing) R.string.trip_sync_uploading
+                    else R.string.trip_sync_waiting
+                ),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripDetailViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripDetailViewModel.kt
@@ -5,6 +5,9 @@ import android.net.Uri
 import android.provider.MediaStore
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import java.io.File
 import java.io.IOException
 import java.time.Instant
 import java.time.OffsetDateTime
@@ -12,35 +15,59 @@ import java.time.ZoneId
 import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.polybrain.tasks.health.data.PhotoConfirmRequest
-import org.polybrain.tasks.health.data.PhotoPresignRequest
+import org.polybrain.tasks.health.data.Outbox
+import org.polybrain.tasks.health.data.OutboxItem
 import org.polybrain.tasks.health.data.Settings
 import org.polybrain.tasks.health.data.SettingsSnapshot
 import org.polybrain.tasks.health.data.TasksApi
 import org.polybrain.tasks.health.data.TasksClient
 import org.polybrain.tasks.health.data.TripDetailResponse
 import org.polybrain.tasks.health.data.TripEvent
-import org.polybrain.tasks.health.data.TripNoteRequest
 import org.polybrain.tasks.health.data.TripStoryIdRequest
 import org.polybrain.tasks.health.data.TripSummary
 import org.polybrain.tasks.health.data.TripUpdateRequest
 import org.polybrain.tasks.health.location.LocationFix
 import org.polybrain.tasks.health.location.LocationProvider
+import org.polybrain.tasks.health.sync.SyncScheduler
 
 class TripDetailViewModel(application: Application) : AndroidViewModel(application) {
 
     private val settings = Settings(application)
     private val locationProvider = LocationProvider(application)
+    private val outbox = Outbox(application)
+    private val workManager = WorkManager.getInstance(application)
 
     private val _story = MutableStateFlow<TripSummary?>(null)
     val story: StateFlow<TripSummary?> = _story.asStateFlow()
 
     private val _events = MutableStateFlow<List<TripEvent>>(emptyList())
     val events: StateFlow<List<TripEvent>> = _events.asStateFlow()
+
+    /** Trip writes still in the local outbox (waiting / syncing / failed). */
+    private val _pending = MutableStateFlow<List<OutboxItem>>(emptyList())
+    val pending: StateFlow<List<OutboxItem>> = _pending.asStateFlow()
+
+    /** True while the outbox drain worker is actively running. */
+    private val _syncing = MutableStateFlow(false)
+    val syncing: StateFlow<Boolean> = _syncing.asStateFlow()
+
+    /**
+     * Server events and local pending items merged into one chronological list
+     * (newest first), so a just-queued note/photo shows in the timeline before
+     * it ever reaches the server.
+     */
+    val timeline: StateFlow<List<TimelineRow>> =
+        combine(_events, _pending) { events, pending ->
+            (events.map { TimelineRow.Synced(it) } + pending.map { TimelineRow.Pending(it) })
+                .sortedByDescending { instantOf(it.publishedIso) }
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     private val _loading = MutableStateFlow(false)
     val loading: StateFlow<Boolean> = _loading.asStateFlow()
@@ -58,10 +85,6 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
 
     private val _selectedPhoto = MutableStateFlow<Uri?>(null)
     val selectedPhoto: StateFlow<Uri?> = _selectedPhoto.asStateFlow()
-
-    /** True while a photo is being uploaded + confirmed. */
-    private val _uploading = MutableStateFlow(false)
-    val uploading: StateFlow<Boolean> = _uploading.asStateFlow()
 
     /** Presigned URL for the full-size original being viewed (null = closed). */
     private val _viewerUrl = MutableStateFlow<String?>(null)
@@ -91,6 +114,22 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
 
     private var storyId: Long = -1
 
+    init {
+        // Track the drain worker: keep the pending list fresh, drive the
+        // "Syncing…" label, and reload server events when a drain completes
+        // (so synced items flip from pending → real timeline rows).
+        viewModelScope.launch {
+            var wasRunning = false
+            workManager.getWorkInfosForUniqueWorkFlow(SyncScheduler.OUTBOX).collect { infos ->
+                val running = infos.any { it.state == WorkInfo.State.RUNNING }
+                _syncing.value = running
+                refreshPending()
+                if (wasRunning && !running) reloadIfLoaded()
+                wasRunning = running
+            }
+        }
+    }
+
     fun load(id: Long) {
         if (id == storyId && _story.value != null) return
         storyId = id
@@ -98,7 +137,10 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
     }
 
     fun refresh() {
-        viewModelScope.launch { reload() }
+        viewModelScope.launch {
+            reload()
+            refreshPending()
+        }
     }
 
     fun openAddNote() {
@@ -120,7 +162,6 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
     }
 
     fun closeAddPhoto() {
-        if (_uploading.value) return
         _photoDialogOpen.value = false
         _selectedPhoto.value = null
         _gps.value = GpsState.Idle
@@ -162,8 +203,7 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
     fun sendNote(text: String) {
         val story = _story.value ?: return
         if (story.stopped != null) return
-        val gpsState = _gps.value
-        val fix = (gpsState as? GpsState.Ready)?.fix
+        val fix = (_gps.value as? GpsState.Ready)?.fix
         if (fix == null && !_allowNoLocation.value) return
 
         val comment = composeComment(fix, text)
@@ -172,21 +212,12 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
         _gps.value = GpsState.Idle
         _allowNoLocation.value = false
 
+        // Queue locally and kick the drain; the item shows immediately and the
+        // worker delivers it (now or when connectivity returns).
         viewModelScope.launch {
-            val snapshot = ensureConfigured() ?: return@launch
-            try {
-                val api = buildApi(snapshot)
-                api.addTripNote(
-                    TripNoteRequest(
-                        storyId = story.id,
-                        comment = comment,
-                        published = published,
-                    )
-                )
-                reload()
-            } catch (t: Throwable) {
-                _error.value = t.message ?: t.javaClass.simpleName
-            }
+            withContext(Dispatchers.IO) { outbox.enqueueNote(story.id, comment, published) }
+            refreshPending()
+            SyncScheduler.drainOutbox(getApplication())
         }
     }
 
@@ -194,58 +225,58 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
         val story = _story.value ?: return
         if (story.stopped != null) return
         val uri = _selectedPhoto.value ?: return
-        val gpsState = _gps.value
-        val fix = (gpsState as? GpsState.Ready)?.fix
+        val fix = (_gps.value as? GpsState.Ready)?.fix
         if (fix == null && !_allowNoLocation.value) return
 
         val comment = composeComment(fix, text)
-        _uploading.value = true
+        // Close the dialog now; copy + enqueue happen in the background.
+        _photoDialogOpen.value = false
+        _selectedPhoto.value = null
+        _gps.value = GpsState.Idle
+        _allowNoLocation.value = false
 
         viewModelScope.launch {
-            val snapshot = ensureConfigured()
-            if (snapshot == null) {
-                _uploading.value = false
-                return@launch
-            }
             try {
                 val resolver = getApplication<Application>().contentResolver
                 val contentType = resolver.getType(uri) ?: "image/jpeg"
+                // Read the bytes NOW — the picker's content Uri is only readable
+                // for this session, so they must be copied before we lose access.
                 val bytes = withContext(Dispatchers.IO) {
                     resolver.openInputStream(uri)?.use { it.readBytes() }
                 } ?: throw IOException("could not read the selected photo")
-                // Timestamp the photo with when it was taken, not now. The
-                // backend further overrides this with the original's EXIF
-                // DateTimeOriginal when present.
                 val published = withContext(Dispatchers.IO) { captureTimeFor(uri) }
-
-                val api = buildApi(snapshot)
-                val presign = api.presignPhoto(
-                    PhotoPresignRequest(storyId = story.id, contentType = contentType)
-                )
                 withContext(Dispatchers.IO) {
-                    TasksClient.putToPresignedUrl(presign.uploadUrl, bytes, contentType)
+                    outbox.enqueuePhoto(story.id, comment, published, contentType, bytes)
                 }
-                api.addTripPhoto(
-                    PhotoConfirmRequest(
-                        storyId = story.id,
-                        key = presign.key,
-                        comment = comment,
-                        contentType = contentType,
-                        published = published,
-                    )
-                )
-                _photoDialogOpen.value = false
-                _selectedPhoto.value = null
-                _gps.value = GpsState.Idle
-                _allowNoLocation.value = false
-                reload()
+                refreshPending()
+                SyncScheduler.drainOutbox(getApplication())
             } catch (t: Throwable) {
                 _error.value = t.message ?: t.javaClass.simpleName
-            } finally {
-                _uploading.value = false
             }
         }
     }
+
+    /** Re-queue a permanently-failed item for another delivery attempt. */
+    fun retry(item: OutboxItem) {
+        viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                outbox.update(item.copy(failedPermanently = false, lastError = null))
+            }
+            refreshPending()
+            SyncScheduler.drainOutbox(getApplication())
+        }
+    }
+
+    /** Drop a queued item (and its photo file) without sending it. */
+    fun discard(item: OutboxItem) {
+        viewModelScope.launch {
+            withContext(Dispatchers.IO) { outbox.remove(item) }
+            refreshPending()
+        }
+    }
+
+    /** Local file backing a pending photo, for the timeline thumbnail. */
+    fun pendingPhotoFile(item: OutboxItem): File? = outbox.photoFile(item)
 
     /**
      * Best-effort capture time of a picked image: the gallery's DATE_TAKEN
@@ -344,6 +375,10 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
         _error.value = null
     }
 
+    private fun reloadIfLoaded() {
+        if (storyId > 0) viewModelScope.launch { reload() }
+    }
+
     private suspend fun reload() {
         if (storyId <= 0) return
         val snapshot = ensureConfigured() ?: return
@@ -361,6 +396,14 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
         }
     }
 
+    private suspend fun refreshPending() {
+        _pending.value = if (storyId <= 0) {
+            emptyList()
+        } else {
+            withContext(Dispatchers.IO) { outbox.forStory(storyId) }
+        }
+    }
+
     private suspend fun ensureConfigured(): SettingsSnapshot? {
         val snapshot = settings.snapshot()
         if (!snapshot.isConfigured) {
@@ -372,6 +415,19 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
 
     private fun buildApi(snapshot: SettingsSnapshot): TasksApi =
         TasksClient.build(snapshot.serverUrl, snapshot.apiToken)
+
+    /** One row in the merged timeline: either a server event or a queued item. */
+    sealed class TimelineRow {
+        abstract val publishedIso: String
+
+        data class Synced(val event: TripEvent) : TimelineRow() {
+            override val publishedIso: String get() = event.published
+        }
+
+        data class Pending(val item: OutboxItem) : TimelineRow() {
+            override val publishedIso: String get() = item.published
+        }
+    }
 
     companion object {
         internal fun composeComment(fix: LocationFix?, text: String): String {
@@ -385,5 +441,8 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
                 trimmed
             }
         }
+
+        private fun instantOf(iso: String): Instant =
+            runCatching { OffsetDateTime.parse(iso).toInstant() }.getOrDefault(Instant.EPOCH)
     }
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -39,6 +39,16 @@
     <string name="trip_photo_send">Upload</string>
     <string name="trip_photo_processing">Processing photo…</string>
 
+    <string name="trip_sync_waiting">Waiting to sync</string>
+    <string name="trip_sync_uploading">Syncing…</string>
+    <string name="trip_sync_failed">Couldn\'t sync: %1$s</string>
+    <string name="trip_sync_retry">Retry</string>
+    <string name="trip_sync_discard">Discard</string>
+    <string name="trip_sync_badge_waiting">%1$d waiting to sync</string>
+    <string name="trip_sync_badge_syncing">Syncing %1$d…</string>
+    <string name="trip_sync_badge_failed">%1$d failed to sync</string>
+    <string name="trip_sync_retry_all">Retry all</string>
+
     <string name="today_empty">Nothing on today\'s plan yet.</string>
     <string name="today_add_hint">Add a task</string>
     <string name="today_add_button">Add</string>

--- a/android/app/src/test/java/org/polybrain/tasks/health/data/OutboxTest.kt
+++ b/android/app/src/test/java/org/polybrain/tasks/health/data/OutboxTest.kt
@@ -1,0 +1,94 @@
+package org.polybrain.tasks.health.data
+
+import java.io.File
+import java.nio.file.Files
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class OutboxTest {
+
+    private lateinit var dir: File
+    private lateinit var outbox: Outbox
+
+    @Before
+    fun setUp() {
+        dir = Files.createTempDirectory("outbox-test").toFile()
+        outbox = Outbox(dir)
+    }
+
+    @After
+    fun tearDown() {
+        dir.deleteRecursively()
+    }
+
+    @Test
+    fun `enqueueNote persists a retrievable item`() {
+        val item = outbox.enqueueNote(7L, "#poi lat=1.0 lng=2.0\nhi", "2026-06-06T10:00:00Z")
+        val all = outbox.all()
+        assertEquals(1, all.size)
+        assertEquals(item.id, all[0].id)
+        assertEquals(OutboxItem.Kind.NOTE, all[0].kind)
+        assertEquals(7L, all[0].storyId)
+        assertEquals("#poi lat=1.0 lng=2.0\nhi", all[0].comment)
+    }
+
+    @Test
+    fun `enqueuePhoto writes the photo bytes alongside the item`() {
+        val bytes = byteArrayOf(1, 2, 3, 4, 5)
+        val item = outbox.enqueuePhoto(3L, "caption", "2026-06-06T10:00:00Z", "image/jpeg", bytes)
+        assertTrue(item.isPhoto)
+        assertEquals("image/jpeg", item.contentType)
+        assertTrue(outbox.photoFile(item)!!.name.endsWith(".jpg"))
+        assertTrue(bytes.contentEquals(outbox.photoBytes(item)))
+    }
+
+    @Test
+    fun `all returns items oldest first`() {
+        // createdAt is the filename prefix; force distinct timestamps by spacing.
+        val a = outbox.enqueueNote(1L, "first", "t1")
+        Thread.sleep(2)
+        val b = outbox.enqueueNote(1L, "second", "t2")
+        val ids = outbox.all().map { it.id }
+        assertEquals(listOf(a.id, b.id), ids)
+    }
+
+    @Test
+    fun `forStory filters by story`() {
+        outbox.enqueueNote(1L, "a", "t")
+        outbox.enqueueNote(2L, "b", "t")
+        assertEquals(1, outbox.forStory(1L).size)
+        assertEquals(2L, outbox.forStory(2L).single().storyId)
+    }
+
+    @Test
+    fun `update rewrites the same file in place`() {
+        val item = outbox.enqueueNote(1L, "x", "t")
+        outbox.update(item.copy(attempts = 3, lastError = "boom"))
+        val reloaded = outbox.all().single()
+        assertEquals(item.id, reloaded.id)
+        assertEquals(3, reloaded.attempts)
+        assertEquals("boom", reloaded.lastError)
+        assertEquals(1, outbox.all().size) // no duplicate file
+    }
+
+    @Test
+    fun `remove deletes the json and the photo file`() {
+        val item = outbox.enqueuePhoto(1L, "c", "t", "image/png", byteArrayOf(9))
+        val photo = outbox.photoFile(item)!!
+        assertTrue(photo.exists())
+        outbox.remove(item)
+        assertTrue(outbox.all().isEmpty())
+        assertFalse(photo.exists())
+    }
+
+    @Test
+    fun `photoBytes is null for a note`() {
+        val item = outbox.enqueueNote(1L, "x", "t")
+        assertNull(outbox.photoBytes(item))
+    }
+}

--- a/android/app/src/test/java/org/polybrain/tasks/health/sync/OutboxDrainerTest.kt
+++ b/android/app/src/test/java/org/polybrain/tasks/health/sync/OutboxDrainerTest.kt
@@ -1,0 +1,193 @@
+package org.polybrain.tasks.health.sync
+
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import kotlinx.coroutines.test.runTest
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.polybrain.tasks.health.data.BoardItemsResponse
+import org.polybrain.tasks.health.data.Outbox
+import org.polybrain.tasks.health.data.OkResponse
+import org.polybrain.tasks.health.data.PhotoConfirmRequest
+import org.polybrain.tasks.health.data.PhotoConfirmResponse
+import org.polybrain.tasks.health.data.PhotoOriginalResponse
+import org.polybrain.tasks.health.data.PhotoPresignRequest
+import org.polybrain.tasks.health.data.PhotoPresignResponse
+import org.polybrain.tasks.health.data.PlanListResponse
+import org.polybrain.tasks.health.data.TaskCompleteRequest
+import org.polybrain.tasks.health.data.TaskTextRequest
+import org.polybrain.tasks.health.data.TasksApi
+import org.polybrain.tasks.health.data.TodayTasksResponse
+import org.polybrain.tasks.health.data.TrackHabitRequest
+import org.polybrain.tasks.health.data.TrackHabitResponse
+import org.polybrain.tasks.health.data.TrackHabitTextRequest
+import org.polybrain.tasks.health.data.TripDetailResponse
+import org.polybrain.tasks.health.data.TripListResponse
+import org.polybrain.tasks.health.data.TripNoteRequest
+import org.polybrain.tasks.health.data.TripNoteResponse
+import org.polybrain.tasks.health.data.TripResponse
+import org.polybrain.tasks.health.data.TripStartRequest
+import org.polybrain.tasks.health.data.TripStoryIdRequest
+import org.polybrain.tasks.health.data.TripUpdateRequest
+import retrofit2.HttpException
+import retrofit2.Response
+
+class OutboxDrainerTest {
+
+    private lateinit var dir: File
+    private lateinit var outbox: Outbox
+
+    @Before
+    fun setUp() {
+        dir = Files.createTempDirectory("drainer-test").toFile()
+        outbox = Outbox(dir)
+    }
+
+    @After
+    fun tearDown() {
+        dir.deleteRecursively()
+    }
+
+    private fun httpException(code: Int) =
+        HttpException(Response.error<Any>(code, "err".toResponseBody(null)))
+
+    private val noopPut = OutboxDrainer.PhotoPutter { _, _, _ -> }
+
+    @Test
+    fun `note success sends idempotency key and reports Sent`() = runTest {
+        val item = outbox.enqueueNote(5L, "hello", "2026-06-06T10:00:00Z")
+        val api = FakeApi()
+        val outcome = OutboxDrainer.process(item, api, outbox, noopPut)
+        assertTrue(outcome is OutboxDrainer.Outcome.Sent)
+        assertEquals(1, api.noteRequests.size)
+        assertEquals(item.id, api.noteRequests.single().idempotencyKey)
+        assertEquals(5L, api.noteRequests.single().storyId)
+    }
+
+    @Test
+    fun `photo first send presigns puts confirms and marks uploaded`() = runTest {
+        val item = outbox.enqueuePhoto(2L, "cap", "t", "image/jpeg", byteArrayOf(1, 2, 3))
+        val api = FakeApi(presignKey = "trips/2/k.jpg", presignUrl = "https://put/x")
+        var putCalls = 0
+        val put = OutboxDrainer.PhotoPutter { url, _, _ ->
+            putCalls++
+            assertEquals("https://put/x", url)
+        }
+        val outcome = OutboxDrainer.process(item, api, outbox, put)
+        assertTrue(outcome is OutboxDrainer.Outcome.Sent)
+        assertEquals(1, putCalls)
+        assertEquals(1, api.presignRequests.size)
+        val confirm = api.confirmRequests.single()
+        assertEquals("trips/2/k.jpg", confirm.key)
+        assertEquals(item.id, confirm.idempotencyKey)
+        // The resume flag is persisted on the returned item.
+        assertTrue((outcome as OutboxDrainer.Outcome.Sent).item.uploaded)
+    }
+
+    @Test
+    fun `photo retry skips re-upload when already uploaded`() = runTest {
+        val base = outbox.enqueuePhoto(2L, "cap", "t", "image/jpeg", byteArrayOf(1, 2, 3))
+        // Simulate a previous run that uploaded but failed at confirm.
+        val resumed = base.copy(uploaded = true, presignedKey = "trips/2/already.jpg")
+        outbox.update(resumed)
+        val api = FakeApi()
+        var putCalls = 0
+        val put = OutboxDrainer.PhotoPutter { _, _, _ -> putCalls++ }
+        val outcome = OutboxDrainer.process(resumed, api, outbox, put)
+        assertTrue(outcome is OutboxDrainer.Outcome.Sent)
+        assertEquals(0, putCalls)
+        assertEquals(0, api.presignRequests.size)
+        assertEquals("trips/2/already.jpg", api.confirmRequests.single().key)
+    }
+
+    @Test
+    fun `4xx is permanent`() = runTest {
+        val item = outbox.enqueueNote(1L, "x", "t")
+        val api = FakeApi(noteError = httpException(409))
+        val outcome = OutboxDrainer.process(item, api, outbox, noopPut)
+        assertTrue(outcome is OutboxDrainer.Outcome.Permanent)
+    }
+
+    @Test
+    fun `5xx is retryable`() = runTest {
+        val item = outbox.enqueueNote(1L, "x", "t")
+        val api = FakeApi(noteError = httpException(503))
+        val outcome = OutboxDrainer.process(item, api, outbox, noopPut)
+        assertTrue(outcome is OutboxDrainer.Outcome.Retry)
+    }
+
+    @Test
+    fun `network error is retryable`() = runTest {
+        val item = outbox.enqueueNote(1L, "x", "t")
+        val api = FakeApi(noteError = IOException("no route to host"))
+        val outcome = OutboxDrainer.process(item, api, outbox, noopPut)
+        assertTrue(outcome is OutboxDrainer.Outcome.Retry)
+    }
+
+    @Test
+    fun `missing photo bytes is permanent not an endless retry`() = runTest {
+        val item = outbox.enqueuePhoto(1L, "c", "t", "image/jpeg", byteArrayOf(7))
+        // Delete the bytes file but keep the item (simulates corruption).
+        outbox.photoFile(item)!!.delete()
+        val api = FakeApi()
+        val outcome = OutboxDrainer.process(item, api, outbox, noopPut)
+        assertTrue(outcome is OutboxDrainer.Outcome.Permanent)
+        assertEquals(0, api.presignRequests.size)
+    }
+
+    /**
+     * Fake covering the whole [TasksApi]; only the three outbox endpoints are
+     * exercised, the rest throw if a test ever wanders into them.
+     */
+    private class FakeApi(
+        private val presignKey: String = "k",
+        private val presignUrl: String = "https://put/url",
+        private val noteError: Throwable? = null,
+        private val photoError: Throwable? = null,
+    ) : TasksApi {
+        val noteRequests = mutableListOf<TripNoteRequest>()
+        val presignRequests = mutableListOf<PhotoPresignRequest>()
+        val confirmRequests = mutableListOf<PhotoConfirmRequest>()
+
+        override suspend fun addTripNote(body: TripNoteRequest): TripNoteResponse {
+            noteError?.let { throw it }
+            noteRequests += body
+            return TripNoteResponse(ok = true, journalId = 1)
+        }
+
+        override suspend fun presignPhoto(body: PhotoPresignRequest): PhotoPresignResponse {
+            presignRequests += body
+            return PhotoPresignResponse(key = presignKey, uploadUrl = presignUrl)
+        }
+
+        override suspend fun addTripPhoto(body: PhotoConfirmRequest): PhotoConfirmResponse {
+            photoError?.let { throw it }
+            confirmRequests += body
+            return PhotoConfirmResponse(ok = true, photoId = 1)
+        }
+
+        // --- unused endpoints ---
+        override suspend fun trackHabit(body: TrackHabitRequest): TrackHabitResponse = nope()
+        override suspend fun trackHabitText(body: TrackHabitTextRequest): OkResponse = nope()
+        override suspend fun listTodayTasks(date: String): TodayTasksResponse = nope()
+        override suspend fun listBoardItems(): BoardItemsResponse = nope()
+        override suspend fun addTodayTask(body: TaskTextRequest): OkResponse = nope()
+        override suspend fun completeTodayTask(body: TaskCompleteRequest): OkResponse = nope()
+        override suspend fun deleteTodayTask(body: TaskTextRequest): OkResponse = nope()
+        override suspend fun listPlans(thread: String, pubDate: String): PlanListResponse = nope()
+        override suspend fun startTrip(body: TripStartRequest): TripResponse = nope()
+        override suspend fun stopTrip(body: TripStoryIdRequest): TripResponse = nope()
+        override suspend fun updateTrip(body: TripUpdateRequest): TripResponse = nope()
+        override suspend fun listTrips(page: Int, pageSize: Int): TripListResponse = nope()
+        override suspend fun tripDetail(storyId: Long): TripDetailResponse = nope()
+        override suspend fun photoOriginal(eventId: Long): PhotoOriginalResponse = nope()
+
+        private fun nope(): Nothing = throw AssertionError("unexpected API call")
+    }
+}

--- a/tasks/apps/tree/migrations/0071_event_idempotency_key.py
+++ b/tasks/apps/tree/migrations/0071_event_idempotency_key.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("tree", "0070_remove_quicknote"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="event",
+            name="idempotency_key",
+            field=models.CharField(blank=True, max_length=64, null=True),
+        ),
+        migrations.AddConstraint(
+            model_name="event",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("idempotency_key__isnull", False)),
+                fields=("idempotency_key",),
+                name="event_idempotency_key_unique",
+            ),
+        ),
+    ]

--- a/tasks/apps/tree/models.py
+++ b/tasks/apps/tree/models.py
@@ -42,6 +42,13 @@ class Event(PolymorphicModel):
 
     event_stream_id = models.UUIDField(editable=False)
 
+    # Optional client-supplied key for exactly-once creation. When a device
+    # retries a write whose response was lost (e.g. an offline outbox), the
+    # service re-uses the existing event instead of creating a duplicate. A
+    # transport concern, deliberately on the generic Event base so any
+    # event-creating endpoint can opt in — not just trip notes/photos.
+    idempotency_key = models.CharField(max_length=64, null=True, blank=True)
+
     class Meta:
         indexes = [
             models.Index(fields=["published"]),
@@ -49,6 +56,18 @@ class Event(PolymorphicModel):
         ]
 
         ordering = ("published",)
+
+        constraints = [
+            # Partial unique constraint: only opted-in rows are indexed, so the
+            # hot tree_event table pays nothing for the rows that don't set a
+            # key. Client keys are globally unique UUIDs, so no user/story
+            # scoping is needed.
+            models.UniqueConstraint(
+                fields=["idempotency_key"],
+                condition=models.Q(idempotency_key__isnull=False),
+                name="event_idempotency_key_unique",
+            ),
+        ]
 
     def __str__(self):
         return "[{cls}] #{pk}".format(

--- a/tasks/apps/tree/services/trips/operations.py
+++ b/tasks/apps/tree/services/trips/operations.py
@@ -8,7 +8,7 @@ either all commit or none do.
 from datetime import timedelta
 
 from django.conf import settings
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 
 from ...models import JournalAdded, PhotoAdded, Story, StoryEvent, Thread
@@ -53,6 +53,17 @@ def _get_owned_story(user, story_id):
         ) from e
 
 
+def _existing_event(model, idempotency_key):
+    """The event previously created for ``idempotency_key``, or None.
+
+    Used for exactly-once writes: a retried request (whose first response was
+    lost) re-uses the existing event instead of creating a duplicate.
+    """
+    if not idempotency_key:
+        return None
+    return model.objects.filter(idempotency_key=idempotency_key).first()
+
+
 @transaction.atomic
 def start_trip(user, title=None, type_=Story.Type.TRIP, started=None):
     """Create and persist a new Story for the user.
@@ -90,23 +101,44 @@ def update_trip(user, story_id, title=None):
 
 
 @transaction.atomic
-def add_trip_note(user, story_id, comment, published=None):
+def add_trip_note(user, story_id, comment, published=None, idempotency_key=None):
     """Create a JournalAdded linked to ``story``, processed through the
     journalling pipeline so embedded hashtags create HabitTracked
     entries that are also linked to the story.
 
     Raises ``StoryStoppedError`` if the story is already stopped.
+
+    ``idempotency_key`` makes the write exactly-once: a retry carrying a key
+    that already produced a note returns that same note. The lookup runs
+    *before* the stopped check so re-delivering an already-saved note succeeds
+    even if the trip was stopped in the meantime.
     """
     story = _get_owned_story(user, story_id)
+
+    existing = _existing_event(JournalAdded, idempotency_key)
+    if existing is not None:
+        return existing
+
     if story.stopped is not None:
         raise StoryStoppedError(f"Story #{story_id} is stopped; cannot add new notes.")
 
-    journal_added = JournalAdded.objects.create(
-        thread=_journal_thread_for(user),
-        comment=comment,
-        published=published or timezone.now(),
-    )
-    process_journal_entry(journal_added, story=story)
+    try:
+        # Nested savepoint so a unique-key collision (concurrent retry) rolls
+        # back only this insert, leaving the outer transaction usable for the
+        # re-fetch below.
+        with transaction.atomic():
+            journal_added = JournalAdded.objects.create(
+                thread=_journal_thread_for(user),
+                comment=comment,
+                published=published or timezone.now(),
+                idempotency_key=idempotency_key,
+            )
+            process_journal_entry(journal_added, story=story)
+    except IntegrityError:
+        existing = _existing_event(JournalAdded, idempotency_key)
+        if existing is not None:
+            return existing
+        raise
     return journal_added
 
 
@@ -141,15 +173,27 @@ def _capture_datetime_from_storage(key):
 
 
 @transaction.atomic
-def add_trip_photo(user, story_id, key, comment, content_type, published=None):
+def add_trip_photo(
+    user, story_id, key, comment, content_type, published=None, idempotency_key=None
+):
     """Confirm an uploaded photo: create a PhotoAdded linked to ``story`` and
     run it through the journalling pipeline (so a ``#poi`` line in ``comment``
     still creates a HabitTracked). Enqueues the thumbnail task on commit.
 
     Raises ``StoryStoppedError`` if stopped, ``PhotoObjectMissingError`` if the
     object isn't in the bucket (or the key doesn't belong to this user/story).
+
+    ``idempotency_key`` makes the confirm exactly-once: a retry carrying a key
+    that already produced a photo returns that same photo (checked before the
+    stopped/object existence guards, so a re-delivered confirm succeeds even
+    after the trip stopped or the S3 object was swept).
     """
     story = _get_owned_story(user, story_id)
+
+    existing = _existing_event(PhotoAdded, idempotency_key)
+    if existing is not None:
+        return existing
+
     if story.stopped is not None:
         raise StoryStoppedError(f"Story #{story_id} is stopped; cannot add photos.")
     if not key_belongs_to(key, user.pk, story_id):
@@ -163,14 +207,24 @@ def add_trip_photo(user, story_id, key, comment, content_type, published=None):
     # the correct date.
     captured = _capture_datetime_from_storage(key)
 
-    photo = PhotoAdded.objects.create(
-        thread=_journal_thread_for(user),
-        comment=comment,
-        original_key=key,
-        content_type=content_type,
-        published=captured or published or timezone.now(),
-    )
-    process_journal_entry(photo, story=story)
+    try:
+        # Nested savepoint so a unique-key collision (concurrent retry) rolls
+        # back only this insert, leaving the outer transaction usable.
+        with transaction.atomic():
+            photo = PhotoAdded.objects.create(
+                thread=_journal_thread_for(user),
+                comment=comment,
+                original_key=key,
+                content_type=content_type,
+                published=captured or published or timezone.now(),
+                idempotency_key=idempotency_key,
+            )
+            process_journal_entry(photo, story=story)
+    except IntegrityError:
+        existing = _existing_event(PhotoAdded, idempotency_key)
+        if existing is not None:
+            return existing
+        raise
 
     # Import here to avoid importing celery tasks at module load.
     from ...tasks import generate_photo_thumbnail

--- a/tasks/apps/tree/tests/test_photo_api.py
+++ b/tasks/apps/tree/tests/test_photo_api.py
@@ -42,18 +42,25 @@ class PhotoAPITestCase(APITestCase):
         )
 
     def _confirm(
-        self, story_id, key, comment="", content_type="image/jpeg", published=PUB_AT
+        self,
+        story_id,
+        key,
+        comment="",
+        content_type="image/jpeg",
+        published=PUB_AT,
+        idempotency_key=None,
     ):
+        payload = {
+            "story_id": story_id,
+            "key": key,
+            "comment": comment,
+            "content_type": content_type,
+            "published": published,
+        }
+        if idempotency_key is not None:
+            payload["idempotency_key"] = idempotency_key
         return self.client.post(
-            reverse("android-trip-photo-confirm"),
-            {
-                "story_id": story_id,
-                "key": key,
-                "comment": comment,
-                "content_type": content_type,
-                "published": published,
-            },
-            format="json",
+            reverse("android-trip-photo-confirm"), payload, format="json"
         )
 
     # --- presign ---
@@ -109,6 +116,19 @@ class PhotoAPITestCase(APITestCase):
         self.assertTrue(
             StoryEvent.objects.filter(story=self.story, event=photo).exists()
         )
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_confirm_idempotency_key_dedupes(self, _exists):
+        # A retried confirm with the same idempotency_key returns the same
+        # photo_id and creates exactly one PhotoAdded + one StoryEvent link.
+        key = f"trips/{self.user.pk}/{self.story.pk}/abc.jpg"
+        first = self._confirm(self.story.pk, key, idempotency_key="ph-123")
+        second = self._confirm(self.story.pk, key, idempotency_key="ph-123")
+        self.assertEqual(first.status_code, status.HTTP_200_OK)
+        self.assertEqual(second.status_code, status.HTTP_200_OK)
+        self.assertEqual(first.data["photo_id"], second.data["photo_id"])
+        self.assertEqual(PhotoAdded.objects.filter(idempotency_key="ph-123").count(), 1)
+        self.assertEqual(StoryEvent.objects.filter(story=self.story).count(), 1)
 
     @mock.patch(f"{STORAGE}.object_exists", return_value=False)
     def test_confirm_missing_object_409(self, _exists):

--- a/tasks/apps/tree/tests/test_trip_api.py
+++ b/tasks/apps/tree/tests/test_trip_api.py
@@ -46,12 +46,11 @@ class TripAPITestCase(APITestCase):
             format="json",
         )
 
-    def _note(self, story_id, comment, published=PUB_AT):
-        return self.client.post(
-            reverse("android-trip-note"),
-            {"story_id": story_id, "comment": comment, "published": published},
-            format="json",
-        )
+    def _note(self, story_id, comment, published=PUB_AT, idempotency_key=None):
+        payload = {"story_id": story_id, "comment": comment, "published": published}
+        if idempotency_key is not None:
+            payload["idempotency_key"] = idempotency_key
+        return self.client.post(reverse("android-trip-note"), payload, format="json")
 
     def _list(self, page=1, page_size=20):
         return self.client.get(
@@ -154,6 +153,21 @@ class TripAPITestCase(APITestCase):
         self._auth(self.other_token)
         r = self._note(sid, "leak attempt")
         self.assertEqual(r.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_note_idempotency_key_dedupes(self):
+        # A retried POST with the same idempotency_key returns the same
+        # journal_id and creates exactly one event + one StoryEvent link.
+        self._auth()
+        sid = self._start().json()["story"]["id"]
+        first = self._note(sid, "walking", idempotency_key="abc-123")
+        second = self._note(sid, "walking", idempotency_key="abc-123")
+        self.assertEqual(first.status_code, status.HTTP_200_OK)
+        self.assertEqual(second.status_code, status.HTTP_200_OK)
+        self.assertEqual(first.json()["journal_id"], second.json()["journal_id"])
+        self.assertEqual(
+            JournalAdded.objects.filter(idempotency_key="abc-123").count(), 1
+        )
+        self.assertEqual(StoryEvent.objects.filter(story_id=sid).count(), 1)
 
     def test_list_returns_active_and_history(self):
         self._auth()

--- a/tasks/apps/tree/tests/test_trip_service.py
+++ b/tasks/apps/tree/tests/test_trip_service.py
@@ -133,6 +133,63 @@ class TripServiceTestCase(TestCase):
         with self.assertRaises(StoryNotFoundError):
             add_trip_note(self.bob, story.pk, comment="ha", published=timezone.now())
 
+    def test_add_trip_note_idempotency_returns_same_note(self):
+        # A retried note carrying the same key creates exactly one event.
+        story = start_trip(self.alice)
+        published = timezone.now()
+        first = add_trip_note(
+            self.alice,
+            story.pk,
+            comment="walk",
+            published=published,
+            idempotency_key="note-key-1",
+        )
+        second = add_trip_note(
+            self.alice,
+            story.pk,
+            comment="walk",
+            published=published,
+            idempotency_key="note-key-1",
+        )
+        self.assertEqual(first.pk, second.pk)
+        self.assertEqual(
+            JournalAdded.objects.filter(idempotency_key="note-key-1").count(), 1
+        )
+        self.assertEqual(StoryEvent.objects.filter(story=story, event=first).count(), 1)
+
+    def test_add_trip_note_idempotent_retry_succeeds_after_stop(self):
+        # The first call's response was lost, the trip was then stopped, and the
+        # outbox retries: the dedup lookup precedes the stopped check, so the
+        # retry returns the original note instead of raising StoryStoppedError.
+        story = start_trip(self.alice)
+        first = add_trip_note(
+            self.alice,
+            story.pk,
+            comment="walk",
+            published=timezone.now(),
+            idempotency_key="note-key-2",
+        )
+        stop_trip(self.alice, story.pk)
+        second = add_trip_note(
+            self.alice,
+            story.pk,
+            comment="walk",
+            published=timezone.now(),
+            idempotency_key="note-key-2",
+        )
+        self.assertEqual(first.pk, second.pk)
+
+    def test_add_trip_note_without_key_allows_duplicates(self):
+        # No key => current at-least-once behavior is preserved.
+        story = start_trip(self.alice)
+        a = add_trip_note(
+            self.alice, story.pk, comment="same", published=timezone.now()
+        )
+        b = add_trip_note(
+            self.alice, story.pk, comment="same", published=timezone.now()
+        )
+        self.assertNotEqual(a.pk, b.pk)
+
     def test_list_active_returns_only_users_active_trips(self):
         a1 = start_trip(self.alice)
         a2 = start_trip(self.alice)
@@ -249,6 +306,35 @@ class TripPhotoServiceTestCase(TestCase):
         self.assertEqual(photo.original_key, key)
         self.assertIsNone(photo.thumbnail_key)
         self.assertTrue(StoryEvent.objects.filter(story=story, event=photo).exists())
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_add_trip_photo_idempotency_returns_same_photo(self, _exists):
+        # A retried confirm carrying the same key creates exactly one photo.
+        story = start_trip(self.alice)
+        key = f"trips/{self.alice.pk}/{story.pk}/abc.jpg"
+        first = add_trip_photo(
+            self.alice,
+            story.pk,
+            key=key,
+            comment="sunset",
+            content_type="image/jpeg",
+            published=timezone.now(),
+            idempotency_key="photo-key-1",
+        )
+        second = add_trip_photo(
+            self.alice,
+            story.pk,
+            key=key,
+            comment="sunset",
+            content_type="image/jpeg",
+            published=timezone.now(),
+            idempotency_key="photo-key-1",
+        )
+        self.assertEqual(first.pk, second.pk)
+        self.assertEqual(
+            PhotoAdded.objects.filter(idempotency_key="photo-key-1").count(), 1
+        )
+        self.assertEqual(StoryEvent.objects.filter(story=story, event=first).count(), 1)
 
     @mock.patch(f"{STORAGE}.object_exists", return_value=True)
     def test_add_trip_photo_with_poi_creates_habittracked(self, _exists):

--- a/tasks/apps/tree/views_android_trip.py
+++ b/tasks/apps/tree/views_android_trip.py
@@ -172,9 +172,16 @@ class AndroidTripNoteView(APIView):
         published = _parse_datetime(request.data.get("published"))
         if published is None:
             return _bad_request("published is required (full ISO 8601 timestamp)")
+        idempotency_key = request.data.get("idempotency_key")
+        if idempotency_key is not None and not isinstance(idempotency_key, str):
+            return _bad_request("idempotency_key must be a string")
         try:
             journal = add_trip_note(
-                request.user, story_id, comment=comment, published=published
+                request.user,
+                story_id,
+                comment=comment,
+                published=published,
+                idempotency_key=idempotency_key,
             )
         except StoryNotFoundError:
             return _not_found()
@@ -287,6 +294,9 @@ class AndroidTripPhotoConfirmView(APIView):
         published = _parse_datetime(request.data.get("published"))
         if published is None:
             return _bad_request("published is required (full ISO 8601 timestamp)")
+        idempotency_key = request.data.get("idempotency_key")
+        if idempotency_key is not None and not isinstance(idempotency_key, str):
+            return _bad_request("idempotency_key must be a string")
         try:
             photo = add_trip_photo(
                 request.user,
@@ -295,6 +305,7 @@ class AndroidTripPhotoConfirmView(APIView):
                 comment=comment,
                 content_type=content_type,
                 published=published,
+                idempotency_key=idempotency_key,
             )
         except StoryNotFoundError:
             return _not_found()


### PR DESCRIPTION
## Why

Trip notes and photos were sent **inline** — `TripDetailViewModel.sendNote()`/`sendPhoto()` fired the network call directly and, on any failure, just set an error and **discarded the captured entry**. The real failure this fixes: a photo taken off-grid already had its GPS frozen into the comment (`#poi lat=… lng=…`), but the upload timed out and the whole entry vanished, coordinates and all.

## What

A durable **outbox**: every send is frozen to disk and delivered by a background worker that retries when connectivity returns. Because retries are at-least-once, the backend gains **idempotency keys** so a request whose response was lost is never duplicated. Queued items show **inline** in the trip timeline so you always see what's captured vs. still local.

### Android
- **File-based queue** (`data/Outbox`, `data/OutboxItem`) under `filesDir/outbox/` — one JSON file per item, photo bytes in a sibling file. Comment (incl. the `#poi` line), `published`, and photo bytes are all frozen at enqueue (the picker's content `Uri` isn't durable, so bytes are copied immediately).
- **`sync/OutboxDrainer`** — pure per-item delivery (note: one POST; photo: resume-aware presign → PUT → confirm that never re-uploads a successful PUT), classifying failures as retryable (IO / 5xx / 401 / 429) vs permanent (other 4xx).
- **`sync/OutboxWorker` + `SyncScheduler.drainOutbox`** — network-constrained, exponential backoff; kicked on every send and on app start (resumes after reboot/kill).
- **`TripDetailScreen`** — pending notes/photos render inline with a *Waiting to sync / Syncing…* status, a per-trip badge, and Retry/Discard on permanent failure. Sends are now instant (no upload spinner).

### Backend (exactly-once)
- **`Event.idempotency_key`** — nullable field + partial unique constraint on the generic polymorphic base (not on `JournalAdded`), so any event-creating endpoint can opt into exactly-once, not just trip notes/photos. Migration `0071_event_idempotency_key`.
- **`add_trip_note` / `add_trip_photo`** dedupe on the key **before** the stopped/object-existence checks (so a retry of an already-saved write returns the original even if the trip was stopped meanwhile), with a nested-savepoint + `IntegrityError` fallback for the concurrent-retry race.
- Note/photo-confirm views parse an optional `idempotency_key` (backward compatible).

## Testing
- **Backend:** `makemigrations --check` → no drift; **63 trip/photo tests pass**, incl. 5 new idempotency tests (note + photo, service + API level, and the retry-after-stop case).
- **Android:** `testDebugUnitTest` green incl. new `OutboxTest` (7) and `OutboxDrainerTest` (7 — resume-skip, 4xx-permanent, 5xx/IO-retry, missing-bytes); `assembleDebug` succeeds.
- **Manual (left for device):** airplane-mode drill — add a note + photo offline → both show *Waiting to sync*; re-enable network → worker drains, rows flip to synced with original `#poi` coords and capture time; re-trigger mid-flight → no duplicates.

## Notes / follow-ups
- Out of scope: a global pending badge on `TripsScreen` (across all trips), and a design doc for the outbox.
- The `android/` project has no `gradlew` wrapper script or `gradle-wrapper.jar` (only `gradle-wrapper.properties`); I ran the cached Gradle 9.4.1 distribution directly. Worth committing a wrapper for CI/other machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)