### PR TITLE
feat(observations): two-column master-detail list layout

### DIFF
--- a/tasks/apps/tree/templatetags/observation_menu.py
+++ b/tasks/apps/tree/templatetags/observation_menu.py
@@ -9,6 +9,8 @@ register = template.Library()
 def observation_menu(context, attach_mode=False):
     request = context["request"]
 
+    active = getattr(request.resolver_match, "url_name", None)
+
     return {
         "mine_count": Observation.objects.filter(user=request.user).count(),
         "open_count": Observation.objects.count(),
@@ -17,4 +19,5 @@ def observation_menu(context, attach_mode=False):
             InsightRefined.objects.values("event_stream_id").distinct().count()
         ),
         "attach_mode": attach_mode,
+        "active": active,
     }

--- a/tasks/assets/app.js
+++ b/tasks/assets/app.js
@@ -6,6 +6,7 @@
 import "./scripts/shared.js";
 import "./app.scss";
 import "./observation_search.js";
+import "./observation_master_detail.js";
 
 const nodeList = document.querySelectorAll(
     'article.observation'

--- a/tasks/assets/observation_master_detail.js
+++ b/tasks/assets/observation_master_detail.js
@@ -1,0 +1,63 @@
+// Master-detail interaction for the Observations pages (live / closed /
+// insights). The left column lists situations; clicking one reveals its full
+// detail panel in the right column — like selecting a message in an email
+// client. The first situation is selected on load (or, in attach mode, the base
+// observation the others are being attached to).
+
+const initObservationMasterDetail = () => {
+    const layout = document.querySelector(".observations-layout");
+    if (!layout) {
+        return;
+    }
+
+    const left = layout.querySelector(".split-left");
+    const right = layout.querySelector(".split-right");
+    if (!left || !right) {
+        return;
+    }
+
+    const items = [...left.querySelectorAll(".situation-item[data-obs]")];
+    const panels = [...right.querySelectorAll(".observation-detail[data-obs]")];
+    const empty = right.querySelector(".detail-empty");
+
+    if (panels.length === 0) {
+        return;
+    }
+
+    const select = (obs) => {
+        let matched = false;
+        items.forEach((item) =>
+            item.classList.toggle("selected", item.dataset.obs === obs)
+        );
+        panels.forEach((panel) => {
+            const show = panel.dataset.obs === obs;
+            panel.classList.toggle("shown", show);
+            if (show) {
+                matched = true;
+            }
+        });
+        if (empty) {
+            empty.style.display = matched ? "none" : "";
+        }
+    };
+
+    items.forEach((item) => {
+        item.addEventListener("click", (event) => {
+            // Leave the attach checkbox and any inline links to their own handlers.
+            if (event.target.closest("a, input, label")) {
+                return;
+            }
+            select(item.dataset.obs);
+        });
+    });
+
+    // Initial selection: the attach-mode base observation, otherwise the first.
+    const base = layout.dataset.baseObs;
+    if (base) {
+        select(base);
+    } else if (items.length) {
+        select(items[0].dataset.obs);
+    }
+};
+
+initObservationMasterDetail();

--- a/tasks/assets/observation_search.js
+++ b/tasks/assets/observation_search.js
@@ -1,9 +1,9 @@
-// Client-side filter for the observation list (/observations/).
+// Client-side filter for the Observations pages (live / closed / insights).
 //
 // All searchable text (situation, interpretation, approach and every update
-// comment) is already rendered into each article's `data-search` attribute by
-// the template, so this builds small in-memory stem indexes from the DOM and
-// hides the articles that don't match the query.
+// comment) is already rendered into each situation row's `data-search`
+// attribute by the template, so this builds small in-memory stem indexes from
+// the DOM and hides the situation rows that don't match the query.
 //
 // Stemming handles both Polish and English: every token is reduced by both the
 // Polish (lunr-languages) and English (lunr core) stemmers. Polish is only
@@ -115,7 +115,7 @@ const initObservationSearch = () => {
     }
 
     const articles = [
-        ...document.querySelectorAll("article.observation[data-search]"),
+        ...document.querySelectorAll(".situation-item[data-search]"),
     ];
 
     if (articles.length === 0) {
@@ -184,7 +184,11 @@ const initObservationSearch = () => {
         input.scrollIntoView({ behavior: "smooth", block: "start" });
     };
 
-    articles.forEach((article) => decorateTags(article, applyTag));
+    // Decorate [bracketed] shortcuts in both the situation list and the detail
+    // panels so they are clickable wherever they appear.
+    document
+        .querySelectorAll(".situation-item, .observation-detail")
+        .forEach((el) => decorateTags(el, applyTag));
 };
 
 initObservationSearch();

--- a/tasks/assets/styles/_observations.scss
+++ b/tasks/assets/styles/_observations.scss
@@ -399,3 +399,353 @@
         margin-left: 0;
     }
 }
+
+// === Observations: two-column master-detail layout (live / closed / insights) ===
+// An email-style reading view on the shared .split-layout grid: a white list of
+// situations on the left, the selected observation's full detail on the right.
+
+body.page-observations {
+    background: #f9f9f9;
+}
+
+.observations-layout {
+    // 40 / 60 split.
+    --split-cols: 2fr 3fr;
+
+    // Fixed viewport with independently scrolling columns (like a mail client).
+    height: 100vh;
+    overflow: hidden;
+
+    .split-left,
+    .split-right {
+        min-height: 0;
+        overflow-y: auto;
+    }
+
+    // Left: the white, shadowless situation list.
+    .split-left {
+        background: #fff;
+        border-right: 1px solid #e6e6e6;
+        padding: 0;
+    }
+
+    // Right: the reading pane.
+    .split-right {
+        background: #fff;
+        padding: 1.5rem 2rem 4rem;
+    }
+
+    // --- Upper pane: the filter sits in the middle, "+ New" on the right ---
+    .observation-filter-bar {
+        flex: 1 1 auto;
+        min-width: 0;
+        margin: 0 1rem;
+
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+    }
+
+    .observation-filter-input {
+        flex: 1 1 auto;
+        min-width: 0;
+
+        padding: 0.35rem 0.75rem;
+
+        font-size: 0.95rem;
+        color: #343434;
+
+        background: #fff;
+        border: 1px solid #d3d8de;
+        border-radius: 4px;
+
+        &::placeholder {
+            color: #aab1ba;
+        }
+
+        &:focus {
+            outline: 0;
+            border-color: #4a7dfb;
+            box-shadow: 0 0 0 0.15rem rgba(74, 125, 251, 0.2);
+        }
+    }
+
+    .observation-filter-count {
+        flex: 0 0 auto;
+        font-size: 0.8rem;
+        color: #999;
+        white-space: nowrap;
+    }
+
+    .btn-new {
+        flex: 0 0 auto;
+
+        padding: 0.3rem 0.75rem;
+
+        border: 1px solid #c7d8f5;
+        border-radius: 4px;
+        background: #eef3fd;
+        color: #3367d6;
+
+        text-decoration: none;
+        font-size: 0.9rem;
+        white-space: nowrap;
+
+        &:hover {
+            background: #e0eaff;
+        }
+    }
+}
+
+// --- Lower pane: the Mine / All / Closed / Insights tabs ---
+.page-observations .lower-pane {
+    align-items: stretch;
+    padding: 0 12px;
+    gap: 0;
+}
+
+.observation-tabs {
+    display: flex;
+    align-items: stretch;
+    width: 100%;
+
+    a {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+
+        padding: 0 0.9rem;
+
+        color: #666;
+        text-decoration: none;
+        font-size: 0.95rem;
+
+        border-bottom: 2px solid transparent;
+
+        &:hover {
+            color: #205e7d;
+        }
+
+        &.active {
+            color: #205e7d;
+            font-weight: 600;
+            border-bottom-color: #205e7d;
+        }
+
+        .badge {
+            display: inline-flex;
+            align-items: center;
+            line-height: 1;
+
+            font-size: 0.72rem;
+            font-weight: 600;
+            color: #888;
+            background: #eef0f2;
+            border-radius: 9px;
+            padding: 0.2em 0.45em;
+        }
+
+        &.active .badge {
+            color: #205e7d;
+            background: #dbe9f1;
+        }
+    }
+
+    .attach-exit {
+        margin-left: auto;
+        color: #c0392b;
+
+        &:hover {
+            color: color.adjust(#c0392b, $lightness: -10%);
+        }
+    }
+}
+
+// --- Left column: situation list ---
+.situation-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    .empty {
+        padding: 2rem 1.25rem;
+        color: #999;
+        font-style: italic;
+    }
+}
+
+.situation-item {
+    position: relative;
+
+    padding: 0.9rem 1.25rem;
+    border-bottom: 1px solid #eee;
+
+    cursor: pointer;
+
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+
+    transition: background 0.1s ease;
+
+    &:hover {
+        background: #f6f8fa;
+    }
+
+    &.selected {
+        background: #eef3fd;
+        box-shadow: inset 3px 0 0 #4a7dfb;
+    }
+
+    .situation-text {
+        color: #333;
+        font-weight: 600;
+        line-height: 1.4;
+
+        // Keep rows compact — a few lines, like an email subject/preview.
+        display: -webkit-box;
+        -webkit-line-clamp: 4;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+
+        p {
+            margin: 0;
+        }
+    }
+
+    .situation-meta {
+        color: #999;
+        font-size: 0.82rem;
+
+        .complex-badge {
+            font-style: normal;
+        }
+    }
+}
+
+// Attach mode: a checkbox in the gutter of each candidate row.
+.observations-layout.attach-mode {
+    .situation-item {
+        padding-left: 2.6rem;
+    }
+
+    .attach-toggle {
+        position: absolute;
+        left: 0.95rem;
+        top: 1.05rem;
+    }
+
+    .situation-item.is-base {
+        background: #fff7e6;
+        box-shadow: inset 3px 0 0 #ca8911;
+    }
+
+    .attach-hint {
+        margin: 0;
+        padding: 0.75rem 1.25rem;
+        background: #fff7e6;
+        border-bottom: 1px solid #f0e2c0;
+        color: #8a6d3b;
+        font-size: 0.9rem;
+    }
+}
+
+// --- Right column: detail pane ---
+.detail-empty {
+    color: #999;
+    font-style: italic;
+}
+
+.observation-detail {
+    display: none;
+    max-width: 48rem;
+
+    &.shown {
+        display: block;
+    }
+
+    .meta {
+        color: #999;
+        font-size: 1rem;
+        font-style: italic;
+
+        a {
+            color: #999;
+        }
+    }
+
+    .type {
+        color: #ca8911;
+    }
+
+    .strong {
+        color: #444;
+        font-weight: bold;
+        font-size: 1.15rem;
+        margin: 1rem 0;
+    }
+
+    .situation-italic {
+        font-style: italic;
+        color: #666;
+        margin-top: 0.5rem;
+    }
+
+    .label {
+        color: #999;
+        margin-top: 1.25rem;
+        margin-bottom: 0.25rem;
+    }
+
+    .update {
+        margin-top: 1rem;
+    }
+
+    hr.just-line {
+        border: 0;
+        border-top: 1px solid #eee;
+        margin: 1.5rem 0;
+    }
+
+    .complex-badge {
+        display: inline-block;
+        margin-left: 0.25rem;
+
+        color: #4a7dfb;
+
+        font-size: 0.8rem;
+        font-style: normal;
+        white-space: nowrap;
+    }
+
+    .detail-actions {
+        margin-top: 2rem;
+        display: flex;
+        gap: 0.75rem;
+
+        .btn {
+            padding: 0.4rem 0.9rem;
+
+            border-radius: 4px;
+            text-decoration: none;
+            font-size: 0.9rem;
+
+            background: #1a5f8d;
+            color: #fff;
+            border: 1px solid #1a5f8d;
+
+            &:hover {
+                background: color.adjust(#1a5f8d, $lightness: -8%);
+            }
+
+            &.btn-outline {
+                background: #fff;
+                color: #1a5f8d;
+
+                &:hover {
+                    background: #eef3fd;
+                }
+            }
+        }
+    }
+}

--- a/tasks/templates/tree/_observation_menu.html
+++ b/tasks/templates/tree/_observation_menu.html
@@ -1,9 +1,9 @@
-<p class="menu observation with-badges">
-    <a href="{% url 'public-observation-list' %}">Mine <span class="badge">{{ mine_count }}</span></a>
-    <a href="{% url 'public-observation-list-all' %}">All <span class="badge">{{ open_count }}</span></a>
-    <a href="{% url 'public-observation-list-closed' %}">Closed <span class="badge">{{ closed_count }}</span></a>
-    <a href="{% url 'public-insights-list' %}">Insights <span class="badge">{{ insights_count }}</span></a>
+<nav class="observation-tabs">
+    <a class="{% if active == 'public-observation-list' %}active{% endif %}" href="{% url 'public-observation-list' %}">Mine <span class="badge">{{ mine_count }}</span></a>
+    <a class="{% if active == 'public-observation-list-all' %}active{% endif %}" href="{% url 'public-observation-list-all' %}">All <span class="badge">{{ open_count }}</span></a>
+    <a class="{% if active == 'public-observation-list-closed' %}active{% endif %}" href="{% url 'public-observation-list-closed' %}">Closed <span class="badge">{{ closed_count }}</span></a>
+    <a class="{% if active == 'public-insights-list' %}active{% endif %}" href="{% url 'public-insights-list' %}">Insights <span class="badge">{{ insights_count }}</span></a>
     {% if attach_mode %}
-        <a href="?">Exit Attach Mode</a>
+        <a class="attach-exit" href="?">Exit Attach Mode</a>
     {% endif %}
-</p>
+</nav>

--- a/tasks/templates/tree/_observation_topbar.html
+++ b/tasks/templates/tree/_observation_topbar.html
@@ -1,0 +1,21 @@
+{% load observation_menu %}
+<div class="topbar">
+    <div class="upper-pane">
+        <h1>Observations</h1>
+
+        <div class="observation-filter-bar">
+            <input type="search"
+                   id="observation-filter"
+                   class="observation-filter-input"
+                   placeholder="Filter Observations (Polish/English)…"
+                   autocomplete="off"
+                   aria-label="Filter observations">
+            <span id="observation-filter-count" class="observation-filter-count" aria-live="polite"></span>
+        </div>
+
+        <a class="btn-new" href="{% url 'public-observation-add' %}">+ New</a>
+    </div>
+    <div class="lower-pane">
+        {% observation_menu attach_mode=attach_mode %}
+    </div>
+</div>

--- a/tasks/templates/tree/insights_list.html
+++ b/tasks/templates/tree/insights_list.html
@@ -2,35 +2,50 @@
 {% load render_assets %}
 {% load observation_menu %}
 
-{% block body_class %}page-daily{% endblock %}
+{% block body_class %}page-observations{% endblock %}
 
 {% block title %}Insights | Tasks Collector{% endblock %}
+
 {% block content %}
-<!-- Vue entry-point -->
 
+<div class="split-layout observations-layout" data-base-obs="">
 
-<div class="observations">
-    <div class="cont">
+    {% include "tree/_observation_topbar.html" %}
 
-        {% observation_menu %}
+    <div class="split-left">
+        <ul class="situation-list">
+            {% for insight in object_list %}
+                <li class="situation-item"
+                    data-obs="{{ insight.pk }}"
+                    data-search="{{ insight.situation|default:'' }} {{ insight.approach|default:'' }}">
+                    <div class="situation-text">{{ insight.situation|linebreaks }}</div>
+                    <div class="situation-meta">
+                        {{ insight.published|date }} ·
+                        <span class="type" style="color: {{ insight.type.color }};">{{ insight.type }}</span>
+                    </div>
+                </li>
+            {% empty %}
+                <li class="empty">No insights yet. Close an observation and extract an insight to get started.</li>
+            {% endfor %}
+        </ul>
     </div>
+
+    <div class="split-right">
+        <div class="detail-empty">Select an insight to view it.</div>
+
         {% for insight in object_list %}
-        <article class="observation" id="insight-{{ insight.pk }}">
+            <article class="observation-detail" data-obs="{{ insight.pk }}" id="insight-{{ insight.pk }}">
+                <div class="meta">{{ insight.published|date }} (<span class="type" style="color: {{ insight.type.color }};">{{ insight.type }}</span>; <span class="thread">{{ insight.thread }}</span> <a href="{% url 'public-insight-edit' insight.event_stream_id %}">edit</a>)</div>
+                <div class="strong">{{ insight.approach|linebreaks }}</div>
+                <div class="situation-italic">{{ insight.situation|linebreaks }}</div>
 
-            <div class="meta">
-                {{ insight.published|date }}
-                (<span class="type" style="color: {{ insight.type.color }};">{{ insight.type }}</span>;
-                <span class="thread">{{ insight.thread }}</span>
-                <a href="{% url 'public-insight-edit' insight.event_stream_id %}">$</a>)
-            </div>
-            <div class="strong">{{ insight.approach|linebreaks }}</div>
-            <div class="situation-italic">{{ insight.situation|linebreaks }}</div>
-        </article>
-
-        {% empty %}
-        <div class="empty">
-            No insights yet. Close an observation and extract an insight to get started.
-        </div>
+                <div class="detail-actions">
+                    <a href="{% url 'public-insight-edit' insight.event_stream_id %}" class="btn">Edit insight</a>
+                </div>
+            </article>
         {% endfor %}
+    </div>
+
 </div>
+
 {% endblock %}

--- a/tasks/templates/tree/observation_list.html
+++ b/tasks/templates/tree/observation_list.html
@@ -2,119 +2,122 @@
 {% load render_assets %}
 {% load observation_menu %}
 
-{% block body_class %}page-daily{% endblock %}
+{% block body_class %}page-observations{% endblock %}
 
 {% block title %}Observations | Tasks Collector{% endblock %}
 
 {% block content %}
-<!-- Vue entry-point -->
 
 {% csrf_token %}
-<div class="observations">
-    <div class="cont">
-        <div class="observation-filter-bar">
-            <input type="search"
-                   id="observation-filter"
-                   class="observation-filter-input"
-                   placeholder="Filter observations (Polish/English)…"
-                   autocomplete="off"
-                   aria-label="Filter observations">
-            <span id="observation-filter-count" class="observation-filter-count" aria-live="polite"></span>
-        </div>
+<div class="split-layout observations-layout{% if attach_mode %} attach-mode{% endif %}" data-base-obs="{{ attach_observation_id }}">
 
+    {% include "tree/_observation_topbar.html" %}
 
-        {% observation_menu attach_mode=attach_mode %}
-    </div>
-        {% for observation in object_list %}
-        <article class="observation{% if observation.attached_count %} is-complex{% endif %}"
-                 id="observation-{{ observation.pk }}"
-                 data-search="{{ observation.situation|default:'' }} {{ observation.interpretation|default:'' }} {{ observation.approach|default:'' }}{% for update in observation.observationupdated_set.all %} {{ update.comment|default:'' }}{% endfor %}">
-            {% if attach_mode and not attach_observation_id|stringformat:"s" == observation.pk|stringformat:"s" %}
-                <div class="attach-checkbox">
-                    <input type="checkbox" 
-                           id="attach-{{ observation.event_stream_id }}" 
-                           data-observation-id="{{ observation.pk }}"
-                           data-event-stream-id="{{ observation.event_stream_id }}"
-                           class="attach-toggle">
-                    <label for="attach-{{ observation.event_stream_id }}">Attach/Detach</label>
-                </div>
-            {% endif %}
+    <div class="split-left">
+        {% if attach_mode %}
+            <p class="attach-hint">Tick the observations to attach to <strong>#{{ attach_observation_id }}</strong>.</p>
+        {% endif %}
 
-            <div class="meta">{{ observation.pub_date }} (<span class="type" style="color: {{ observation.type.color }};">{{ observation.type }}</span>; <span class="thread">{{ observation.thread }}</span> <a href="{% url 'public-observation-edit' observation.pk %}">#{{ observation.pk }}</a>){% if observation.attached_count %} <span class="complex-badge" title="{{ observation.attached_count }} attached observation{{ observation.attached_count|pluralize }}">&#128206; {{ observation.attached_count }}</span>{% endif %}</div>
-            <div class="strong">{{ observation.situation|linebreaks }}</div>
-
-            <div class="expand">
-            <div class="label">How you saw it, what you felt?</div>
-            <div>{{ observation.interpretation|linebreaks }}</div>
-            <div class="label">How should you approach it in the future?</div>
-            <div>{{ observation.approach|linebreaks }}</div>
-
-            {% if not attach_mode %}
-                <a href="?attach_mode=true&observation_id={{ observation.pk }}" class="btn btn-sm btn-outline-secondary">Enter Attach Mode</a>
-            {% endif %}
-
-            {% if observation.observationupdated_set.all %}
-                <hr class="just-line">
-
-                {% for update in observation.observationupdated_set.all %}
-                    <div class="update">
-                        <p class="label">Updated on {{ update.published|date:"Y-m-d" }}</p>
-                        <div>
-                            {{ update.comment | linebreaks }}
-                        </div>
+        <ul class="situation-list">
+            {% for observation in object_list %}
+                <li class="situation-item{% if observation.attached_count %} is-complex{% endif %}{% if attach_mode and attach_observation_id|stringformat:"s" == observation.pk|stringformat:"s" %} is-base{% endif %}"
+                    data-obs="{{ observation.pk }}"
+                    data-search="{{ observation.situation|default:'' }} {{ observation.interpretation|default:'' }} {{ observation.approach|default:'' }}{% for update in observation.observationupdated_set.all %} {{ update.comment|default:'' }}{% endfor %}">
+                    {% if attach_mode and not attach_observation_id|stringformat:"s" == observation.pk|stringformat:"s" %}
+                        <input type="checkbox"
+                               id="attach-{{ observation.event_stream_id }}"
+                               data-observation-id="{{ observation.pk }}"
+                               data-event-stream-id="{{ observation.event_stream_id }}"
+                               class="attach-toggle"
+                               aria-label="Attach/Detach">
+                    {% endif %}
+                    <div class="situation-text">{{ observation.situation|linebreaks }}</div>
+                    <div class="situation-meta">
+                        {{ observation.pub_date }} ·
+                        <span class="type" style="color: {{ observation.type.color }};">{{ observation.type }}</span> ·
+                        #{{ observation.pk }}{% if observation.attached_count %} · <span class="complex-badge" title="{{ observation.attached_count }} attached">&#128206; {{ observation.attached_count }}</span>{% endif %}
                     </div>
-                {% endfor %}
-            {% endif %}
-            </div>
-        </article>
+                </li>
+            {% empty %}
+                <li class="empty">
+                    No observations yet. <a href="{% url 'public-observation-add' %}">Create your first observation</a>.
+                </li>
+            {% endfor %}
+        </ul>
+    </div>
 
-        {% empty %}
-        <div class="empty">
-            No observations yet. <a href="{% url 'public-observation-add' %}">Create your first observation</a>.
-        </div>
+    <div class="split-right">
+        <div class="detail-empty">Select an observation to view its details.</div>
+
+        {% for observation in object_list %}
+            <article class="observation-detail" data-obs="{{ observation.pk }}" id="observation-{{ observation.pk }}">
+                <div class="meta">{{ observation.pub_date }} (<span class="type" style="color: {{ observation.type.color }};">{{ observation.type }}</span>; <span class="thread">{{ observation.thread }}</span> <a href="{% url 'public-observation-edit' observation.pk %}">#{{ observation.pk }}</a>){% if observation.attached_count %} <span class="complex-badge" title="{{ observation.attached_count }} attached observation{{ observation.attached_count|pluralize }}">&#128206; {{ observation.attached_count }}</span>{% endif %}</div>
+                <div class="strong">{{ observation.situation|linebreaks }}</div>
+
+                <div class="label">How you saw it, what you felt?</div>
+                <div>{{ observation.interpretation|linebreaks }}</div>
+                <div class="label">How should you approach it in the future?</div>
+                <div>{{ observation.approach|linebreaks }}</div>
+
+                {% if observation.observationupdated_set.all %}
+                    <hr class="just-line">
+                    {% for update in observation.observationupdated_set.all %}
+                        <div class="update">
+                            <p class="label">Updated on {{ update.published|date:"Y-m-d" }}</p>
+                            <div>{{ update.comment|linebreaks }}</div>
+                        </div>
+                    {% endfor %}
+                {% endif %}
+
+                <div class="detail-actions">
+                    <a href="{% url 'public-observation-edit' observation.pk %}" class="btn">Edit</a>
+                    {% if not attach_mode %}
+                        <a href="?attach_mode=true&observation_id={{ observation.pk }}" class="btn btn-outline">Enter Attach Mode</a>
+                    {% endif %}
+                </div>
+            </article>
         {% endfor %}
+    </div>
+
 </div>
 
 {% endblock %}
 
-<!-- Load Vue app -->
 {% block extrajs %}
 {% if attach_mode %}
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     const attachObservationId = '{{ attach_observation_id }}';
-    
+
     // Load current attachments and set checkbox states
     fetch(`/observations/${attachObservationId}/attachments/`)
         .then(response => response.json())
         .then(data => {
             const attachedStreamIds = data.attached_observation_stream_ids;
-            
-            // Set checkbox states based on current attachments
+
             document.querySelectorAll('.attach-toggle').forEach(checkbox => {
                 const eventStreamId = checkbox.dataset.eventStreamId;
                 checkbox.checked = attachedStreamIds.includes(eventStreamId);
             });
         })
         .catch(error => console.error('Error loading attachments:', error));
-    
+
     // Handle checkbox clicks
     document.querySelectorAll('.attach-toggle').forEach(checkbox => {
         checkbox.addEventListener('change', function() {
             const eventStreamId = this.dataset.eventStreamId;
             const observationId = this.dataset.observationId;
             const isAttaching = this.checked;
-            
+
             const url = `/observations/${attachObservationId}/${isAttaching ? 'attach' : 'detach'}/`;
             const data = {
                 other_event_stream_id: eventStreamId
             };
-            
-            // Add observation_id for attach requests (as fallback)
+
             if (isAttaching) {
                 data.other_observation_id = observationId;
             }
-            
+
             fetch(url, {
                 method: 'POST',
                 headers: {
@@ -126,21 +129,18 @@ document.addEventListener('DOMContentLoaded', function() {
             .then(response => response.json())
             .then(data => {
                 if (data.error) {
-                    // Revert checkbox state on error
                     this.checked = !this.checked;
                     alert('Error: ' + data.error);
                 }
             })
             .catch(error => {
-                // Revert checkbox state on error
                 this.checked = !this.checked;
                 console.error('Error:', error);
                 alert('An error occurred. Please try again.');
             });
         });
     });
-    
-    // CSRF token helper function
+
     function getCookie(name) {
         let cookieValue = null;
         if (document.cookie && document.cookie !== '') {
@@ -159,4 +159,3 @@ document.addEventListener('DOMContentLoaded', function() {
 </script>
 {% endif %}
 {% endblock %}
-

--- a/tasks/templates/tree/observationclosed_list.html
+++ b/tasks/templates/tree/observationclosed_list.html
@@ -2,42 +2,54 @@
 {% load render_assets %}
 {% load observation_menu %}
 
-{% block body_class %}page-daily{% endblock %}
+{% block body_class %}page-observations{% endblock %}
 
 {% block title %}Closed Observations | Tasks Collector{% endblock %}
+
 {% block content %}
-<!-- Vue entry-point -->
 
+<div class="split-layout observations-layout" data-base-obs="">
 
-<div class="observations">
-    <div class="cont">
+    {% include "tree/_observation_topbar.html" %}
 
-        {% observation_menu %}
+    <div class="split-left">
+        <ul class="situation-list">
+            {% for observation in object_list %}
+                <li class="situation-item"
+                    data-obs="{{ observation.pk }}"
+                    data-search="{{ observation.situation|default:'' }} {{ observation.interpretation|default:'' }} {{ observation.approach|default:'' }}">
+                    <div class="situation-text">{{ observation.situation|linebreaks }}</div>
+                    <div class="situation-meta">
+                        {{ observation.published|date }} ·
+                        <span class="type" style="color: {{ observation.type.color }};">{{ observation.type }}</span>
+                    </div>
+                </li>
+            {% empty %}
+                <li class="empty">No closed observations yet.</li>
+            {% endfor %}
+        </ul>
     </div>
+
+    <div class="split-right">
+        <div class="detail-empty">Select an observation to view its details.</div>
+
         {% for observation in object_list %}
-        <article class="observation" id="observation-{{ observation.pk }}">
+            <article class="observation-detail" data-obs="{{ observation.pk }}" id="observation-{{ observation.pk }}">
+                <div class="meta">{{ observation.published|date }} (<span class="type" style="color: {{ observation.type.color }};">{{ observation.type }}</span>; <span class="thread">{{ observation.thread }}</span> <a href="{% url 'public-observation-closed-detail' observation.event_stream_id %}">details</a>)</div>
+                <div class="strong">{{ observation.situation|linebreaks }}</div>
 
-            <div class="meta">
-                {{ observation.published|date }}
-                (<span class="type" style="color: {{ observation.type.color }};">{{ observation.type }}</span>;
-                <span class="thread">{{ observation.thread }}</span>
-                <a href="{% url 'public-observation-closed-detail' observation.event_stream_id %}">$</a>)
-            </div>
-            <div class="strong">{{ observation.situation|linebreaks }}</div>
+                <div class="label">How you saw it, what you felt?</div>
+                <div>{{ observation.interpretation|linebreaks }}</div>
+                <div class="label">How should you approach it in the future?</div>
+                <div>{{ observation.approach|linebreaks }}</div>
 
-            <div class="expand">
-            <div class="label">How you saw it, what you felt?</div>
-            <div>{{ observation.interpretation|linebreaks }}</div>
-            <div class="label">How should you approach it in the future?</div>
-            <div>{{ observation.approach|linebreaks }}</div>
-            </div>
-        </article>
-
-        {% empty %}
-        <div class="empty">
-            No articles yet.
-        </div>
+                <div class="detail-actions">
+                    <a href="{% url 'public-observation-closed-detail' observation.event_stream_id %}" class="btn">View timeline</a>
+                </div>
+            </article>
         {% endfor %}
+    </div>
+
 </div>
 
 {% endblock %}


### PR DESCRIPTION
## Summary

Reworks the Observations pages (live / closed / insights) into an **email-style master-detail** view on the shared `.split-layout` grid — a white list of situations on the left, the selected item's full detail on the right — consistent across all three pages.

## Topbar
- **Upper pane**: "Observations" title (left) · **Filter** input (middle) · **+ New** (right).
- **Lower pane**: **Mine / All / Closed / Insights** tabs with counts and an active-tab underline.

## Layout
- **Left (40%)** — white, no shadows: situations only, separated by divider lines; clickable rows with hover/selected states; independently scrolls.
- **Right (60%)** — the selected observation's detail:
  - **Live**: meta, situation, interpretation, approach, **all updates**, + *Enter Attach Mode* / *Edit*.
  - **Closed**: same minus updates, + *View timeline*.
  - **Insights**: approach (bold) + situation (italic), + *Edit insight*.

## Attach mode (preserved)
*Enter Attach Mode* still reloads with `?attach_mode=true&observation_id=X`; the right pane pins to the base, left rows get attach/detach checkboxes (all but the base), a hint banner shows the base, and the existing attach/detach `fetch` JS is unchanged.

## JS
- New `observation_master_detail.js`: click a situation → reveal its panel; auto-selects the first row (or the base in attach mode).
- `observation_search.js` filter retargeted to the new `.situation-item` rows (Polish/English stemming + `[bracket]` shortcuts preserved, now on all three pages).

## Notes / decisions
- Right pane is read-oriented; editing stays on the existing editor (linked via *Edit*).
- Added a **+ New** action (the list had no create affordance).
- Kept the old `.observations` / `.menu.observation` styles — still used by the observation edit/detail and lessons pages.

## Verification
- `npm run build` compiles clean; **211 tree tests pass**.
- All pages render **200** with correct structure (situation rows ↔ detail panels, correct active tab); attach mode shows the `attach-mode` class, base row, and checkboxes on all non-base rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)