### PR TITLE
feat(trips): make note/photo location an explicit opt-in

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/AddNoteDialog.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/AddNoteDialog.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -28,16 +27,12 @@ import org.polybrain.tasks.health.R
 @Composable
 fun AddNoteDialog(vm: TripDetailViewModel) {
     val gps by vm.gps.collectAsState()
-    val allowNoLocation by vm.allowNoLocation.collectAsState()
 
     var draft by remember { mutableStateOf("") }
 
     val permissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission(),
     ) { granted -> vm.onLocationPermissionResult(granted) }
-
-    val canSend = gps is TripDetailViewModel.GpsState.Ready ||
-            (allowNoLocation && gps !is TripDetailViewModel.GpsState.Waiting)
 
     AlertDialog(
         onDismissRequest = { vm.closeAddNote() },
@@ -50,17 +45,6 @@ fun AddNoteDialog(vm: TripDetailViewModel) {
                         permissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
                     },
                 )
-                if (gps is TripDetailViewModel.GpsState.Denied ||
-                    gps is TripDetailViewModel.GpsState.Unavailable
-                ) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Checkbox(
-                            checked = allowNoLocation,
-                            onCheckedChange = vm::setAllowNoLocation,
-                        )
-                        Text(stringResource(R.string.trip_note_send_without_location))
-                    }
-                }
                 OutlinedTextField(
                     value = draft,
                     onValueChange = { draft = it },
@@ -71,12 +55,25 @@ fun AddNoteDialog(vm: TripDetailViewModel) {
                 )
             }
         },
+        // "Send" is the default action and attaches no location; "Save with
+        // location" is the explicit opt-in, enabled only when a fix is ready.
         confirmButton = {
-            TextButton(
-                onClick = { vm.sendNote(draft) },
-                enabled = canSend,
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(stringResource(R.string.trip_note_send))
+                TextButton(
+                    onClick = { vm.sendNote(draft, includeLocation = true) },
+                    enabled = gps is TripDetailViewModel.GpsState.Ready,
+                ) {
+                    Text(stringResource(R.string.trip_save_with_location))
+                }
+                TextButton(
+                    onClick = { vm.sendNote(draft, includeLocation = false) },
+                    enabled = draft.isNotBlank(),
+                ) {
+                    Text(stringResource(R.string.trip_send))
+                }
             }
         },
         dismissButton = {

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/AddPhotoDialog.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/AddPhotoDialog.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -35,7 +34,6 @@ import org.polybrain.tasks.health.R
 @Composable
 fun AddPhotoDialog(vm: TripDetailViewModel) {
     val gps by vm.gps.collectAsState()
-    val allowNoLocation by vm.allowNoLocation.collectAsState()
     val selectedPhoto by vm.selectedPhoto.collectAsState()
 
     var draft by remember { mutableStateOf("") }
@@ -43,11 +41,6 @@ fun AddPhotoDialog(vm: TripDetailViewModel) {
     val permissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission(),
     ) { granted -> vm.onLocationPermissionResult(granted) }
-
-    // Sending now just queues the photo to the outbox and closes the dialog —
-    // the upload happens in the background, so there's no in-dialog spinner.
-    val canSend = gps is TripDetailViewModel.GpsState.Ready ||
-        (allowNoLocation && gps !is TripDetailViewModel.GpsState.Waiting)
 
     AlertDialog(
         onDismissRequest = { vm.closeAddPhoto() },
@@ -86,17 +79,6 @@ fun AddPhotoDialog(vm: TripDetailViewModel) {
                         },
                     )
                 }
-                if (gps is TripDetailViewModel.GpsState.Denied ||
-                    gps is TripDetailViewModel.GpsState.Unavailable
-                ) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Checkbox(
-                            checked = allowNoLocation,
-                            onCheckedChange = vm::setAllowNoLocation,
-                        )
-                        Text(stringResource(R.string.trip_note_send_without_location))
-                    }
-                }
                 OutlinedTextField(
                     value = draft,
                     onValueChange = { draft = it },
@@ -107,12 +89,22 @@ fun AddPhotoDialog(vm: TripDetailViewModel) {
                 )
             }
         },
+        // "Send" is the default and attaches no location; "Save with location"
+        // is the explicit opt-in, enabled only when the track produced a fix.
         confirmButton = {
-            TextButton(
-                onClick = { vm.sendPhoto(draft) },
-                enabled = canSend,
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(stringResource(R.string.trip_photo_send))
+                TextButton(
+                    onClick = { vm.sendPhoto(draft, includeLocation = true) },
+                    enabled = gps is TripDetailViewModel.GpsState.Ready,
+                ) {
+                    Text(stringResource(R.string.trip_save_with_location))
+                }
+                TextButton(onClick = { vm.sendPhoto(draft, includeLocation = false) }) {
+                    Text(stringResource(R.string.trip_send))
+                }
             }
         },
         dismissButton = {

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripDetailViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripDetailViewModel.kt
@@ -117,10 +117,6 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
     private val _gps = MutableStateFlow<GpsState>(GpsState.Idle)
     val gps: StateFlow<GpsState> = _gps.asStateFlow()
 
-    /** Whether the user has explicitly opted to send without location. */
-    private val _allowNoLocation = MutableStateFlow(false)
-    val allowNoLocation: StateFlow<Boolean> = _allowNoLocation.asStateFlow()
-
     private val _renameOpen = MutableStateFlow(false)
     val renameOpen: StateFlow<Boolean> = _renameOpen.asStateFlow()
 
@@ -163,7 +159,6 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
     fun closeAddNote() {
         _noteDialogOpen.value = false
         _gps.value = GpsState.Idle
-        _allowNoLocation.value = false
     }
 
     /**
@@ -175,7 +170,6 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
     fun openAddPhoto(uri: Uri) {
         _selectedPhoto.value = uri
         _photoDialogOpen.value = true
-        _allowNoLocation.value = false
         _gps.value = GpsState.Waiting
         viewModelScope.launch {
             val captureMs = withContext(Dispatchers.IO) {
@@ -187,8 +181,8 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
             _gps.value = if (fix != null) {
                 GpsState.Ready(fix, GpsSource.TRACK, captureMs)
             } else {
-                // No trusted track location for this photo's time — the dialog
-                // offers "send without location".
+                // No trusted track location for this photo's time — only plain
+                // "Send" (without location) will be offered.
                 GpsState.Unavailable
             }
         }
@@ -198,12 +192,10 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
         _photoDialogOpen.value = false
         _selectedPhoto.value = null
         _gps.value = GpsState.Idle
-        _allowNoLocation.value = false
     }
 
-    /** Shared GPS bootstrap used by both the note and photo dialogs. */
+    /** Live GPS bootstrap for the note dialog (a note is recorded "now"). */
     private fun startGpsResolution() {
-        _allowNoLocation.value = false
         _gps.value = GpsState.Waiting
         viewModelScope.launch {
             if (!locationProvider.hasFineLocationPermission()) {
@@ -213,10 +205,6 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
             val fix = locationProvider.currentFix()
             _gps.value = if (fix != null) GpsState.Ready(fix) else GpsState.Unavailable
         }
-    }
-
-    fun setAllowNoLocation(value: Boolean) {
-        _allowNoLocation.value = value
     }
 
     /** Called by the screen after the runtime permission request finishes. */
@@ -233,17 +221,22 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
         }
     }
 
-    fun sendNote(text: String) {
+    /**
+     * Enqueue a note. [includeLocation] is the explicit "Save with location"
+     * choice — the default "Send" attaches no `#poi`, so location lands only on
+     * notes where it's actually wanted.
+     */
+    fun sendNote(text: String, includeLocation: Boolean) {
         val story = _story.value ?: return
         if (story.stopped != null) return
-        val fix = (_gps.value as? GpsState.Ready)?.fix
-        if (fix == null && !_allowNoLocation.value) return
+        val fix = if (includeLocation) (_gps.value as? GpsState.Ready)?.fix else null
 
         val comment = composeComment(fix, text)
+        // A note needs content; without a location line that means some text.
+        if (comment.isBlank()) return
         val published = OffsetDateTime.now().toString()
         _noteDialogOpen.value = false
         _gps.value = GpsState.Idle
-        _allowNoLocation.value = false
 
         // Queue locally and kick the drain; the item shows immediately and the
         // worker delivers it (now or when connectivity returns).
@@ -254,19 +247,18 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
         }
     }
 
-    fun sendPhoto(text: String) {
+    /** Enqueue a photo. [includeLocation] mirrors [sendNote] (the track fix). */
+    fun sendPhoto(text: String, includeLocation: Boolean) {
         val story = _story.value ?: return
         if (story.stopped != null) return
         val uri = _selectedPhoto.value ?: return
-        val fix = (_gps.value as? GpsState.Ready)?.fix
-        if (fix == null && !_allowNoLocation.value) return
+        val fix = if (includeLocation) (_gps.value as? GpsState.Ready)?.fix else null
 
         val comment = composeComment(fix, text)
         // Close the dialog now; copy + enqueue happen in the background.
         _photoDialogOpen.value = false
         _selectedPhoto.value = null
         _gps.value = GpsState.Idle
-        _allowNoLocation.value = false
 
         viewModelScope.launch {
             try {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -26,17 +26,16 @@
 
     <string name="trip_note_dialog_title">Add a note</string>
     <string name="trip_note_hint">What\'s going on?</string>
-    <string name="trip_note_send">Send</string>
+    <string name="trip_send">Send</string>
+    <string name="trip_save_with_location">Save with location</string>
     <string name="trip_note_cancel">Cancel</string>
     <string name="trip_note_gps_waiting">Waiting for GPS…</string>
     <string name="trip_note_gps_ready">Location ready (%1$.5f, %2$.5f)</string>
     <string name="trip_note_gps_missing">No location available.</string>
-    <string name="trip_note_send_without_location">Send without location</string>
     <string name="trip_note_grant_location">Grant location permission</string>
 
     <string name="trip_photo_dialog_title">Add a photo</string>
     <string name="trip_photo_hint">Add a caption (optional)</string>
-    <string name="trip_photo_send">Upload</string>
     <string name="trip_photo_processing">Processing photo…</string>
 
     <string name="trip_sync_waiting">Waiting to sync</string>


### PR DESCRIPTION
## Why

The add-note and add-photo modals attached location **by default**, surfacing a
"send without location" checkbox only when GPS was missing. But location is only
useful on *some* entries, so it should be opt-in, not opt-out.

## What

The modals now offer three actions — **Cancel · Save with location · Send** —
with **Send** as the default (rightmost/primary):

- **Send** (default) → saves the note/photo **without** a `#poi` line.
- **Save with location** → attaches the location (a live GPS fix for notes, the
  breadcrumb-track fix for photos), enabled only when a fix is actually available.
- **Cancel** → dismiss.

### Implementation
- `TripDetailViewModel.sendNote` / `sendPhoto` now take `includeLocation: Boolean`;
  the fix is only composed into the comment when it's true. Notes reject an empty,
  location-less comment before enqueue; photos still allow an empty caption.
- Removed the `allowNoLocation` state + the "send without location" checkbox; the
  GPS/track status line stays so you can see whether "Save with location" will work.
- `AddNoteDialog` / `AddPhotoDialog`: single Send button → three-button layout.
- Removed three now-unused string resources; added `trip_send` / `trip_save_with_location`.

## Testing
- `testDebugUnitTest` green (existing resolver/store/outbox suites unaffected); `assembleDebug` succeeds.
- Manual (left for device): in both modals, **Save with location** is greyed out until a
  fix/track match is ready; **Send** stores without `#poi`; a blank note can't be sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)