### PR TITLE
feat(layout): reusable content-rail layout across content pages

### DIFF
--- a/tasks/apps/tree/tests/test_trip_web.py
+++ b/tasks/apps/tree/tests/test_trip_web.py
@@ -130,13 +130,41 @@ class TripWebTestCase(TestCase):
         # A single-day trip hides the day-jump nav.
         self.assertNotContains(r, 'aside class="days"')
 
-    def test_trip_detail_multi_day_shows_day_nav(self):
+    def test_trip_detail_multi_day_has_no_rail(self):
+        # The trip detail page is full-width (no-rail): no day-jump rail even
+        # when the trip spans several days.
         self._note("Day one", published=timezone.now() - timedelta(days=2))
         self._note("Day three", published=timezone.now())
 
         r = self.client.get(reverse("trip-detail", args=[self.story.pk]))
         self.assertEqual(r.status_code, 200)
-        self.assertContains(r, 'aside class="days"')
+        self.assertContains(r, "Day one")
+        self.assertContains(r, "Day three")
+        self.assertContains(r, "content-rail no-rail")
+        self.assertNotContains(r, 'aside class="days"')
+
+    def test_trip_detail_same_day_shows_single_date(self):
+        # A trip that starts and stops on the same (UTC) day shows one date,
+        # not a start–stop range, in the topbar lower pane.
+        start = timezone.now().replace(hour=8, minute=0, second=0, microsecond=0)
+        self.story.started = start
+        self.story.stopped = start.replace(hour=20)
+        self.story.save()
+
+        r = self.client.get(reverse("trip-detail", args=[self.story.pk]))
+        self.assertEqual(r.status_code, 200)
+        self.assertNotContains(r, "&ndash;")
+
+    def test_trip_detail_multi_day_shows_date_range(self):
+        # A trip spanning days shows a start–stop range in the lower pane.
+        start = timezone.now().replace(hour=8, minute=0, second=0, microsecond=0)
+        self.story.started = start
+        self.story.stopped = start + timedelta(days=2)
+        self.story.save()
+
+        r = self.client.get(reverse("trip-detail", args=[self.story.pk]))
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, "&ndash;")
 
     @mock.patch(f"{STORAGE}.presign_get_web")
     def test_trip_detail_renders_photo_thumbnail(self, presign_get_web):

--- a/tasks/assets/styles/_daily.scss
+++ b/tasks/assets/styles/_daily.scss
@@ -82,6 +82,143 @@ body.page-daily {
     }
 }
 
+// Diary / journal month archive: the white journal column sits on the LEFT in
+// line with the topbar (inverting Daily), and a transparent rail on the RIGHT
+// carries two side-by-side nav columns — the Days jump-list and the month Archive.
+.page-diary {
+    background: #f9f9f9;
+
+    .split-layout {
+        --split-cols: minmax(50rem, 1fr) 16rem;
+    }
+
+    // White journal column. The wide left padding gives the [data-time] gutter
+    // (offset -3.24rem from each entry) room to sit inside the white box.
+    .split-left {
+        background: #fff;
+        padding: 1.5rem 2.5rem 1.5rem 4rem;
+    }
+
+    // Drop the standalone journal's own centering / card so it fills the column.
+    .split-left section.journal {
+        max-width: none;
+        margin: 0;
+        padding: 0;
+        background: transparent;
+    }
+
+    .split-left .pagination {
+        margin-top: 2rem;
+        display: flex;
+        gap: 1.5rem;
+
+        a {
+            color: #0066cc;
+            text-decoration: none;
+
+            &:hover {
+                text-decoration: underline;
+            }
+        }
+    }
+
+    // Transparent rail: Days | Archive as two columns, each sticky.
+    .split-right {
+        padding: 1.5rem 1.25rem;
+        background: transparent;
+
+        display: flex;
+        flex-direction: row;
+        gap: 1.25rem;
+        align-items: flex-start;
+    }
+
+    aside.days,
+    aside.months {
+        position: sticky;
+        top: 20px;
+
+        // Reset the floated, negative-margin, faded styling the asides inherit
+        // when they live inside section.journal on the centered layout.
+        float: none;
+        margin: 0;
+        width: auto;
+        max-width: none;
+        opacity: 1;
+
+        background: transparent;
+        border: 0;
+        padding: 0;
+
+        h2 {
+            margin: 0 0 0.5rem;
+            font-size: 1rem;
+            font-weight: 600;
+            color: #999;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        ul {
+            margin: 0;
+            padding-left: 0;
+        }
+
+        li {
+            list-style: none;
+        }
+    }
+
+    // Day jump-list: a narrow column of day-number chips.
+    aside.days {
+        flex: 0 0 auto;
+
+        a {
+            display: block;
+            margin: 0.25rem 0;
+            padding: 0.25rem 0.5rem;
+
+            border: 1px solid #ddd;
+            border-radius: 0.25rem;
+            background: #fff;
+
+            font-size: 0.8rem;
+            font-weight: bold;
+            text-align: center;
+
+            color: #0066cc;
+            text-decoration: none;
+
+            &:hover {
+                border-color: #83bcf5;
+                color: #336ca4;
+            }
+        }
+    }
+
+    // Month archive: a column of month links.
+    aside.months {
+        flex: 1 1 auto;
+
+        li {
+            margin-bottom: 0.5rem;
+
+            &:last-child {
+                margin-bottom: 0;
+            }
+
+            a {
+                color: #0066cc;
+                text-decoration: none;
+
+                &:hover {
+                    text-decoration: underline;
+                }
+            }
+        }
+    }
+}
+
 .small-plan {
     margin-bottom: 1rem;
     h3, h4, p {

--- a/tasks/assets/styles/_daily.scss
+++ b/tasks/assets/styles/_daily.scss
@@ -82,142 +82,9 @@ body.page-daily {
     }
 }
 
-// Diary / journal month archive: the white journal column sits on the LEFT in
-// line with the topbar (inverting Daily), and a transparent rail on the RIGHT
-// carries two side-by-side nav columns — the Days jump-list and the month Archive.
-.page-diary {
-    background: #f9f9f9;
-
-    .split-layout {
-        --split-cols: minmax(50rem, 1fr) 16rem;
-    }
-
-    // White journal column. The wide left padding gives the [data-time] gutter
-    // (offset -3.24rem from each entry) room to sit inside the white box.
-    .split-left {
-        background: #fff;
-        padding: 1.5rem 2.5rem 1.5rem 4rem;
-    }
-
-    // Drop the standalone journal's own centering / card so it fills the column.
-    .split-left section.journal {
-        max-width: none;
-        margin: 0;
-        padding: 0;
-        background: transparent;
-    }
-
-    .split-left .pagination {
-        margin-top: 2rem;
-        display: flex;
-        gap: 1.5rem;
-
-        a {
-            color: #0066cc;
-            text-decoration: none;
-
-            &:hover {
-                text-decoration: underline;
-            }
-        }
-    }
-
-    // Transparent rail: Days | Archive as two columns, each sticky.
-    .split-right {
-        padding: 1.5rem 1.25rem;
-        background: transparent;
-
-        display: flex;
-        flex-direction: row;
-        gap: 1.25rem;
-        align-items: flex-start;
-    }
-
-    aside.days,
-    aside.months {
-        position: sticky;
-        top: 20px;
-
-        // Reset the floated, negative-margin, faded styling the asides inherit
-        // when they live inside section.journal on the centered layout.
-        float: none;
-        margin: 0;
-        width: auto;
-        max-width: none;
-        opacity: 1;
-
-        background: transparent;
-        border: 0;
-        padding: 0;
-
-        h2 {
-            margin: 0 0 0.5rem;
-            font-size: 1rem;
-            font-weight: 600;
-            color: #999;
-            text-transform: uppercase;
-            letter-spacing: 0.03em;
-        }
-
-        ul {
-            margin: 0;
-            padding-left: 0;
-        }
-
-        li {
-            list-style: none;
-        }
-    }
-
-    // Day jump-list: a narrow column of day-number chips.
-    aside.days {
-        flex: 0 0 auto;
-
-        a {
-            display: block;
-            margin: 0.25rem 0;
-            padding: 0.25rem 0.5rem;
-
-            border: 1px solid #ddd;
-            border-radius: 0.25rem;
-            background: #fff;
-
-            font-size: 0.8rem;
-            font-weight: bold;
-            text-align: center;
-
-            color: #0066cc;
-            text-decoration: none;
-
-            &:hover {
-                border-color: #83bcf5;
-                color: #336ca4;
-            }
-        }
-    }
-
-    // Month archive: a column of month links.
-    aside.months {
-        flex: 1 1 auto;
-
-        li {
-            margin-bottom: 0.5rem;
-
-            &:last-child {
-                margin-bottom: 0;
-            }
-
-            a {
-                color: #0066cc;
-                text-decoration: none;
-
-                &:hover {
-                    text-decoration: underline;
-                }
-            }
-        }
-    }
-}
+// NOTE: the diary / trips / habits / summaries pages share the reusable
+// `.split-layout.content-rail` variant in _layouts.scss (white left content
+// column + transparent sticky nav rail).
 
 .small-plan {
     margin-bottom: 1rem;
@@ -620,9 +487,7 @@ section.journal {
     flex-direction: column;
     gap: 2px;
     padding: 2px;
-    background-color: #f0f0f0;
-    border-radius: 4px;
-    margin: 0 auto;
+    margin: 0;
     width: fit-content;
 
     .calendar-daily-row {

--- a/tasks/assets/styles/_habits.scss
+++ b/tasks/assets/styles/_habits.scss
@@ -3,3 +3,18 @@
 #id_habit_line-line {
     height: 4em;
 }
+
+// Single-habit page: occurrences grouped into month sections (the rail carries
+// the matching "Archive" of months + counts).
+.habit-month {
+    margin-top: 2.5rem;
+
+    &:first-child {
+        margin-top: 1rem;
+    }
+
+    h3 {
+        margin: 0;
+        color: #999;
+    }
+}

--- a/tasks/assets/styles/_layouts.scss
+++ b/tasks/assets/styles/_layouts.scss
@@ -28,3 +28,147 @@
         min-width: 0;
     }
 }
+
+// === Content + rail variant ===
+// A white content column on the LEFT, in line with the topbar, plus a transparent
+// rail on the RIGHT for sticky navigation (day jump-lists, month/section
+// archives). Shared by the diary, trips, habits, and task summaries. Pair with
+// `page-rail` on the <body> for the surrounding off-white backdrop.
+body.page-rail {
+    background: #f9f9f9;
+}
+
+.split-layout.content-rail {
+    --split-cols: minmax(50rem, 1fr) 16rem;
+
+    .split-left {
+        background: #fff;
+        padding: 1.5rem 2.5rem 1.5rem 1.5rem;
+
+        // Let an embedded journal section fill the column rather than render as
+        // its own centered card.
+        section.journal {
+            max-width: none;
+            margin: 0;
+            padding: 0;
+            background: transparent;
+        }
+
+        .pagination {
+            margin-top: 2rem;
+            display: flex;
+            justify-content: flex-start;
+            gap: 0.75rem;
+
+            a {
+                color: #0066cc;
+                text-decoration: none;
+
+                &:hover {
+                    text-decoration: underline;
+                }
+            }
+        }
+    }
+
+    .split-right {
+        padding: 1.5rem 1.25rem;
+        background: transparent;
+
+        display: flex;
+        flex-direction: row;
+        gap: 1.25rem;
+        align-items: flex-start;
+    }
+
+    // Rail-less variant: drop the right rail and let the white content column
+    // fill the full width, still in line with the topbar. Add `no-rail` to the
+    // .split-layout and omit the .split-right element.
+    &.no-rail {
+        grid-template-columns: 1fr;
+        grid-template-areas:
+            "header"
+            "left";
+    }
+}
+
+// Rail nav blocks. Default is a vertical link list (month / section archives);
+// add `.days` for a wrap of compact day-number jump chips.
+.content-rail .split-right aside {
+    position: sticky;
+    top: 20px;
+    flex: 1 1 auto;
+
+    // Defend against the floated, faded styling asides pick up inside
+    // section.journal on the older centered layouts.
+    float: none;
+    margin: 0;
+    width: auto;
+    max-width: none;
+    opacity: 1;
+
+    background: transparent;
+    border: 0;
+    padding: 0;
+
+    h2 {
+        margin: 0 0 0.5rem;
+        font-size: 1rem;
+        font-weight: 600;
+        color: #999;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+    }
+
+    ul {
+        margin: 0;
+        padding-left: 0;
+    }
+
+    li {
+        list-style: none;
+        margin-bottom: 0.5rem;
+
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
+
+    a {
+        color: #0066cc;
+        text-decoration: none;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+}
+
+// Day jump-list: a narrow column of day-number chips.
+.content-rail .split-right aside.days {
+    flex: 0 0 auto;
+
+    li {
+        margin-bottom: 0;
+    }
+
+    a {
+        display: block;
+        margin: 0.25rem 0;
+        padding: 0.25rem 0.5rem;
+
+        border: 1px solid #ddd;
+        border-radius: 0.25rem;
+        background: #fff;
+
+        font-size: 0.8rem;
+        font-weight: bold;
+        text-align: center;
+
+        &:hover {
+            border-color: #83bcf5;
+            color: #336ca4;
+            text-decoration: none;
+        }
+    }
+}

--- a/tasks/assets/styles/_tasks.scss
+++ b/tasks/assets/styles/_tasks.scss
@@ -533,6 +533,14 @@
     border: 0;
 }
 
+// On the content-rail layout the summaries fill the white left column instead
+// of being a centered fixed-min-width block.
+.content-rail .summaries {
+    width: auto;
+    min-width: 0;
+    margin: 0;
+}
+
 .summaries {
     width: 75%;
 

--- a/tasks/templates/summary.html
+++ b/tasks/templates/summary.html
@@ -1,85 +1,91 @@
 {% extends 'base.html' %}
 {% load render_assets %}
 
+{% block body_class %}page-rail{% endblock %}
+
 {% block title %}Summaries | Tasks Collector{% endblock %}
 
 {% block content %}
-<!-- Vue entry-point -->
 
+<div class="split-layout content-rail no-rail">
+
+<div class="topbar">
+    <div class="upper-pane">
+        <h1>{% if single_view %}Summary{% else %}Summaries{% endif %}</h1>
+    </div>
     {% if not single_view %}
-    <div class="topbar">
-        <div class="upper-pane">
-            <h1>Summaries</h1>
-        </div>
-        <div class="lower-pane">
-            <form class="date-filters" method="get" action="{% url 'summaries' %}">
-                <label for="from">From:</label>
-                <input type="date" id="from" name="from" value="{{ request.GET.from }}" onchange="this.form.submit()">
+    <div class="lower-pane">
+        <form class="date-filters" method="get" action="{% url 'summaries' %}">
+            <label for="from">From:</label>
+            <input type="date" id="from" name="from" value="{{ request.GET.from }}" onchange="this.form.submit()">
 
-                <label for="to">To:</label>
-                <input type="date" id="to" name="to" value="{{ request.GET.to }}" onchange="this.form.submit()">
+            <label for="to">To:</label>
+            <input type="date" id="to" name="to" value="{{ request.GET.to }}" onchange="this.form.submit()">
 
-                {% if request.GET.from or request.GET.to %}
-                <a href="{% url 'summaries' %}">Reset</a>
-                {% endif %}
-            </form>
-        </div>
+            {% if request.GET.from or request.GET.to %}
+            <a href="{% url 'summaries' %}">Reset</a>
+            {% endif %}
+        </form>
     </div>
     {% endif %}
+</div>
 
-<div class="summaries">
+<div class="split-left">
+    <div class="summaries">
 
-    {% for summary in summaries %}
+        {% for summary in summaries %}
 
-    <article class="summary">
-        <h2>
-            {% if not single_view %}
-            <a href="{% url 'board-summary' summary.board.id %}">
+        <article class="summary" id="summary-{{ summary.board.id }}">
+            <h2>
+                {% if not single_view %}
+                <a href="{% url 'board-summary' summary.board.id %}">
+                    {{ summary.board.date_closed|date }} ({{ summary.board.thread }}):
+                </a>
+                {% else %}
                 {{ summary.board.date_closed|date }} ({{ summary.board.thread }}):
-            </a>
-            {% else %}
-            {{ summary.board.date_closed|date }} ({{ summary.board.thread }}):
-            {% endif %}
-            <span class="focus">
-                {{ summary.board.focus }}
+                {% endif %}
+                <span class="focus">
+                    {{ summary.board.focus }}
 
 
-                <small>
-                    [{{ summary.board.date_started|date:"Y-m-d" }} –
-                    {{ summary.board.date_closed|date:"Y-m-d" }},
-                    {{ summary.days }} days]
-                </small>
-            </span>
-        </h2>
+                    <small>
+                        [{{ summary.board.date_started|date:"Y-m-d" }} –
+                        {{ summary.board.date_closed|date:"Y-m-d" }},
+                        {{ summary.days }} days]
+                    </small>
+                </span>
+            </h2>
 
-        <div class="boxes">
-            {% if summary.finished_count > 0 %}
-            <ol class="finished">
-                {% for item in summary.finished %}
-                    {% include "item.html" %}
-                {% endfor %}
-            </ol>
-            {% endif %}
-    
-            {% if summary.postponed_count > 0 %}
-            <ol class="postponed">
-                {% for item in summary.postponed %}
-                    {% include "item.html" %}
-                {% endfor %}
-            </ol>
-            {% endif %}
-            {% if summary.removed_count > 0 %}
-            <ol class="removed">
-                {% for item in summary.removed %}
-                    {% include "item.html" %}
-                {% endfor %}
-            </ol>
-            {% endif %}
-        </div>
-    </article>
+            <div class="boxes">
+                {% if summary.finished_count > 0 %}
+                <ol class="finished">
+                    {% for item in summary.finished %}
+                        {% include "item.html" %}
+                    {% endfor %}
+                </ol>
+                {% endif %}
 
-    {% endfor %}
+                {% if summary.postponed_count > 0 %}
+                <ol class="postponed">
+                    {% for item in summary.postponed %}
+                        {% include "item.html" %}
+                    {% endfor %}
+                </ol>
+                {% endif %}
+                {% if summary.removed_count > 0 %}
+                <ol class="removed">
+                    {% for item in summary.removed %}
+                        {% include "item.html" %}
+                    {% endfor %}
+                </ol>
+                {% endif %}
+            </div>
+        </article>
+
+        {% endfor %}
+    </div>
+</div>
+
 </div>
 
 {% endblock %}
-

--- a/tasks/templates/tree/habit_detail.html
+++ b/tasks/templates/tree/habit_detail.html
@@ -1,45 +1,71 @@
 {% extends "base.html" %}
 
-{% block body_class %}page-daily{% endblock %}
+{% block body_class %}page-rail{% endblock %}
 
 {% block title %}{{ object.name }} | Habits | Tasks Collector{% endblock %}
 
 {% block content %}
 
+<div class="split-layout content-rail">
 
 <div class="topbar">
     <div class="upper-pane">
         <h1>Habit: {{ object.name }}</h1>
-        <span class="topbar-meta on-right">Total events: {{ total_event_count }}</span>
+    </div>
+    <div class="lower-pane">
+        Total events: {{ total_event_count }}
     </div>
 </div>
 
-<section class="journal">
-    <div class="cont">
-    </div>
+<div class="split-left">
+    <section class="journal">
+        <div class="calendar" data-color-from="#8de0f3" data-color-to="#4199ad" data-color-negative="#bfab59">
+            {% include "tree/calendar.html" %}
+        </div>
 
-    <div class="calendar" data-color-from="#8de0f3" data-color-to="#4199ad" data-color-negative="#bfab59">
-        {% include "tree/calendar.html" %}
-    </div>
-
-    <main>
-        <ul>
-            {% regroup tracked_habits by published.date as entries_by_date %}
-            {% for date, entries in entries_by_date %}
-                <li id="{{ date|date:"b-d" }}">
-                    <strong>{{ date|date:"d F" }}</strong>
+        <main>
+            {% regroup tracked_habits by published|date:"F Y" as tracked_by_month %}
+            {% for month, month_events in tracked_by_month %}
+                <section class="habit-month" id="{{ month_events.0.published|date:"Y-m" }}">
+                    <h3>{{ month }}</h3>
                     <ul>
-                        {% for event in entries %}
-                            <li>
-                                {% include event.template %}
+                        {% regroup month_events by published.date as entries_by_date %}
+                        {% for date, entries in entries_by_date %}
+                            <li id="{{ date|date:"b-d" }}">
+                                <strong>{{ date|date:"d F" }}</strong>
+                                <ul>
+                                    {% for event in entries %}
+                                        <li>
+                                            {% include event.template %}
+                                        </li>
+                                    {% endfor %}
+                                </ul>
                             </li>
                         {% endfor %}
                     </ul>
-                </li>
+                </section>
             {% empty %}
-                <li>No journal entries for this month.</li>
+                <p>No occurrences yet.</p>
+            {% endfor %}
+        </main>
+    </section>
+</div>
+
+<div class="split-right">
+    <aside class="months">
+        <h2>Archive</h2>
+        <ul>
+            {% regroup tracked_habits by published|date:"F Y" as tracked_by_month %}
+            {% for month, month_events in tracked_by_month %}
+                <li>
+                    <a href="#{{ month_events.0.published|date:"Y-m" }}">
+                        {{ month }} ({{ month_events|length }})
+                    </a>
+                </li>
             {% endfor %}
         </ul>
-    </main>
-</section>
+    </aside>
+</div>
+
+</div>
 {% endblock %}

--- a/tasks/templates/tree/habit_list.html
+++ b/tasks/templates/tree/habit_list.html
@@ -1,32 +1,33 @@
 {% extends "base.html" %}
 
-{% block body_class %}page-daily{% endblock %}
+{% block body_class %}page-rail{% endblock %}
 
 {% block title %}Habits | Tasks Collector{% endblock %}
 
 {% block content %}
 
+<div class="split-layout content-rail no-rail">
 
 <div class="topbar"><div class="upper-pane"><h1>Habits</h1></div></div>
 
-<section class="journal">
-    <div class="cont">
-    </div>
+<div class="split-left">
+    <section class="journal">
+        <main>
+            <dl>
+                {% for habit in object_list %}
+                    <dt id="habit-{{ habit.slug }}">
+                        <strong><a href="{% url 'public-habit-detail' habit.slug %}">{{ habit.name }}</a></strong> ({{ habit.as_hashtags|join:', ' }})
+                    </dt>
+                    {% if habit.description %}
+                        <dd>
+                            {{ habit.description|linebreaks }}
+                        </dd>
+                    {% endif %}
+                {% endfor %}
+            </dl>
+        </main>
+    </section>
+</div>
 
-    <main>
-        <dl>
-            {% for habit in object_list %}
-                <dt>
-                    <strong><a href="{% url 'public-habit-detail' habit.slug %}">{{ habit.name }}</a></strong> ({{ habit.as_hashtags|join:', ' }})
-                </dt>
-                {% if habit.description %}
-                    <dd>
-                        {{ habit.description|linebreaks }}
-                    </dd>
-                {% endif %}
-            {% endfor %}
-        </dl>
-        </ul>
-    </main>
-</section>
+</div>
 {% endblock %}

--- a/tasks/templates/tree/journaladded_archive_month.html
+++ b/tasks/templates/tree/journaladded_archive_month.html
@@ -3,11 +3,11 @@
 
 {% block title %}Journal Entries for {{ month|date:"F Y" }}{% endblock %}
 
-{% block body_class %}page-diary{% endblock %}
+{% block body_class %}page-rail{% endblock %}
 
 {% block content %}
 
-<div class="split-layout">
+<div class="split-layout content-rail">
 
 <div class="topbar">
     <div class="upper-pane">

--- a/tasks/templates/tree/journaladded_archive_month.html
+++ b/tasks/templates/tree/journaladded_archive_month.html
@@ -3,9 +3,11 @@
 
 {% block title %}Journal Entries for {{ month|date:"F Y" }}{% endblock %}
 
-{% block body_class %}page-daily{% endblock %}
+{% block body_class %}page-diary{% endblock %}
 
 {% block content %}
+
+<div class="split-layout">
 
 <div class="topbar">
     <div class="upper-pane">
@@ -21,8 +23,8 @@
         {% endif %}
 
         {% for option_tag in tags %}
-            <option 
-                {% if option_tag.slug == tag.slug %}selected{% endif %} 
+            <option
+                {% if option_tag.slug == tag.slug %}selected{% endif %}
                 {% if is_current_month %}
                     value="{% url 'public-diary-archive-current-month-tag' option_tag.slug %}"
                 {% else %}
@@ -42,9 +44,59 @@
     </div>
 </div>
 
-<section class="journal">
-    <div class="cont">
-    </div>
+<div class="split-left">
+    <section class="journal">
+        <main>
+            <ul>
+                {% regroup object_list by published.date as entries_by_date %}
+                {% for date, entries in entries_by_date %}
+                    <li id="{{ date|date:"b-d" }}">
+                        <strong>{{ date|date:"d F (l)" }}</strong>
+                        <ul>
+                            {% for event in entries %}
+                                <li>
+                                    {% include "tree/events/journal_added.html" %}
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </li>
+                {% empty %}
+                    <li>No journal entries for this month.</li>
+                {% endfor %}
+            </ul>
+
+            <div class="pagination">
+                {% if previous_month %}
+                    {% if tag %}
+                        <a href="{% url 'public-diary-archive-month-tag' tag.slug previous_month.year previous_month.month %}">&laquo; Previous Month</a>
+                    {% else %}
+                        <a href="{% url 'public-diary-archive-month' previous_month.year previous_month.month %}">&laquo; Previous Month</a>
+                    {% endif %}
+                {% endif %}
+                {% if next_month %}
+                    {% if tag %}
+                        <a href="{% url 'public-diary-archive-month-tag' tag.slug next_month.year next_month.month %}">Next Month &raquo;</a>
+                    {% else %}
+                        <a href="{% url 'public-diary-archive-month' next_month.year next_month.month %}">Next Month &raquo;</a>
+                    {% endif %}
+                {% endif %}
+            </div>
+        </main>
+    </section>
+</div>
+
+<div class="split-right">
+    <aside class="days">
+        <h2>Days</h2>
+        <ul>
+        {% regroup object_list by published.date as entries_by_date %}
+        {% for date, entries in entries_by_date %}
+            <li>
+                <a href="#{{ date|date:"b-d" }}">{{ date|date:"d" }}</a>
+            </li>
+        {% endfor %}
+        </ul>
+    </aside>
 
     <aside class="months">
         <h2>Archive</h2>
@@ -62,54 +114,7 @@
             {% endfor %}
         </ul>
     </aside>
+</div>
 
-    <aside class="days">
-        <ul>
-        {% regroup object_list by published.date as entries_by_date %}
-        {% for date, entries in entries_by_date %}
-            <li>
-                <a href="#{{ date|date:"b-d" }}">{{ date|date:"d" }}</a>
-            </li>
-        {% endfor %}
-        </ul>
-    </aside>
-
-    <main>
-        <ul>
-            {% regroup object_list by published.date as entries_by_date %}
-            {% for date, entries in entries_by_date %}
-                <li id="{{ date|date:"b-d" }}">
-                    <strong>{{ date|date:"d F (l)" }}</strong>
-                    <ul>
-                        {% for event in entries %}
-                            <li>
-                                {% include "tree/events/journal_added.html" %}
-                            </li>
-                        {% endfor %}
-                    </ul>
-                </li>
-            {% empty %}
-                <li>No journal entries for this month.</li>
-            {% endfor %}
-        </ul>
-
-        <div class="pagination">
-            {% if previous_month %}
-                {% if tag %}
-                    <a href="{% url 'public-diary-archive-month-tag' tag.slug previous_month.year previous_month.month %}">&laquo; Previous Month</a>
-                {% else %}
-                    <a href="{% url 'public-diary-archive-month' previous_month.year previous_month.month %}">&laquo; Previous Month</a>
-                {% endif %}
-            {% endif %}
-            {% if next_month %}
-                {% if tag %}
-                    <a href="{% url 'public-diary-archive-month-tag' tag.slug next_month.year next_month.month %}">Next Month &raquo;</a>
-                {% else %}
-                    <a href="{% url 'public-diary-archive-month' next_month.year next_month.month %}">Next Month &raquo;</a>
-                {% endif %}
-            {% endif %}
-        </div>
-    </main>
-  
-</section>
+</div>
 {% endblock %}

--- a/tasks/templates/tree/trips/trip_detail.html
+++ b/tasks/templates/tree/trips/trip_detail.html
@@ -1,56 +1,52 @@
 {% extends 'base.html' %}
 
-{% block body_class %}page-daily{% endblock %}
+{% block body_class %}page-rail{% endblock %}
 
 {% block title %}{{ story }} | Trips{% endblock %}
 
 {% block content %}
 
-<section class="journal trip-entries">
-    <div class="cont">
-    </div>
+<div class="split-layout content-rail no-rail">
 
-    <h1>{{ story }}</h1>
-    <p class="trip-meta">
-        {{ story.started|date:"D, d M Y H:i" }}
+<div class="topbar">
+    <div class="upper-pane">
+        <h1>{{ story }}</h1>
+    </div>
+    <div class="lower-pane">
+        {{ story.started|date:"D, d M Y" }}
         {% if story.stopped %}
-            &ndash; {{ story.stopped|date:"D, d M Y H:i" }}
+            {% if story.started|date:"Y-m-d" != story.stopped|date:"Y-m-d" %}
+                &ndash; {{ story.stopped|date:"D, d M Y" }}
+            {% endif %}
         {% else %}
             &middot; <strong>active</strong>
         {% endif %}
-    </p>
+    </div>
+</div>
 
-    {% regroup events by published.date as entries_by_date %}
+<div class="split-left">
+    <section class="journal trip-entries">
+        <main>
+            <ul>
+                {% regroup events by published.date as entries_by_date %}
+                {% for date, day_events in entries_by_date %}
+                    <li id="{{ date|date:"b-d" }}">
+                        <strong>{{ date|date:"d F Y" }}</strong>
+                        <ul>
+                            {% for event in day_events %}
+                                <li>
+                                    {% include "tree/events/journal_added.html" with readonly=True hide_trip_marker=True %}
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </li>
+                {% empty %}
+                    <li>No entries in this trip yet.</li>
+                {% endfor %}
+            </ul>
+        </main>
+    </section>
+</div>
 
-    {% if entries_by_date|length > 1 %}
-    <aside class="days">
-        <ul>
-        {% for date, day_events in entries_by_date %}
-            <li>
-                <a href="#{{ date|date:"b-d" }}">{{ date|date:"d" }}</a>
-            </li>
-        {% endfor %}
-        </ul>
-    </aside>
-    {% endif %}
-
-    <main>
-        <ul>
-            {% for date, day_events in entries_by_date %}
-                <li id="{{ date|date:"b-d" }}">
-                    <strong>{{ date|date:"d F Y" }}</strong>
-                    <ul>
-                        {% for event in day_events %}
-                            <li>
-                                {% include "tree/events/journal_added.html" with readonly=True hide_trip_marker=True %}
-                            </li>
-                        {% endfor %}
-                    </ul>
-                </li>
-            {% empty %}
-                <li>No entries in this trip yet.</li>
-            {% endfor %}
-        </ul>
-    </main>
-</section>
+</div>
 {% endblock %}

--- a/tasks/templates/tree/trips/trip_list.html
+++ b/tasks/templates/tree/trips/trip_list.html
@@ -1,28 +1,16 @@
 {% extends 'base.html' %}
 
-{% block body_class %}page-daily{% endblock %}
+{% block body_class %}page-rail{% endblock %}
 
 {% block title %}Trips | Tasks Collector{% endblock %}
 
 {% block content %}
 
+<div class="split-layout content-rail">
+
 <div class="topbar"><div class="upper-pane"><h1>Trips</h1></div></div>
 
-<section class="journal">
-    <div class="cont">
-    </div>
-
-    <aside class="months">
-        <h2>Archive</h2>
-        <ul>
-            {% for month in months %}
-                <li>
-                    <a href="#{{ month|date:"Y-m" }}">{{ month|date:"F Y" }}</a>
-                </li>
-            {% endfor %}
-        </ul>
-    </aside>
-
+<div class="split-left">
     <main class="trip-months">
         {% regroup trips by started|date:"F Y" as trips_by_month %}
         {% for month, month_trips in trips_by_month %}
@@ -53,5 +41,20 @@
             <p>No trips yet.</p>
         {% endfor %}
     </main>
-</section>
+</div>
+
+<div class="split-right">
+    <aside class="months">
+        <h2>Archive</h2>
+        <ul>
+            {% for month in months %}
+                <li>
+                    <a href="#{{ month|date:"Y-m" }}">{{ month|date:"F Y" }}</a>
+                </li>
+            {% endfor %}
+        </ul>
+    </aside>
+</div>
+
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary

Introduces a reusable **`.split-layout.content-rail`** layout and rolls it out across the journal-style pages. It started as a diary redesign and grew into a shared layout system.

The pattern: a **white content column on the left**, in line with the topbar, plus an optional **transparent sticky nav rail on the right** (day jump-lists, month/section archives). A **`no-rail`** modifier gives a full-width single-column variant.

## Layout (`_layouts.scss`)
- `.split-layout.content-rail` — white left column (`minmax(50rem, 1fr)`) + 16rem transparent rail; neutralizes an embedded `section.journal` card; left-aligned pagination.
- Rail nav asides — default vertical link list (archives) + `.days` chips for day jump-lists.
- `&.no-rail` — single full-width column (drops the rail).
- `body.page-rail` — off-white backdrop the transparent rail shows through.
- Removed the now-redundant `.page-diary` block from `_daily.scss`.

## Pages
| Page | Rail | Notes |
|---|---|---|
| **Diary** | Days + month Archive | the original redesign |
| **Trips list** | month Archive | tiles in the white column |
| **Trip detail** | none (full-width) | dates moved to topbar **lower-pane**; same-day trips show a single date, not a range |
| **Task summaries** | none (full-width) | fills the column instead of a fixed 1140px centered block (list + single board view) |
| **Habits list** | none (full-width) | |
| **Single habit** | month **Archive** | occurrences grouped into month sections; rail shows `Month YYYY (count)` linking to each section; **Total events** moved to the lower-pane; contribution calendar left-aligned with its grey background removed |

## Verification
- `npm run build` compiles clean.
- Every affected page renders **200** end-to-end via Django's test client with real DB data, with the expected structure: content-rail / split-left / split-right presence, no-rail pages drop the right rail (only the global app sidebar aside remains), habit Archive anchors all match their month sections, and the trip date label collapses correctly for same-day / multi-day / active trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)