### PR TITLE
feat(trips): location breadcrumbs to back-date photo coordinates

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,14 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
+    <!-- Foreground service that records the trip's location breadcrumb trail.
+         Type "location" lets it sample in the background on a while-in-use
+         grant, so no ACCESS_BACKGROUND_LOCATION is needed. POST_NOTIFICATIONS
+         (Android 13+) is for the required ongoing service notification. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <uses-permission android:name="android.permission.health.READ_STEPS" />
     <uses-permission android:name="android.permission.health.READ_DISTANCE" />
     <uses-permission android:name="android.permission.health.READ_EXERCISE" />
@@ -60,6 +68,11 @@
                 <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE" />
             </intent-filter>
         </activity-alias>
+
+        <service
+            android:name=".location.TripLocationService"
+            android:exported="false"
+            android:foregroundServiceType="location" />
 
     </application>
 </manifest>

--- a/android/app/src/main/java/org/polybrain/tasks/health/data/Breadcrumb.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/Breadcrumb.kt
@@ -1,0 +1,18 @@
+package org.polybrain.tasks.health.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * One recorded location sample on a trip's breadcrumb trail.
+ *
+ * [t] is the sample's wall-clock moment (epoch millis) — the key used to match
+ * a photo to where it was taken. Kept deliberately tiny: a long trip records
+ * thousands of these, one NDJSON line each.
+ */
+@Serializable
+data class Breadcrumb(
+    val t: Long,
+    val lat: Double,
+    val lng: Double,
+    val acc: Float? = null,
+)

--- a/android/app/src/main/java/org/polybrain/tasks/health/data/BreadcrumbStore.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/BreadcrumbStore.kt
@@ -1,0 +1,55 @@
+package org.polybrain.tasks.health.data
+
+import android.content.Context
+import java.io.File
+import kotlinx.serialization.json.Json
+
+/**
+ * Append-only local log of a trip's location [Breadcrumb]s.
+ *
+ * One JSON object per line (NDJSON) in [file], so each new sample is a cheap
+ * append — no rewrite of the growing file. The location service is the only
+ * writer (single-threaded callback); readers tolerate a torn final line via
+ * per-line parsing. Takes a [File] (Context convenience ctor) so it is
+ * unit-testable on the JVM with a temp file, mirroring [Outbox].
+ */
+class BreadcrumbStore(private val file: File) {
+
+    constructor(context: Context) : this(File(context.filesDir, "breadcrumbs.log"))
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    fun append(crumb: Breadcrumb) {
+        file.parentFile?.mkdirs()
+        // Append a single line; FileWriter(append=true) keeps the O(1) cost.
+        java.io.FileWriter(file, true).use { w ->
+            w.append(json.encodeToString(Breadcrumb.serializer(), crumb))
+            w.append('\n')
+        }
+    }
+
+    /** All breadcrumbs, oldest first. Skips any unparseable (e.g. torn) line. */
+    fun all(): List<Breadcrumb> {
+        if (!file.exists()) return emptyList()
+        return file.readLines()
+            .mapNotNull { line ->
+                if (line.isBlank()) {
+                    null
+                } else {
+                    runCatching { json.decodeFromString(Breadcrumb.serializer(), line) }.getOrNull()
+                }
+            }
+            .sortedBy { it.t }
+    }
+
+    fun lastAtOrBefore(t: Long): Breadcrumb? = all().lastOrNull { it.t <= t }
+
+    fun firstAtOrAfter(t: Long): Breadcrumb? = all().firstOrNull { it.t >= t }
+
+    fun clear() {
+        file.delete()
+    }
+}

--- a/android/app/src/main/java/org/polybrain/tasks/health/data/Settings.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/Settings.kt
@@ -80,11 +80,38 @@ class Settings(private val context: Context) {
         }
     }
 
+    /**
+     * Story ids whose trips are currently being location-tracked on this phone.
+     * The local source of truth for whether [TripLocationService] should run:
+     * survives an app kill (tracking resumes on reopen) but not a reboot.
+     */
+    suspend fun trackedStoryIds(): Set<String> =
+        context.dataStore.data.first()[TRACKED_STORY_IDS].orEmpty()
+
+    suspend fun addTrackedStoryId(id: Long) {
+        context.dataStore.edit { prefs ->
+            prefs[TRACKED_STORY_IDS] = prefs[TRACKED_STORY_IDS].orEmpty() + id.toString()
+        }
+    }
+
+    suspend fun removeTrackedStoryId(id: Long) {
+        context.dataStore.edit { prefs ->
+            prefs[TRACKED_STORY_IDS] = prefs[TRACKED_STORY_IDS].orEmpty() - id.toString()
+        }
+    }
+
+    suspend fun replaceTrackedStoryIds(ids: Collection<Long>) {
+        context.dataStore.edit { prefs ->
+            prefs[TRACKED_STORY_IDS] = ids.map { it.toString() }.toSet()
+        }
+    }
+
     private companion object {
         val SERVER_URL = stringPreferencesKey("server_url")
         val API_TOKEN = stringPreferencesKey("api_token")
         val LAST_SYNC_MS = longPreferencesKey("last_sync_ms")
         val LAST_SYNC_ERROR = stringPreferencesKey("last_sync_error")
         val SYNCED_BIKE_SESSION_IDS = stringSetPreferencesKey("synced_bike_session_ids")
+        val TRACKED_STORY_IDS = stringSetPreferencesKey("tracked_story_ids")
     }
 }

--- a/android/app/src/main/java/org/polybrain/tasks/health/location/PhotoLocationResolver.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/location/PhotoLocationResolver.kt
@@ -1,0 +1,68 @@
+package org.polybrain.tasks.health.location
+
+import kotlin.math.abs
+import kotlin.math.asin
+import kotlin.math.cos
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.math.sqrt
+import org.polybrain.tasks.health.data.Breadcrumb
+
+/**
+ * Derives a photo's location from a trip's breadcrumb trail, by the photo's
+ * capture time — so you can curate/upload photos long after (and far from)
+ * where they were taken and still attach the right coordinates.
+ *
+ * Rule (see plan): take the breadcrumbs immediately before and after the
+ * capture time.
+ *  - If the nearer one is within [DIRECT_MATCH_MS] → use it (direct hit).
+ *  - Otherwise the capture time sits in a tracking gap; only trust it if it is
+ *    bracketed by two points less than [STATIONARY_METERS] apart (you were in
+ *    one place) and use the closer-in-time one. Never interpolate across a
+ *    move — return null so the caller sends the photo without a location.
+ */
+object PhotoLocationResolver {
+
+    private const val DIRECT_MATCH_MS = 2 * 60 * 1000L
+    private const val STATIONARY_METERS = 200.0
+
+    fun resolve(breadcrumbs: List<Breadcrumb>, captureMs: Long): LocationFix? {
+        if (breadcrumbs.isEmpty()) return null
+
+        val before = breadcrumbs.filter { it.t <= captureMs }.maxByOrNull { it.t }
+        val after = breadcrumbs.filter { it.t >= captureMs }.minByOrNull { it.t }
+        val nearest = closer(before, after, captureMs)
+
+        if (nearest != null && abs(nearest.t - captureMs) <= DIRECT_MATCH_MS) {
+            return nearest.toFix()
+        }
+
+        // In a >2 min gap: only trust a bracket of two nearby points.
+        if (before != null && after != null &&
+            haversineMeters(before.lat, before.lng, after.lat, after.lng) < STATIONARY_METERS
+        ) {
+            return closer(before, after, captureMs)!!.toFix()
+        }
+
+        return null
+    }
+
+    private fun closer(a: Breadcrumb?, b: Breadcrumb?, t: Long): Breadcrumb? {
+        if (a == null) return b
+        if (b == null) return a
+        return if (abs(a.t - t) <= abs(b.t - t)) a else b
+    }
+
+    private fun Breadcrumb.toFix() = LocationFix(lat = lat, lng = lng, accuracyMeters = acc)
+
+    /** Great-circle distance in metres between two lat/lng points. */
+    fun haversineMeters(lat1: Double, lng1: Double, lat2: Double, lng2: Double): Double {
+        val earthRadius = 6_371_000.0
+        val dLat = Math.toRadians(lat2 - lat1)
+        val dLng = Math.toRadians(lng2 - lng1)
+        val a = sin(dLat / 2).pow(2) +
+            cos(Math.toRadians(lat1)) * cos(Math.toRadians(lat2)) * sin(dLng / 2).pow(2)
+        return 2 * earthRadius * asin(min(1.0, sqrt(a)))
+    }
+}

--- a/android/app/src/main/java/org/polybrain/tasks/health/location/TripLocationService.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/location/TripLocationService.kt
@@ -1,0 +1,183 @@
+package org.polybrain.tasks.health.location
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageManager
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.os.Looper
+import android.os.PowerManager
+import androidx.core.app.NotificationCompat
+import androidx.core.app.ServiceCompat
+import androidx.core.content.ContextCompat
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationResult
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import org.polybrain.tasks.health.MainActivity
+import org.polybrain.tasks.health.R
+import org.polybrain.tasks.health.data.Breadcrumb
+import org.polybrain.tasks.health.data.BreadcrumbStore
+
+/**
+ * Foreground service that records a [Breadcrumb] trail while a trip is active.
+ *
+ * Sampling cadence adapts to screen state — every [ACTIVE_INTERVAL_MS] while
+ * the phone is interactive, every [IDLE_INTERVAL_MS] while it's locked — to
+ * keep a useful trail without draining the battery. Lifecycle is driven by
+ * [TripTracker]; this service just samples while running.
+ *
+ * Type `location` + a started-from-foreground app means we sample in the
+ * background on a while-in-use grant, with no `ACCESS_BACKGROUND_LOCATION`.
+ */
+class TripLocationService : Service() {
+
+    private lateinit var client: FusedLocationProviderClient
+    private lateinit var store: BreadcrumbStore
+    private var interactive = true
+    private var started = false
+
+    private val callback = object : LocationCallback() {
+        override fun onLocationResult(result: LocationResult) {
+            for (location in result.locations) {
+                store.append(
+                    Breadcrumb(
+                        t = if (location.time > 0) location.time else System.currentTimeMillis(),
+                        lat = location.latitude,
+                        lng = location.longitude,
+                        acc = if (location.hasAccuracy()) location.accuracy else null,
+                    )
+                )
+            }
+        }
+    }
+
+    // SCREEN_ON/OFF are sticky system broadcasts that must be registered at
+    // runtime; flipping interactive re-requests updates at the new cadence.
+    private val screenReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            when (intent.action) {
+                Intent.ACTION_SCREEN_ON -> setInteractive(true)
+                Intent.ACTION_SCREEN_OFF -> setInteractive(false)
+            }
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        client = LocationServices.getFusedLocationProviderClient(this)
+        store = BreadcrumbStore(this)
+        interactive = (getSystemService(Context.POWER_SERVICE) as PowerManager).isInteractive
+        ContextCompat.registerReceiver(
+            this,
+            screenReceiver,
+            IntentFilter().apply {
+                addAction(Intent.ACTION_SCREEN_ON)
+                addAction(Intent.ACTION_SCREEN_OFF)
+            },
+            ContextCompat.RECEIVER_NOT_EXPORTED,
+        )
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (!hasLocationPermission()) {
+            // Started without the location grant (e.g. the user denied it).
+            // Do NOT promote to a location-type foreground service — that throws
+            // on Android 14+. Stop cleanly before the start-timeout instead.
+            stopSelf()
+            return START_NOT_STICKY
+        }
+        startForegroundNotification()
+        if (!started) {
+            started = true
+            requestUpdates()
+        }
+        // Re-create the service (and resume sampling) if the OS kills it.
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        client.removeLocationUpdates(callback)
+        runCatching { unregisterReceiver(screenReceiver) }
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent): IBinder? = null
+
+    private fun setInteractive(value: Boolean) {
+        if (interactive == value || !started) return
+        interactive = value
+        requestUpdates()
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun requestUpdates() {
+        if (!hasLocationPermission()) return
+        client.removeLocationUpdates(callback)
+        val intervalMs = if (interactive) ACTIVE_INTERVAL_MS else IDLE_INTERVAL_MS
+        val request = LocationRequest.Builder(
+            Priority.PRIORITY_BALANCED_POWER_ACCURACY,
+            intervalMs,
+        ).build()
+        client.requestLocationUpdates(request, callback, Looper.getMainLooper())
+    }
+
+    private fun hasLocationPermission(): Boolean =
+        ContextCompat.checkSelfPermission(
+            this, Manifest.permission.ACCESS_FINE_LOCATION,
+        ) == PackageManager.PERMISSION_GRANTED
+
+    private fun startForegroundNotification() {
+        val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                getString(R.string.trip_tracking_channel_name),
+                NotificationManager.IMPORTANCE_LOW,
+            )
+            manager.createNotificationChannel(channel)
+        }
+        val openApp = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, MainActivity::class.java),
+            PendingIntent.FLAG_IMMUTABLE,
+        )
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(getString(R.string.trip_tracking_notification_title))
+            .setContentText(getString(R.string.trip_tracking_notification_text))
+            .setSmallIcon(android.R.drawable.ic_menu_mylocation)
+            .setOngoing(true)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setContentIntent(openApp)
+            .build()
+        ServiceCompat.startForeground(
+            this,
+            NOTIFICATION_ID,
+            notification,
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
+            } else {
+                0
+            },
+        )
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "trip_location"
+        private const val NOTIFICATION_ID = 4201
+        private const val ACTIVE_INTERVAL_MS = 30_000L
+        private const val IDLE_INTERVAL_MS = 120_000L
+    }
+}

--- a/android/app/src/main/java/org/polybrain/tasks/health/location/TripTracker.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/location/TripTracker.kt
@@ -1,0 +1,61 @@
+package org.polybrain.tasks.health.location
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.ContextCompat
+import org.polybrain.tasks.health.data.BreadcrumbStore
+import org.polybrain.tasks.health.data.Settings
+
+/**
+ * Drives [TripLocationService]'s lifecycle off the set of locally-tracked
+ * trips ([Settings.trackedStoryIds]) — the analogue of `SyncScheduler` for the
+ * outbox. The service runs whenever that set is non-empty; when it empties
+ * (the last active trip stopped) the service is stopped and the breadcrumb log
+ * is cleared.
+ *
+ * All entry points are `suspend` because they touch DataStore; call them from
+ * a coroutine (the trip ViewModels already do).
+ */
+object TripTracker {
+
+    /** Begin tracking a newly started trip. */
+    suspend fun start(context: Context, storyId: Long) {
+        val settings = Settings(context.applicationContext)
+        settings.addTrackedStoryId(storyId)
+        ensureService(context.applicationContext, settings)
+    }
+
+    /** Stop tracking a trip that was just stopped. */
+    suspend fun stop(context: Context, storyId: Long) {
+        val settings = Settings(context.applicationContext)
+        settings.removeTrackedStoryId(storyId)
+        ensureService(context.applicationContext, settings)
+    }
+
+    /**
+     * Align tracking with the server's current active trips (e.g. a trip
+     * stopped from the web turns tracking off; one started elsewhere turns it
+     * on). Call after a trip-list reload.
+     */
+    suspend fun reconcile(context: Context, activeIds: Collection<Long>) {
+        val settings = Settings(context.applicationContext)
+        settings.replaceTrackedStoryIds(activeIds)
+        ensureService(context.applicationContext, settings)
+    }
+
+    /** Restart the service on app open if trips were being tracked (post app-kill). */
+    suspend fun resumeIfNeeded(context: Context) {
+        ensureService(context.applicationContext, Settings(context.applicationContext))
+    }
+
+    private suspend fun ensureService(appContext: Context, settings: Settings) {
+        val intent = Intent(appContext, TripLocationService::class.java)
+        if (settings.trackedStoryIds().isNotEmpty()) {
+            ContextCompat.startForegroundService(appContext, intent)
+        } else {
+            appContext.stopService(intent)
+            // No active trip owns the trail anymore — drop it.
+            BreadcrumbStore(appContext).clear()
+        }
+    }
+}

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/MainViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/MainViewModel.kt
@@ -10,6 +10,7 @@ import org.polybrain.tasks.health.data.Settings
 import org.polybrain.tasks.health.data.SettingsSnapshot
 import org.polybrain.tasks.health.data.TasksClient
 import org.polybrain.tasks.health.data.TrackHabitTextRequest
+import org.polybrain.tasks.health.location.TripTracker
 import org.polybrain.tasks.health.sync.SyncScheduler
 import java.time.LocalDate
 import java.time.OffsetDateTime
@@ -68,6 +69,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         // The worker no-ops when unconfigured, so this is safe to call always.
         SyncScheduler.drainOutbox(application)
         viewModelScope.launch {
+            // Resume location tracking if a trip was being tracked before the
+            // app was killed (the foreground service doesn't survive that).
+            TripTracker.resumeIfNeeded(getApplication())
             refreshPermissionState()
             if (_permissionsGranted.value) refreshMetrics()
         }

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/AddPhotoDialog.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/AddPhotoDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -25,6 +26,10 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 import org.polybrain.tasks.health.R
 
 @Composable
@@ -59,12 +64,28 @@ fun AddPhotoDialog(vm: TripDetailViewModel) {
                             .aspectRatio(4f / 3f),
                     )
                 }
-                GpsStatusBlock(
-                    state = gps,
-                    onRequestPermission = {
-                        permissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
-                    },
-                )
+                val gpsState = gps
+                if (gpsState is TripDetailViewModel.GpsState.Ready &&
+                    gpsState.source == TripDetailViewModel.GpsSource.TRACK
+                ) {
+                    // A photo's location comes from the recorded trip track, not
+                    // a live fix — say so, with the capture time it was matched to.
+                    Text(
+                        text = stringResource(
+                            R.string.trip_note_gps_from_track,
+                            formatTrackTime(gpsState.atMillis),
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                } else {
+                    GpsStatusBlock(
+                        state = gps,
+                        onRequestPermission = {
+                            permissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+                        },
+                    )
+                }
                 if (gps is TripDetailViewModel.GpsState.Denied ||
                     gps is TripDetailViewModel.GpsState.Unavailable
                 ) {
@@ -101,3 +122,9 @@ fun AddPhotoDialog(vm: TripDetailViewModel) {
         },
     )
 }
+
+private val TRACK_TIME_FORMAT: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("HH:mm", Locale.US).withZone(ZoneId.systemDefault())
+
+private fun formatTrackTime(millis: Long?): String =
+    if (millis == null) "" else TRACK_TIME_FORMAT.format(Instant.ofEpochMilli(millis))

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripDetailViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripDetailViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.polybrain.tasks.health.data.BreadcrumbStore
 import org.polybrain.tasks.health.data.Outbox
 import org.polybrain.tasks.health.data.OutboxItem
 import org.polybrain.tasks.health.data.Settings
@@ -35,6 +36,8 @@ import org.polybrain.tasks.health.data.TripSummary
 import org.polybrain.tasks.health.data.TripUpdateRequest
 import org.polybrain.tasks.health.location.LocationFix
 import org.polybrain.tasks.health.location.LocationProvider
+import org.polybrain.tasks.health.location.PhotoLocationResolver
+import org.polybrain.tasks.health.location.TripTracker
 import org.polybrain.tasks.health.sync.SyncScheduler
 
 class TripDetailViewModel(application: Application) : AndroidViewModel(application) {
@@ -42,6 +45,7 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
     private val settings = Settings(application)
     private val locationProvider = LocationProvider(application)
     private val outbox = Outbox(application)
+    private val breadcrumbStore = BreadcrumbStore(application)
     private val workManager = WorkManager.getInstance(application)
 
     private val _story = MutableStateFlow<TripSummary?>(null)
@@ -94,10 +98,18 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
      * GPS resolution state. The dialog reads this to decide whether to
      * gate the Send button and what hint to show.
      */
+    /** Where a Ready fix came from: a live GPS read (notes) or the trip's recorded track (photos). */
+    enum class GpsSource { LIVE, TRACK }
+
     sealed class GpsState {
         object Idle : GpsState()
         object Waiting : GpsState()
-        data class Ready(val fix: LocationFix) : GpsState()
+        data class Ready(
+            val fix: LocationFix,
+            val source: GpsSource = GpsSource.LIVE,
+            // For TRACK: the photo's capture time, shown in the dialog hint.
+            val atMillis: Long? = null,
+        ) : GpsState()
         object Denied : GpsState()
         object Unavailable : GpsState()
     }
@@ -154,11 +166,32 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
         _allowNoLocation.value = false
     }
 
-    /** Open the add-photo dialog for a picked image and resolve GPS. */
+    /**
+     * Open the add-photo dialog for a picked image. Unlike a note, a photo's
+     * location comes from the trip's recorded breadcrumb trail at the photo's
+     * capture time (so an old photo gets where it was *taken*, not where you
+     * are now) — never a fresh fix.
+     */
     fun openAddPhoto(uri: Uri) {
         _selectedPhoto.value = uri
         _photoDialogOpen.value = true
-        startGpsResolution()
+        _allowNoLocation.value = false
+        _gps.value = GpsState.Waiting
+        viewModelScope.launch {
+            val captureMs = withContext(Dispatchers.IO) {
+                captureMillisFor(uri) ?: System.currentTimeMillis()
+            }
+            val fix = withContext(Dispatchers.IO) {
+                PhotoLocationResolver.resolve(breadcrumbStore.all(), captureMs)
+            }
+            _gps.value = if (fix != null) {
+                GpsState.Ready(fix, GpsSource.TRACK, captureMs)
+            } else {
+                // No trusted track location for this photo's time — the dialog
+                // offers "send without location".
+                GpsState.Unavailable
+            }
+        }
     }
 
     fun closeAddPhoto() {
@@ -284,8 +317,21 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
      * with the original's EXIF DateTimeOriginal when the file carries one.
      */
     private fun captureTimeFor(uri: Uri): String {
+        val millis = captureMillisFor(uri)
+        return if (millis != null) {
+            OffsetDateTime.ofInstant(
+                Instant.ofEpochMilli(millis),
+                ZoneId.systemDefault(),
+            ).toString()
+        } else {
+            OffsetDateTime.now().toString()
+        }
+    }
+
+    /** The gallery's DATE_TAKEN (epoch millis), or null when absent. */
+    private fun captureMillisFor(uri: Uri): Long? {
         val resolver = getApplication<Application>().contentResolver
-        val millis = runCatching {
+        return runCatching {
             resolver.query(
                 uri,
                 arrayOf(MediaStore.Images.Media.DATE_TAKEN),
@@ -300,15 +346,7 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
                     null
                 }
             }
-        }.getOrNull()
-        return if (millis != null && millis > 0) {
-            OffsetDateTime.ofInstant(
-                Instant.ofEpochMilli(millis),
-                ZoneId.systemDefault(),
-            ).toString()
-        } else {
-            OffsetDateTime.now().toString()
-        }
+        }.getOrNull()?.takeIf { it > 0 }
     }
 
     /** Fetch a fresh presigned URL for a photo's original and open the viewer. */
@@ -336,6 +374,8 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
             try {
                 val api = buildApi(snapshot)
                 api.stopTrip(TripStoryIdRequest(storyId = story.id))
+                // Stop recording the breadcrumb trail for this trip.
+                TripTracker.stop(getApplication(), story.id)
                 reload()
             } catch (t: Throwable) {
                 _error.value = t.message ?: t.javaClass.simpleName

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripsScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripsScreen.kt
@@ -1,5 +1,9 @@
 package org.polybrain.tasks.health.ui.trip
 
+import android.Manifest
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -23,6 +27,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -53,6 +58,21 @@ fun TripsScreen(
         }
     }
 
+    // Starting a trip turns on location tracking, so ask for the permissions it
+    // needs first (location to sample; notifications for the ongoing service
+    // notice on Android 13+). The trip starts once the user responds either way.
+    val trackingPermissions = remember {
+        buildList {
+            add(Manifest.permission.ACCESS_FINE_LOCATION)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                add(Manifest.permission.POST_NOTIFICATIONS)
+            }
+        }.toTypedArray()
+    }
+    val startTripLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions(),
+    ) { vm.startTrip() }
+
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         error?.let { ErrorBanner(message = it, onDismiss = vm::clearError) }
 
@@ -70,7 +90,7 @@ fun TripsScreen(
                 ) {
                     item {
                         Button(
-                            onClick = vm::startTrip,
+                            onClick = { startTripLauncher.launch(trackingPermissions) },
                             modifier = Modifier.fillMaxWidth(),
                         ) {
                             Text(stringResource(R.string.trips_start_button))

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripsViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripsViewModel.kt
@@ -13,6 +13,7 @@ import org.polybrain.tasks.health.data.TasksApi
 import org.polybrain.tasks.health.data.TasksClient
 import org.polybrain.tasks.health.data.TripStartRequest
 import org.polybrain.tasks.health.data.TripSummary
+import org.polybrain.tasks.health.location.TripTracker
 
 class TripsViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -56,6 +57,8 @@ class TripsViewModel(application: Application) : AndroidViewModel(application) {
                 val api = buildApi(snapshot)
                 val story = api.startTrip(TripStartRequest()).story
                 _focusTrip.value = story.id
+                // Begin recording the location breadcrumb trail for this trip.
+                TripTracker.start(getApplication(), story.id)
                 reload()
             } catch (t: Throwable) {
                 _error.value = t.message ?: t.javaClass.simpleName
@@ -114,6 +117,9 @@ class TripsViewModel(application: Application) : AndroidViewModel(application) {
             _history.value = page.history
             _totalHistory.value = page.totalHistory
             _error.value = null
+            // Align tracking with the server: a trip stopped elsewhere (e.g.
+            // the web) turns the breadcrumb service off; an active one keeps it on.
+            TripTracker.reconcile(getApplication(), page.active.map { it.id })
             // On first successful load only, if exactly one active trip
             // exists, hop the user straight into it. Subsequent refreshes
             // leave them on the list so back-navigation works.

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -49,6 +49,11 @@
     <string name="trip_sync_badge_failed">%1$d failed to sync</string>
     <string name="trip_sync_retry_all">Retry all</string>
 
+    <string name="trip_tracking_channel_name">Trip location tracking</string>
+    <string name="trip_tracking_notification_title">Recording trip location</string>
+    <string name="trip_tracking_notification_text">Sampling your location while this trip is active.</string>
+    <string name="trip_note_gps_from_track">Location from your trip track (%1$s)</string>
+
     <string name="today_empty">Nothing on today\'s plan yet.</string>
     <string name="today_add_hint">Add a task</string>
     <string name="today_add_button">Add</string>

--- a/android/app/src/test/java/org/polybrain/tasks/health/data/BreadcrumbStoreTest.kt
+++ b/android/app/src/test/java/org/polybrain/tasks/health/data/BreadcrumbStoreTest.kt
@@ -1,0 +1,72 @@
+package org.polybrain.tasks.health.data
+
+import java.io.File
+import java.nio.file.Files
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class BreadcrumbStoreTest {
+
+    private lateinit var file: File
+    private lateinit var store: BreadcrumbStore
+
+    @Before
+    fun setUp() {
+        val dir = Files.createTempDirectory("breadcrumb-test").toFile()
+        file = File(dir, "breadcrumbs.log")
+        store = BreadcrumbStore(file)
+    }
+
+    @After
+    fun tearDown() {
+        file.parentFile?.deleteRecursively()
+    }
+
+    @Test
+    fun `append then all round-trips and sorts by time`() {
+        store.append(Breadcrumb(t = 300, lat = 3.0, lng = 3.0))
+        store.append(Breadcrumb(t = 100, lat = 1.0, lng = 1.0, acc = 5f))
+        store.append(Breadcrumb(t = 200, lat = 2.0, lng = 2.0))
+        val all = store.all()
+        assertEquals(listOf(100L, 200L, 300L), all.map { it.t })
+        assertEquals(5f, all.first().acc)
+    }
+
+    @Test
+    fun `all is empty when nothing written`() {
+        assertTrue(store.all().isEmpty())
+    }
+
+    @Test
+    fun `lastAtOrBefore and firstAtOrAfter respect boundaries`() {
+        store.append(Breadcrumb(t = 100, lat = 1.0, lng = 1.0))
+        store.append(Breadcrumb(t = 200, lat = 2.0, lng = 2.0))
+        store.append(Breadcrumb(t = 300, lat = 3.0, lng = 3.0))
+        assertEquals(200L, store.lastAtOrBefore(250)?.t)
+        assertEquals(200L, store.lastAtOrBefore(200)?.t) // inclusive
+        assertEquals(300L, store.firstAtOrAfter(250)?.t)
+        assertEquals(300L, store.firstAtOrAfter(300)?.t) // inclusive
+        assertNull(store.lastAtOrBefore(50))
+        assertNull(store.firstAtOrAfter(400))
+    }
+
+    @Test
+    fun `a torn final line is skipped not fatal`() {
+        store.append(Breadcrumb(t = 100, lat = 1.0, lng = 1.0))
+        file.appendText("{not valid json")
+        assertEquals(1, store.all().size)
+    }
+
+    @Test
+    fun `clear removes the log`() {
+        store.append(Breadcrumb(t = 100, lat = 1.0, lng = 1.0))
+        store.clear()
+        assertFalse(file.exists())
+        assertTrue(store.all().isEmpty())
+    }
+}

--- a/android/app/src/test/java/org/polybrain/tasks/health/location/PhotoLocationResolverTest.kt
+++ b/android/app/src/test/java/org/polybrain/tasks/health/location/PhotoLocationResolverTest.kt
@@ -1,0 +1,81 @@
+package org.polybrain.tasks.health.location
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.polybrain.tasks.health.data.Breadcrumb
+
+class PhotoLocationResolverTest {
+
+    private val min = 60_000L
+
+    @Test
+    fun `empty trail yields no location`() {
+        assertNull(PhotoLocationResolver.resolve(emptyList(), 1_000))
+    }
+
+    @Test
+    fun `direct hit within two minutes uses the nearest point`() {
+        val crumbs = listOf(
+            Breadcrumb(t = 0, lat = 10.0, lng = 10.0),
+            Breadcrumb(t = 1 * min, lat = 20.0, lng = 20.0), // 1 min before capture
+            Breadcrumb(t = 5 * min, lat = 50.0, lng = 50.0),
+        )
+        val fix = PhotoLocationResolver.resolve(crumbs, 2 * min)
+        assertNotNull(fix)
+        // Nearest to t=2min is the t=1min point (1 min away) vs t=5min (3 min).
+        assertEquals(20.0, fix!!.lat, 0.0)
+        assertEquals(20.0, fix.lng, 0.0)
+    }
+
+    @Test
+    fun `gap bracketed by nearby points uses the closer one in time`() {
+        // No point within 2 min of capture, but before/after are ~110 m apart
+        // (same place) → stationary, use closer-in-time (the after point).
+        val crumbs = listOf(
+            Breadcrumb(t = 0, lat = 52.230000, lng = 21.010000), // 10 min before
+            Breadcrumb(t = 13 * min, lat = 52.231000, lng = 21.010000), // 3 min after
+        )
+        val fix = PhotoLocationResolver.resolve(crumbs, 10 * min)
+        assertNotNull(fix)
+        assertEquals(52.231000, fix!!.lat, 0.0) // the after point is closer in time
+    }
+
+    @Test
+    fun `gap bracketed by far apart points yields no location`() {
+        // before/after are kilometres apart → you were moving → don't guess.
+        val crumbs = listOf(
+            Breadcrumb(t = 0, lat = 52.2300, lng = 21.0100),
+            Breadcrumb(t = 20 * min, lat = 52.4000, lng = 21.0100), // ~19 km away
+        )
+        assertNull(PhotoLocationResolver.resolve(crumbs, 10 * min))
+    }
+
+    @Test
+    fun `only one side in a gap yields no location`() {
+        // Photo taken well after the last breadcrumb (tracking ended) — no
+        // bracketing pair to confirm a stationary position.
+        val crumbs = listOf(
+            Breadcrumb(t = 0, lat = 10.0, lng = 10.0),
+            Breadcrumb(t = 5 * min, lat = 10.0, lng = 10.0),
+        )
+        assertNull(PhotoLocationResolver.resolve(crumbs, 30 * min))
+    }
+
+    @Test
+    fun `exact timestamp match is a direct hit`() {
+        val crumbs = listOf(Breadcrumb(t = 7 * min, lat = 1.0, lng = 2.0, acc = 9f))
+        val fix = PhotoLocationResolver.resolve(crumbs, 7 * min)
+        assertNotNull(fix)
+        assertEquals(1.0, fix!!.lat, 0.0)
+        assertEquals(9f, fix.accuracyMeters)
+    }
+
+    @Test
+    fun `haversine matches a known city-scale distance`() {
+        // Warsaw city center to ~1 km north (≈0.009 deg latitude).
+        val d = PhotoLocationResolver.haversineMeters(52.2297, 21.0122, 52.2387, 21.0122)
+        assertEquals(1000.0, d, 5.0)
+    }
+}


### PR DESCRIPTION
## Why

A trip photo's `#poi` coordinates came from a **fresh GPS fix at the moment you press Add**
(`TripDetailViewModel.startGpsResolution` → `LocationProvider.currentFix`). That's wrong for the
real workflow: you shoot photos along the way and *curate/upload them later* — by then you've
moved, so the current fix no longer matches where the photo was taken.

## What

While a trip is active, the app records a **breadcrumb trail** (a location sample every 30–120 s).
When you add a photo, its coordinates are derived from the breadcrumb **nearest the photo's
capture time** — so you can pick photos for upload from anywhere and still get the right location.

### Tracking
- **`location/TripLocationService`** — foreground service (`foregroundServiceType="location"`)
  that samples every **30 s** while the phone is interactive / **120 s** while locked (driven by a
  `SCREEN_ON`/`SCREEN_OFF` receiver), balanced-power accuracy, with an ongoing "Recording trip
  location" notification. Started from the foreground, so **no `ACCESS_BACKGROUND_LOCATION`**
  ("Allow all the time") prompt.
- **`location/TripTracker`** — drives the service off `Settings.trackedStoryIds`: starts on trip
  start, reconciles with the server's active trips (a web-side stop turns it off), stops + clears
  the trail when the last active trip stops, and resumes on app reopen after a kill.

### Storage + matching
- **`data/BreadcrumbStore`** — append-only NDJSON trail (`filesDir/breadcrumbs.log`); cheap
  per-sample appends, tolerant of a torn final line.
- **`location/PhotoLocationResolver`** — pure matching rule: nearest breadcrumb within **2 min**
  → use it; otherwise only trust a **before/after bracket <200 m apart** (you were stationary) and
  take the closer-in-time one; **never interpolate across a move** → return null (send without
  location). No current-fix fallback for photos.

### UI / lifecycle
- **`TripDetailViewModel.openAddPhoto`** resolves location from the trail at the photo's capture
  time; `AddPhotoDialog` shows "Location from your trip track (HH:mm)" or the existing
  send-without-location toggle when there's no trusted match. **Notes are unchanged** (a note is
  "now" → live fix).
- **`TripsScreen`** Start button requests fine-location + notification permissions before starting;
  the service bails out cleanly (no crash on Android 14+) if location isn't granted.
- Manifest: `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_LOCATION`, `POST_NOTIFICATIONS` + the service
  declaration.

## Testing
- **`testDebugUnitTest` green** — new `PhotoLocationResolverTest` (7: direct-hit, stationary
  bracket, far-apart bracket → none, one-sided gap → none, exact match, haversine) and
  `BreadcrumbStoreTest` (5); existing outbox/note suites still pass. **`assembleDebug` succeeds**
  (manifest merge with the new service + permissions is valid).
- **Manual (left for device):** start a trip → confirm the ongoing notification and breadcrumb
  accumulation (lock the phone a few minutes → slower cadence). Take a photo, move, then add it
  later → its `#poi` matches where it was taken, not where you are now. Force-stop + reopen → the
  service resumes. Stop the trip → notification clears and the trail is cleared.

## Notes / decisions
- Lean permissions (chosen): after a **reboot**, tracking resumes when the app is reopened — no
  background-location grant.
- Single global breadcrumb log serves all concurrent active trips (location at time T is
  trip-independent); cleared only when the last active trip stops.
- Sampling uses balanced-power accuracy (~100 m) — ample for a photo POI, easy on battery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)