### PR TITLE
feat(ui): add a reusable two-row topbar across pages

### DIFF
--- a/tasks/assets/app.scss
+++ b/tasks/assets/app.scss
@@ -7,6 +7,13 @@
 $lower-pane: 40px;
 $upper-pane: 54px;
 
+// Expose the pane heights as CSS custom properties (seeded from the Sass vars)
+// so the Board topic-bar height can be tuned at runtime without a rebuild.
+:root {
+    --upper-pane: #{$upper-pane};
+    --lower-pane: #{$lower-pane};
+}
+
 @import './styles/general';
 @import './styles/sidebar';
 @import './styles/tasks';        // uses $upper-pane / $lower-pane (defined above)

--- a/tasks/assets/components/Board.vue
+++ b/tasks/assets/components/Board.vue
@@ -1,7 +1,47 @@
 <template>
     <div class="board">
-        <div class="upper-pane">
-            <h1>{{ startDate }}: <input v-model="focus" @blur="saveState" @keyup.stop></h1>
+        <div class="topbar">
+            <div class="upper-pane">
+                <h1>{{ startDate }}: <input v-model="focus" @blur="saveState" @keyup.stop></h1>
+                <button @click.prevent="prepareCommit" class="on-right">commit</button>
+            </div>
+            <div class="lower-pane">
+                <button @click.prevent="addItem">+</button>
+                <select @change="changeThread($event)">
+                    <option v-for="thread in threads" :key="thread.id" :value="thread.id" :selected="thread.id == currentThreadId">
+                        {{ thread.name }}
+                    </option>
+                </select>
+
+                <button @click.prevent="toggleListViewMode" class="secondary">{{ listViewMode ? 'tree' : 'list' }}</button>
+
+                <router-link class="menulink" to="/">Board</router-link>
+                <router-link class="menulink" to="/eisenhower">Eisenhower</router-link>
+                <router-link class="menulink" to="/moscow">MoSCoW</router-link>
+
+                <select
+                    v-show="!listViewMode"
+                    v-model="filterMode"
+                    class="filter-select"
+                >
+                    <option value="all">all</option>
+                    <option value="important">important</option>
+                    <option value="deprecated">deprecated</option>
+                    <option value="finalizing">clearable</option>
+                    <optgroup label="MoSCoW">
+                        <option value="moscow-must">Must have</option>
+                        <option value="moscow-should">Should have</option>
+                        <option value="moscow-could">Could have</option>
+                        <option value="moscow-wont">Won't have</option>
+                    </optgroup>
+                    <optgroup label="Eisenhower">
+                        <option value="eisenhower-urgent-important">Urgent &amp; Important</option>
+                        <option value="eisenhower-not-urgent-important">Not Urgent &amp; Important</option>
+                        <option value="eisenhower-urgent-not-important">Urgent &amp; Not Important</option>
+                        <option value="eisenhower-not-urgent-not-important">Not Urgent &amp; Not Important</option>
+                    </optgroup>
+                </select>
+            </div>
         </div>
 
         <tree
@@ -17,46 +57,6 @@
         </tree>
 
         <TreeListView v-show="listViewMode" />
-
-        <div class="lower-pane">
-            <button @click.prevent="addItem">+</button>
-            <select @change="changeThread($event)">
-                <option v-for="thread in threads" :key="thread.id" :value="thread.id" :selected="thread.id == currentThreadId">
-                    {{ thread.name }}
-                </option>
-            </select>
-
-            <button @click.prevent="toggleListViewMode" class="secondary">{{ listViewMode ? 'tree' : 'list' }}</button>
-
-            <router-link class="menulink" to="/">Board</router-link>
-            <router-link class="menulink" to="/eisenhower">Eisenhower</router-link>
-            <router-link class="menulink" to="/moscow">MoSCoW</router-link>
-
-            <select
-                v-show="!listViewMode"
-                v-model="filterMode"
-                class="filter-select on-right"
-            >
-                <option value="all">all</option>
-                <option value="important">important</option>
-                <option value="deprecated">deprecated</option>
-                <option value="finalizing">clearable</option>
-                <optgroup label="MoSCoW">
-                    <option value="moscow-must">Must have</option>
-                    <option value="moscow-should">Should have</option>
-                    <option value="moscow-could">Could have</option>
-                    <option value="moscow-wont">Won't have</option>
-                </optgroup>
-                <optgroup label="Eisenhower">
-                    <option value="eisenhower-urgent-important">Urgent &amp; Important</option>
-                    <option value="eisenhower-not-urgent-important">Not Urgent &amp; Important</option>
-                    <option value="eisenhower-urgent-not-important">Urgent &amp; Not Important</option>
-                    <option value="eisenhower-not-urgent-not-important">Not Urgent &amp; Not Important</option>
-                </optgroup>
-            </select>
-
-            <button @click.prevent="prepareCommit" :class="{ 'on-right': listViewMode }">commit</button>
-        </div>
 
         <CommitConfirmationModal
             :show="showCommitModal"

--- a/tasks/assets/components/EnfpDashboard.vue
+++ b/tasks/assets/components/EnfpDashboard.vue
@@ -1,6 +1,8 @@
 <template>
+    <div>
+    <div class="topbar"><div class="upper-pane"><h1>Cognitive Functions</h1></div></div>
+
     <div class="enfp-dashboard">
-        <h1 class="mb-4 text-center">Cognitive Functions</h1>
 
         <p v-if="loading" class="text-center">Loading…</p>
 
@@ -152,6 +154,7 @@
                 </div>
             </section>
         </template>
+    </div>
     </div>
 </template>
 

--- a/tasks/assets/styles/_breakthrough.scss
+++ b/tasks/assets/styles/_breakthrough.scss
@@ -255,19 +255,16 @@
     grid-template-columns: 1fr 1fr;
     grid-template-rows: auto 1fr;
     grid-template-areas:
-        "column1 header"
+        "header  header"
         "column1 column2";
     gap: 0;
 
     header {
         grid-area: header;
-        padding: 0 20px;
+        margin-bottom: 0;
 
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        align-items: center;
-
+        // Layout comes from .topbar / .upper-pane / .lower-pane; this is just the
+        // grid cell + the Save button styling.
         button {
             padding: 0.5rem 1rem;
             font-size: 1.2rem;

--- a/tasks/assets/styles/_general.scss
+++ b/tasks/assets/styles/_general.scss
@@ -24,6 +24,77 @@ body, html {
     width: 0.5rem;
 }
 
+// Reusable page heading bar: a full-width, two-row header that sits OUTSIDE the
+// page's centered container. Row 1 (.upper-pane) holds the prominent title and
+// right-aligned actions (.on-right); row 2 (.lower-pane) holds filters / nav.
+// Both panes are fixed-height (--upper-pane / --lower-pane). Modeled on the Board.
+.topbar {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 1rem;
+    border-bottom: 1px solid #efefef;
+}
+
+.upper-pane {
+    height: var(--upper-pane);
+    padding: 0 20px;
+
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+
+    // Tighten the gap to the lower-pane, but only when one actually follows.
+    &:has(+ .lower-pane) {
+        margin-bottom: -10px;
+    }
+
+    h1, h2, h3 {
+        margin: 0;
+        color: #343434;
+        font-weight: 600;
+        font-size: 1.6rem;
+    }
+
+    .topbar-meta {
+        color: #999;
+        font-size: 0.95rem;
+    }
+}
+
+.lower-pane {
+    height: var(--lower-pane);
+    padding: 0 20px;
+
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+
+    font-size: 0.9rem;
+    color: #666;
+
+    select {
+        font-family: 'Raleway', sans-serif;
+        font-size: 0.9rem;
+        padding: 0.15rem 0.35rem;
+    }
+
+    .menulink {
+        font-size: 0.95rem;
+    }
+
+    .date-filters {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+
+        a {
+            margin-left: 10px;
+        }
+    }
+}
+
 .menu a, .menulink {
     color: #205e7d;
     text-decoration: none;

--- a/tasks/assets/styles/_tasks.scss
+++ b/tasks/assets/styles/_tasks.scss
@@ -17,7 +17,7 @@
 
     display: flex;
     flex-flow: column wrap;
-    height: calc(100vh - #{$lower-pane} - #{$upper-pane});
+    height: 100%;
 }
 
 .tree-node.filter-hidden {
@@ -404,57 +404,37 @@
     height: 100vh;
 }
 
-.upper-pane {
-    height: $upper-pane;
-    padding: 3px 10px;
-
-    h1 {
-        margin-top: 0;
-        margin-bottom: 0;
-        color: #999;
-
-        // Flex row so the focus input fills the remaining width instead of a
-        // viewport-based calc; this keeps the date + topic on one line while the
-        // sidebar slides (the content width animates).
-        flex: 1 1 auto;
-        min-width: 0;
-        display: flex;
-        align-items: center;
-        white-space: nowrap;
-
-        input {
-            padding: 0;
-            border: 0;
-            margin: 0;
-            font-size: 1em;
-            outline: 0;
-            font-weight: bold;
-            flex: 1 1 auto;
-            min-width: 0;
-            color: #666;
-        }
-    }
-
-    display: flex;
-    align-items: center;
-    flex-direction: row;
-
-    border-bottom: 1px solid #efefef;
+// Board chrome: the topbar's two panes sit at the top (shared .upper-pane /
+// .lower-pane in _general); the tree flex-fills the remaining viewport height.
+.board .topbar {
+    margin-bottom: 0;
 }
 
-.lower-pane {
-    height: $lower-pane;
-    padding: 3px 10px;
-    background-color: #efefef;
+.board .tree,
+.board .tree-list-view {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: auto;
+}
 
+// The Board's title row carries the focus input alongside the date.
+.board .upper-pane h1 {
+    flex: 1 1 auto;
+    min-width: 0;
+    white-space: nowrap;
     display: flex;
     align-items: center;
-    flex-direction: row;
 
-    // Vue condenses whitespace between elements, so the view links would render
-    // with no gap; space them explicitly.
-    .menulink {
-        margin: 0 0.35rem;
+    input {
+        padding: 0;
+        border: 0;
+        margin: 0;
+        font-size: 1em;
+        outline: 0;
+        font-weight: bold;
+        flex: 1 1 auto;
+        min-width: 0;
+        color: #666;
     }
 }
 
@@ -560,11 +540,11 @@
 
     margin: auto;
 
-    h2, h3 {
+    article h2, article h3 {
         color: #999;
     }
 
-    h2 {
+    article h2 {
         border-bottom: 1px solid #eee;
     }
 

--- a/tasks/templates/summary.html
+++ b/tasks/templates/summary.html
@@ -6,23 +6,28 @@
 {% block content %}
 <!-- Vue entry-point -->
 
-<div class="summaries">
-
     {% if not single_view %}
-    <div class="date-filters" style="margin-bottom: 20px;">
-        <form method="get" action="{% url 'summaries' %}" style="display: flex; gap: 10px; align-items: center;">
-            <label for="from">From:</label>
-            <input type="date" id="from" name="from" value="{{ request.GET.from }}" onchange="this.form.submit()">
+    <div class="topbar">
+        <div class="upper-pane">
+            <h1>Summaries</h1>
+        </div>
+        <div class="lower-pane">
+            <form class="date-filters" method="get" action="{% url 'summaries' %}">
+                <label for="from">From:</label>
+                <input type="date" id="from" name="from" value="{{ request.GET.from }}" onchange="this.form.submit()">
 
-            <label for="to">To:</label>
-            <input type="date" id="to" name="to" value="{{ request.GET.to }}" onchange="this.form.submit()">
+                <label for="to">To:</label>
+                <input type="date" id="to" name="to" value="{{ request.GET.to }}" onchange="this.form.submit()">
 
-            {% if request.GET.from or request.GET.to %}
-            <a href="{% url 'summaries' %}" style="margin-left: 10px;">Reset</a>
-            {% endif %}
-        </form>
+                {% if request.GET.from or request.GET.to %}
+                <a href="{% url 'summaries' %}">Reset</a>
+                {% endif %}
+            </form>
+        </div>
     </div>
     {% endif %}
+
+<div class="summaries">
 
     {% for summary in summaries %}
 

--- a/tasks/templates/today.html
+++ b/tasks/templates/today.html
@@ -8,42 +8,47 @@
 {% block content %}
 <!-- Vue entry-point -->
 
+<div class="topbar">
+    <div class="upper-pane">
+        <h1>{{ today|date:"l, d M Y" }}</h1>
+    </div>
+    <div class="lower-pane">
+        <a class="menulink" href="?date={{ yesterday|date:"Y-m-d" }}{% if thread.name != 'Daily' %}&thread={{ thread.name }}{% endif %}">&lt;</a>
+        {% if not is_today and thread.name == 'Daily' %}
+            <a class="menulink" href="?date={{ actual_today|date:"Y-m-d" }}"><small>&times;</small></a>
+        {% endif %}
+
+
+        <select name="thread" id="thread">
+            {% for a_thread in threads %}
+            <option
+                value="{{ a_thread.name }}"
+                {% if a_thread.name == thread.name %}
+                    selected
+                {% endif %}
+            >{{ a_thread }}</option>
+            {% endfor %}
+        </select>
+        <script type="text/javascript">
+            const searchParams = new URLSearchParams(window.location.search);
+
+            function setThread(ev) {
+                searchParams.set('thread', ev.target.value);
+                window.location.search = searchParams.toString();
+            }
+
+            document
+                .getElementById('thread')
+                .addEventListener('change', setThread);
+        </script>
+        <a class="menulink" href="?date={{ tomorrow|date:"Y-m-d" }}{% if thread.name != 'Daily' %}&thread={{ thread.name }}{% endif %}">&gt;</a>
+    </div>
+</div>
+
 <div class="daily">
 <form action="" method="POST">
     {% csrf_token %}
     <div class="cont">
-
-        <h2>
-            <a class="menulink" href="?date={{ yesterday|date:"Y-m-d" }}{% if thread.name != 'Daily' %}&thread={{ thread.name }}{% endif %}">&lt;</a>
-            {% if not is_today and thread.name == 'Daily' %}
-                <a class="menulink" href="?date={{ actual_today|date:"Y-m-d" }}"><small>&times;</small></a>
-            {% endif %}
-            {{ today|date:"l, d M Y" }}:
-
-            <select name="thread" id="thread">
-                {% for a_thread in threads %}
-                <option
-                    value="{{ a_thread.name }}"
-                    {% if a_thread.name == thread.name %}
-                        selected
-                    {% endif %}
-                >{{ a_thread }}</option>
-                {% endfor %}
-            </select>
-            <script type="text/javascript">
-                const searchParams = new URLSearchParams(window.location.search);
-
-                function setThread(ev) {
-                    searchParams.set('thread', ev.target.value);
-                    window.location.search = searchParams.toString();
-                }
-
-                document
-                    .getElementById('thread')
-                    .addEventListener('change', setThread);
-            </script>
-            <a class="menulink" href="?date={{ tomorrow|date:"Y-m-d" }}{% if thread.name != 'Daily' %}&thread={{ thread.name }}{% endif %}">&gt;</a>
-        </h2>
 
     </div>
 

--- a/tasks/templates/tree/breakthrough.html
+++ b/tasks/templates/tree/breakthrough.html
@@ -13,19 +13,22 @@
         {% csrf_token %}
         {{ form.id }}
         <main class="breakthrough" id="year" data-year="{{ year }}">
-            <header>
-                <div class="year-navigation">
-                    <a href="{% url 'breakthrough' year=year|add:'-1' %}{% if review_mode %}?review=1{% endif %}" class="nav-link prev-year">&larr; {{ year|add:'-1' }}</a>
-                    {% if review_mode %}
-                        <a href="{% url 'breakthrough' year=year %}" class="nav-link review-toggle">Exit Review</a>
-                    {% else %}
-                        <a href="{% url 'breakthrough' year=year %}?review=1" class="nav-link review-toggle">Review</a>
-                    {% endif %}
-                    <a href="{% url 'breakthrough' year=year|add:'1' %}{% if review_mode %}?review=1{% endif %}" class="nav-link next-year">{{ year|add:'1' }} &rarr;</a>
+            <header class="topbar">
+                <div class="upper-pane">
+                    <h1>Your {{ year }} breakthrough</h1>
+                    <button type="submit" class="on-right">Save</button>
                 </div>
-                <h1>Your {{ year }} breakthrough</h1>
-
-                <button type="submit">Save</button>
+                <div class="lower-pane">
+                    <div class="year-navigation">
+                        <a href="{% url 'breakthrough' year=year|add:'-1' %}{% if review_mode %}?review=1{% endif %}" class="nav-link prev-year">&larr; {{ year|add:'-1' }}</a>
+                        {% if review_mode %}
+                            <a href="{% url 'breakthrough' year=year %}" class="nav-link review-toggle">Exit Review</a>
+                        {% else %}
+                            <a href="{% url 'breakthrough' year=year %}?review=1" class="nav-link review-toggle">Review</a>
+                        {% endif %}
+                        <a href="{% url 'breakthrough' year=year|add:'1' %}{% if review_mode %}?review=1{% endif %}" class="nav-link next-year">{{ year|add:'1' }} &rarr;</a>
+                    </div>
+                </div>
             </header>
 
             <div class="column1">

--- a/tasks/templates/tree/habit_detail.html
+++ b/tasks/templates/tree/habit_detail.html
@@ -7,12 +7,16 @@
 {% block content %}
 
 
+<div class="topbar">
+    <div class="upper-pane">
+        <h1>Habit: {{ object.name }}</h1>
+        <span class="topbar-meta on-right">Total events: {{ total_event_count }}</span>
+    </div>
+</div>
+
 <section class="journal">
     <div class="cont">
     </div>
-
-    <h1>Habit: {{ object.name }}</h1>
-    <p class="text-muted">Total events: {{ total_event_count }}</p>
 
     <div class="calendar" data-color-from="#8de0f3" data-color-to="#4199ad" data-color-negative="#bfab59">
         {% include "tree/calendar.html" %}

--- a/tasks/templates/tree/habit_list.html
+++ b/tasks/templates/tree/habit_list.html
@@ -7,11 +7,11 @@
 {% block content %}
 
 
+<div class="topbar"><div class="upper-pane"><h1>Habits</h1></div></div>
+
 <section class="journal">
     <div class="cont">
     </div>
-
-    <h1>Habits</h1>
 
     <main>
         <dl>

--- a/tasks/templates/tree/journaladded_archive_month.html
+++ b/tasks/templates/tree/journaladded_archive_month.html
@@ -7,12 +7,11 @@
 
 {% block content %}
 
-<section class="journal">
-    <div class="cont">
+<div class="topbar">
+    <div class="upper-pane">
+        <h1>Journal Entries for {{ month|date:"F Y" }} {% if tag %}tagged "{{ tag.name }}"{% endif %}</h1>
     </div>
-
-    <h1>Journal Entries for {{ month|date:"F Y" }} {% if tag %}tagged "{{ tag.name }}"{% endif %}</h1>
-
+    <div class="lower-pane">
     Show:
     <select onchange="if (this.value) window.location.href=this.value">
         {% if is_current_month %}
@@ -40,6 +39,12 @@
         <option value="asc" {% if order == 'asc' %}selected{% endif %}>Ascending</option>
         <option value="desc" {% if order == 'desc' %}selected{% endif %}>Descending</option>
     </select>
+    </div>
+</div>
+
+<section class="journal">
+    <div class="cont">
+    </div>
 
     <aside class="months">
         <h2>Archive</h2>

--- a/tasks/templates/tree/trips/trip_list.html
+++ b/tasks/templates/tree/trips/trip_list.html
@@ -6,11 +6,11 @@
 
 {% block content %}
 
+<div class="topbar"><div class="upper-pane"><h1>Trips</h1></div></div>
+
 <section class="journal">
     <div class="cont">
     </div>
-
-    <h1>Trips</h1>
 
     <aside class="months">
         <h2>Archive</h2>


### PR DESCRIPTION
## Summary

Introduces a shared `.topbar` heading bar (modeled on the Board's topic bar) and rolls it out across the site as a consistent, full-width page header.

## The component (`_general.scss`)
- **Two rows**: `.upper-pane` (prominent `<h1>` title left, actions right via `.on-right`) and an optional `.lower-pane` (filters / secondary nav, smaller muted text, left-aligned).
- **Fixed-height panes** via `--upper-pane` / `--lower-pane` CSS custom properties (seeded from the Sass vars in `app.scss`, so the Board topic-bar height stays tunable at runtime).
- **Full-width**: the topbar sits *outside* each page's centered container, so the title and the bottom-border line span the content area.
- `.upper-pane:has(+ .lower-pane)` gets a `-10px` bottom margin to tighten the gap to the lower row (no effect on title-only bars).

## Pages
- **Daily**: date title up; prev/next/today arrows + thread select down.
- **Summaries**: title up; From/To/Reset filters down.
- **Journal**: title up; Show/Order selects down.
- **Breakthrough**: title + **Save** up; year-nav down. Header now **spans both grid columns** (full-width band above column1/column2).
- **Habit detail**: title + event count (right). **Trips / Habits / Functions**: title-only.
- All titles are `<h1>`; Observations pages left untouched.

## Board (`Board.vue`)
- Both panes move to the **top** inside the topbar — **commit** moves to the upper-pane (right); the filter select is left-aligned in the lower-pane.
- The tree now **flex-fills** the remaining height (`flex:1; min-height:0` + `tree-root { height:100% }`) instead of `calc(100vh − panes)` — robust to pane/border height changes.

## Verification
- Assets build clean (Sass + Vue).
- Server-side render checks: every page's topbar contains an `.upper-pane`; Daily/Summaries/Journal/Breakthrough also have a `.lower-pane`; Board JS carries the restructured topbar; breakthrough grid compiles to `"header header" / "column1 column2"`.
- **214/214 Django tests pass.**

Note: pane heights are fixed everywhere by design, so a very long title could clip in the 54px upper-pane — tune `--upper-pane` if needed. `:has()` is baseline-supported in current browsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)