### PR TITLE
feat(observations): 3-column editor + matching closed/insight pages

### DIFF
--- a/tasks/assets/app.js
+++ b/tasks/assets/app.js
@@ -7,6 +7,7 @@ import "./scripts/shared.js";
 import "./app.scss";
 import "./observation_search.js";
 import "./observation_master_detail.js";
+import "./observation_edit.js";
 
 const nodeList = document.querySelectorAll(
     'article.observation'

--- a/tasks/assets/observation_edit.js
+++ b/tasks/assets/observation_edit.js
@@ -1,0 +1,203 @@
+// Single observation editor (/observations/<id>/): the collapsible History /
+// Complex drawer, the Close / Save burger dropdowns, and the Complex panel's
+// search / attach / detach behaviour.
+
+const initObservationEdit = () => {
+    const editor = document.querySelector(".observation-editor");
+    if (!editor) {
+        return;
+    }
+
+    const csrfToken = () => {
+        const field = editor.querySelector("[name=csrfmiddlewaretoken]");
+        return field ? field.value : "";
+    };
+
+    // --- Drawer: History / Complex toggle -------------------------------------
+    const railButtons = [...editor.querySelectorAll(".drawer-rail [data-drawer]")];
+    const panels = {
+        history: editor.querySelector(".drawer-history"),
+        complex: editor.querySelector(".drawer-complex"),
+    };
+    let currentDrawer = null;
+
+    const setDrawer = (mode) => {
+        // Clicking the active tab closes the drawer.
+        currentDrawer = currentDrawer === mode ? null : mode;
+        editor.classList.toggle("drawer-open", currentDrawer !== null);
+        railButtons.forEach((btn) =>
+            btn.classList.toggle("active", btn.dataset.drawer === currentDrawer)
+        );
+        Object.entries(panels).forEach(([key, panel]) => {
+            if (panel) {
+                panel.classList.toggle("shown", key === currentDrawer);
+            }
+        });
+    };
+
+    railButtons.forEach((btn) =>
+        btn.addEventListener("click", () => setDrawer(btn.dataset.drawer))
+    );
+
+    // --- Topbar burger dropdowns (Close / Save extra actions) -----------------
+    const menuToggles = [...editor.querySelectorAll(".burger[data-menu]")];
+
+    const closeAllMenus = () => {
+        editor.querySelectorAll(".action-menu").forEach((m) => (m.hidden = true));
+    };
+
+    menuToggles.forEach((toggle) => {
+        toggle.addEventListener("click", (event) => {
+            event.stopPropagation();
+            const menu = editor.querySelector(`#${toggle.dataset.menu}`);
+            if (!menu) {
+                return;
+            }
+            const willOpen = menu.hidden;
+            closeAllMenus();
+            menu.hidden = !willOpen;
+        });
+    });
+
+    document.addEventListener("click", (event) => {
+        if (!event.target.closest(".split-action")) {
+            closeAllMenus();
+        }
+    });
+
+    // --- Complex panel: search / attach / detach ------------------------------
+    const observationId = editor.dataset.observationId;
+    if (!observationId) {
+        return;
+    }
+
+    const searchInput = document.getElementById("observation-search");
+    const searchResults = document.getElementById("search-results");
+
+    const truncate = (text, length) =>
+        text && text.length > length ? `${text.slice(0, length)}…` : text || "";
+
+    const attachObservation = (otherId) => {
+        fetch(`/observations/${observationId}/attach/`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "X-CSRFToken": csrfToken(),
+            },
+            body: JSON.stringify({ other_observation_id: otherId }),
+        })
+            .then((response) => response.json())
+            .then((data) => {
+                if (data.id) {
+                    window.location.reload();
+                } else {
+                    alert(`Error attaching observation: ${data.error || "Unknown error"}`);
+                }
+            })
+            .catch((error) => {
+                console.error("Attach error:", error);
+                alert("Error attaching observation");
+            });
+    };
+
+    const displaySearchResults = (results) => {
+        if (!searchResults) {
+            return;
+        }
+        const attachedStreamIds = [
+            ...document.querySelectorAll(".attached-row"),
+        ].map((el) => el.dataset.streamId);
+
+        const html = (results || [])
+            .filter(
+                (obs) =>
+                    String(obs.id) !== String(observationId) &&
+                    !attachedStreamIds.includes(obs.event_stream_id)
+            )
+            .slice(0, 5)
+            .map(
+                (obs) => `
+                <div class="search-result" data-obs-id="${obs.id}" data-stream-id="${obs.event_stream_id}">
+                    <div class="result-situation"><strong>#${obs.id}:</strong> ${truncate(obs.situation, 100) || "No situation"}</div>
+                    <div class="result-meta">${obs.pub_date} - ${obs.thread}</div>
+                    <button type="button" class="attach-btn" data-obs-id="${obs.id}">Attach</button>
+                </div>`
+            )
+            .join("");
+
+        searchResults.innerHTML =
+            html || '<div class="no-results">No matching observations</div>';
+        searchResults.style.display = "block";
+
+        searchResults.querySelectorAll(".attach-btn").forEach((btn) =>
+            btn.addEventListener("click", () => attachObservation(btn.dataset.obsId))
+        );
+    };
+
+    if (searchInput && searchResults) {
+        let searchTimeout;
+        searchInput.addEventListener("input", function () {
+            const query = this.value.trim();
+            clearTimeout(searchTimeout);
+
+            if (query.length < 2) {
+                searchResults.innerHTML = "";
+                searchResults.style.display = "none";
+                return;
+            }
+
+            searchTimeout = setTimeout(() => {
+                fetch(
+                    `/observations/search/?q=${encodeURIComponent(query)}&observation=${observationId}`
+                )
+                    .then((response) => response.json())
+                    .then((data) => displaySearchResults(data.results || data))
+                    .catch((error) => {
+                        console.error("Search error:", error);
+                        searchResults.innerHTML =
+                            '<div class="search-error">Search error occurred</div>';
+                        searchResults.style.display = "block";
+                    });
+            }, 300);
+        });
+
+        document.addEventListener("click", (event) => {
+            if (!event.target.closest(".search-container")) {
+                searchResults.style.display = "none";
+            }
+        });
+    }
+
+    // Detach (event delegation — the rows are server-rendered).
+    document.addEventListener("click", (event) => {
+        const btn = event.target.closest(".detach-btn");
+        if (!btn) {
+            return;
+        }
+        if (!confirm("Detach this observation?")) {
+            return;
+        }
+        fetch(`/observations/${observationId}/detach/`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "X-CSRFToken": csrfToken(),
+            },
+            body: JSON.stringify({ other_event_stream_id: btn.dataset.streamId }),
+        })
+            .then((response) => response.json())
+            .then((data) => {
+                if (data.id) {
+                    window.location.reload();
+                } else {
+                    alert(`Error detaching observation: ${data.error || "Unknown error"}`);
+                }
+            })
+            .catch((error) => {
+                console.error("Detach error:", error);
+                alert("Error detaching observation");
+            });
+    });
+};
+
+initObservationEdit();

--- a/tasks/assets/styles/_general.scss
+++ b/tasks/assets/styles/_general.scss
@@ -61,6 +61,29 @@ body, html {
         font-size: 0.95rem;
     }
 
+    // Back affordance placed to the left of a topbar title.
+    .back-chevron {
+        flex: 0 0 auto;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+
+        width: 1.8rem;
+        height: 1.8rem;
+        margin-right: 0.25rem;
+
+        border-radius: 4px;
+        color: #666;
+        text-decoration: none;
+        font-size: 1.6rem;
+        line-height: 1;
+
+        &:hover {
+            background: #eef0f2;
+            color: #205e7d;
+        }
+    }
+
     // Shared primary-action button for top bars (Daily Submit, Breakthrough Save,
     // Board commit).
     button {

--- a/tasks/assets/styles/_observations.scss
+++ b/tasks/assets/styles/_observations.scss
@@ -400,6 +400,617 @@
     }
 }
 
+// === Single observation editor (three columns + collapsible drawer) ===
+// Form column (situation / interpretation / approach) | editable updates |
+// a History / Complex drawer that expands as a third column on demand. The
+// <form> itself is the grid container so the topbar Save buttons submit it and
+// the htmx Close buttons carry the CSRF token. Mirrors the Daily form style.
+
+body.page-observation-edit {
+    background: #f9f9f9;
+}
+
+// Shared topbar bits for the observation editor and the closed-observation view:
+// the truncated situation title (left) and the action buttons (right).
+// (The back chevron lives in _general.scss as a reusable topbar affordance.)
+.upper-pane .editor-title {
+    flex: 1 1 auto;
+    min-width: 0;
+
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: #343434;
+}
+
+.editor-actions {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    // The extract-insight action is a small <form>; let its button sit inline.
+    form {
+        display: contents;
+    }
+
+    button,
+    .btn-primary,
+    .btn-secondary {
+        display: inline-block;
+
+        font-family: inherit;
+        font-size: 0.9rem;
+        line-height: 1.4;
+        cursor: pointer;
+        text-decoration: none;
+
+        padding: 0.4rem 0.85rem;
+        border: 1px solid #c5ccd2;
+        border-radius: 4px;
+    }
+
+    .btn-primary {
+        background: #0066cc;
+        color: #fff;
+        border-color: #0066cc;
+
+        &:hover {
+            background: #0057c1;
+            color: #fff;
+        }
+    }
+
+    .btn-secondary {
+        background: #fff;
+        color: #555;
+
+        &:hover {
+            background: #f1f3f5;
+        }
+    }
+
+    .split-action {
+        position: relative;
+        display: flex;
+        align-items: stretch;
+
+        > button:first-child {
+            border-radius: 4px 0 0 4px;
+        }
+
+        > .burger {
+            border-radius: 0 4px 4px 0;
+            border-left: 0;
+            padding: 0.4rem 0.5rem;
+            font-size: 0.8rem;
+        }
+    }
+
+    .action-menu {
+        position: absolute;
+        top: 100%;
+        right: 0;
+        margin-top: 0.25rem;
+        z-index: 1200;
+
+        min-width: 14rem;
+
+        background: #fff;
+        border: 1px solid #d3d8de;
+        border-radius: 4px;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+
+        button {
+            display: block;
+            width: 100%;
+            text-align: left;
+            padding: 0.5rem 0.85rem;
+            border: 0;
+            background: transparent;
+            color: #343434;
+            white-space: nowrap;
+
+            &:hover {
+                background: #f1f3f5;
+                color: #343434;
+            }
+        }
+    }
+}
+
+.observation-editor {
+    height: 100vh;
+    overflow: hidden;
+
+    display: grid;
+    grid-template-rows: auto 1fr;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
+    grid-template-areas:
+        "header header"
+        "form   updates";
+
+    // Existing observations carry the drawer rail as a thin third column,
+    // expanding to a full panel when History or Complex is open.
+    &.with-drawer {
+        grid-template-columns: minmax(0, 2fr) minmax(0, 3fr) 2.75rem;
+        grid-template-areas:
+            "header header  header"
+            "form   updates drawer";
+
+        &.drawer-open {
+            grid-template-columns: minmax(0, 2fr) minmax(0, 3fr) 26rem;
+        }
+    }
+
+    > .topbar {
+        grid-area: header;
+        margin-bottom: 0;
+    }
+
+    .editor-form {
+        grid-area: form;
+    }
+    .editor-updates {
+        grid-area: updates;
+    }
+    .editor-drawer {
+        grid-area: drawer;
+    }
+
+    .editor-form,
+    .editor-updates {
+        min-height: 0;
+        overflow-y: auto;
+        padding: 1.5rem 2rem;
+    }
+
+    // The updates column is white; the form column and the drawer are
+    // transparent (page backdrop), separated by dividers.
+    .editor-form {
+        background: transparent;
+        border-right: 1px solid #e6e6e6;
+    }
+
+    .editor-updates {
+        background: #fff;
+    }
+
+    // Topbar title + action buttons are shared with the closed-observation
+    // view — see the top-level `.editor-title` / `.editor-actions` rules below.
+
+    // --- Left column: the observation form (Daily orange-underline style) ---
+    .editor-form {
+        .field {
+            margin-bottom: 1.5rem;
+        }
+
+        label {
+            display: block;
+            color: #999;
+            font-size: 0.9rem;
+            margin-bottom: 0.25rem;
+        }
+
+        textarea {
+            width: 100%;
+            display: block;
+            min-height: 5rem;
+
+            color: #e27410;
+            font-family: 'Raleway', sans-serif;
+            font-size: 1.3rem;
+
+            background-color: transparent;
+            border: 0;
+            border-bottom: 1px solid #d8dbdb;
+            padding: 0 0 0.25rem;
+            outline: none;
+
+            &::placeholder {
+                font-style: italic;
+                color: #999;
+            }
+        }
+
+        .field-meta {
+            display: flex;
+            gap: 1rem;
+            margin-top: 1rem;
+
+            .field {
+                flex: 1;
+                margin-bottom: 0;
+            }
+
+            select,
+            input {
+                width: 100%;
+                padding: 0.3rem 0.4rem;
+
+                border: 1px solid #e6e6e6;
+                border-radius: 4px;
+                background: #fff;
+
+                font-family: 'Raleway', sans-serif;
+                color: #205e7d;
+
+                &:focus {
+                    outline: none;
+                    border-color: #c7d8f5;
+                }
+            }
+        }
+    }
+
+    // --- Middle column: editable updates (and, on the insight page, the
+    //     original observation + history reference) ---
+    .editor-updates {
+        h3 {
+            margin-top: 0;
+            color: #999;
+        }
+
+        .meta {
+            color: #999;
+            font-size: 0.9rem;
+            font-style: italic;
+        }
+
+        hr.just-line {
+            border: 0;
+            border-top: 1px solid #e6e6e6;
+            margin: 2rem 0;
+        }
+
+        .event {
+            margin: 0.4rem 0;
+        }
+
+        .update-form {
+            margin-bottom: 1.25rem;
+
+            textarea {
+                width: 100%;
+
+                border: 1px solid #f0f2f2;
+                border-radius: 4px;
+                padding: 0.5rem 0.75rem;
+
+                font-family: 'Raleway', sans-serif;
+                font-size: 1rem;
+                color: #205e7d;
+                outline: none;
+
+                &:focus,
+                &:hover {
+                    border-color: #e0e6e6;
+                }
+            }
+
+            .delete-update {
+                display: inline-flex;
+                align-items: center;
+                gap: 0.3rem;
+                margin-top: 0.35rem;
+
+                color: #b94a48;
+                font-size: 0.85rem;
+            }
+        }
+    }
+
+    // --- Right column: drawer (rail + expanding panel) ---
+    .editor-drawer {
+        min-height: 0;
+        display: flex;
+        flex-direction: row;
+        overflow: hidden;
+
+        background: transparent;
+        border-left: 1px solid #e6e6e6;
+    }
+
+    .drawer-panels {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow-y: auto;
+        padding: 1.25rem 1.25rem 3rem;
+
+        display: none;
+    }
+
+    &.drawer-open .drawer-panels {
+        display: block;
+    }
+
+    .drawer-panel {
+        display: none;
+
+        &.shown {
+            display: block;
+        }
+
+        h3 {
+            margin-top: 0;
+            color: #999;
+        }
+
+        h4 {
+            color: #343a40;
+            font-size: 0.95rem;
+            margin: 1.25rem 0 0.5rem;
+        }
+
+        .drawer-empty {
+            color: #999;
+            font-style: italic;
+        }
+    }
+
+    .drawer-history .event {
+        margin: 0.4rem 0;
+    }
+
+    .drawer-rail {
+        flex: 0 0 2.75rem;
+        display: flex;
+        flex-direction: column;
+
+        border-left: 1px solid #e6e6e6;
+        background: #f3f4f6;
+
+        button {
+            flex: 1 1 auto;
+
+            border: 0;
+            border-bottom: 1px solid #e6e6e6;
+            background: transparent;
+            cursor: pointer;
+
+            color: #666;
+            font-family: inherit;
+            font-size: 0.85rem;
+
+            writing-mode: vertical-rl;
+            text-orientation: mixed;
+
+            &:hover {
+                background: #e9ecef;
+                color: #205e7d;
+            }
+
+            &.active {
+                background: #fff;
+                color: #205e7d;
+                font-weight: 600;
+            }
+        }
+    }
+
+    // --- Complex panel innards ---
+    .search-container {
+        position: relative;
+        margin-bottom: 1rem;
+    }
+
+    #observation-search {
+        width: 100%;
+        padding: 0.5rem;
+        border: 1px solid #ced4da;
+        border-radius: 4px;
+        font-size: 0.9rem;
+    }
+
+    .search-results {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        z-index: 1100;
+
+        background: #fff;
+        border: 1px solid #ced4da;
+        border-top: 0;
+        border-radius: 0 0 4px 4px;
+
+        max-height: 300px;
+        overflow-y: auto;
+
+        display: none;
+    }
+
+    .search-result {
+        padding: 0.6rem 0.75rem;
+        border-bottom: 1px solid #eee;
+        font-size: 0.85rem;
+
+        &:hover {
+            background: #f8f9fa;
+        }
+
+        .result-meta {
+            color: #999;
+            font-size: 0.78rem;
+        }
+
+        .attach-btn {
+            margin-top: 0.3rem;
+            padding: 0.2rem 0.5rem;
+
+            background: #1a5f8d;
+            color: #fff;
+            border: 0;
+            border-radius: 3px;
+            cursor: pointer;
+            font-size: 0.8rem;
+
+            &:hover {
+                background: color.adjust(#1a5f8d, $lightness: -8%);
+            }
+        }
+    }
+
+    .no-results,
+    .search-error,
+    .no-attached,
+    .no-events {
+        color: #999;
+        font-style: italic;
+        font-size: 0.85rem;
+        padding: 0.4rem 0;
+    }
+
+    // Compact, one-line attached observations.
+    .attached-list {
+        margin-bottom: 1rem;
+    }
+
+    .attached-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.5rem;
+
+        padding: 0.3rem 0;
+        border-bottom: 1px solid #eee;
+        font-size: 0.85rem;
+
+        .attached-sit {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        &.closed .attached-sit {
+            color: #999;
+        }
+
+        .detach-btn {
+            flex: 0 0 auto;
+            padding: 0 0.25rem;
+
+            background: transparent;
+            border: 0;
+            color: #b94a48;
+            cursor: pointer;
+            font-size: 1rem;
+            line-height: 1;
+
+            &:hover {
+                color: #922;
+            }
+        }
+    }
+
+    .attached-event {
+        margin-bottom: 0.4rem;
+        padding: 0.4rem 0.5rem;
+
+        border: 1px solid #eee;
+        border-radius: 4px;
+        font-size: 0.82rem;
+
+        .event-meta {
+            color: #999;
+            font-size: 0.75rem;
+            margin-bottom: 0.2rem;
+        }
+    }
+}
+
+// Read-only field display (closed observation fields, and the "Original
+// Observation" reference on the insight page). Black label, orange value to
+// mirror the editor's editable fields.
+.field-readonly {
+    margin-bottom: 2.5rem;
+
+    .label {
+        color: #1a1a1a;
+        font-size: 0.9rem;
+        margin-bottom: 0.25rem;
+    }
+
+    .value {
+        color: #e27410;
+        font-size: 1.3rem;
+
+        p:first-child {
+            margin-top: 0;
+        }
+
+        p:last-child {
+            margin-bottom: 0;
+        }
+    }
+}
+
+// === Closed observation detail (read-only): fields + history ===
+// Mirrors the editor's two main columns — final situation / interpretation /
+// approach on the (transparent) left, the event history on the (white) right.
+.observation-closed {
+    height: 100vh;
+    overflow: hidden;
+
+    display: grid;
+    grid-template-rows: auto 1fr;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
+    grid-template-areas:
+        "header header"
+        "fields history";
+
+    > .topbar {
+        grid-area: header;
+        margin-bottom: 0;
+    }
+
+    .closed-fields {
+        grid-area: fields;
+        background: transparent;
+        border-right: 1px solid #e6e6e6;
+    }
+
+    .closed-history {
+        grid-area: history;
+        background: #fff;
+    }
+
+    .closed-fields,
+    .closed-history {
+        min-height: 0;
+        overflow-y: auto;
+        padding: 1.5rem 2rem;
+    }
+
+    .closed-history {
+        h3 {
+            margin-top: 0;
+            color: #999;
+        }
+
+        .meta {
+            color: #999;
+            font-size: 0.9rem;
+            font-style: italic;
+        }
+
+        .event {
+            margin: 0.4rem 0;
+        }
+    }
+
+    .lower-pane {
+        gap: 1rem;
+
+        .closed-meta {
+            color: #999;
+        }
+    }
+}
+
 // === Observations: two-column master-detail layout (live / closed / insights) ===
 // An email-style reading view on the shared .split-layout grid: a white list of
 // situations on the left, the selected observation's full detail on the right.

--- a/tasks/templates/sidebar.html
+++ b/tasks/templates/sidebar.html
@@ -55,6 +55,13 @@ Two tiers: primary `.nav-item` rows and smaller, indented `.nav-item.sub` rows.
         </div>
 
         <div class="nav-row">
+            <a href="{% url 'public-insights-list' %}" class="nav-item sub{% if '/insights' in request.path %} active{% endif %}">
+                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"/><path d="M9 18h6"/><path d="M10 22h4"/></svg></span>
+                <span class="nav-label">Insights</span>
+            </a>
+        </div>
+
+        <div class="nav-row">
             <a href="/todo/" class="nav-item{% if '/todo' in request.path %} active{% endif %}">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M13 5h8"/><path d="M13 12h8"/><path d="M13 19h8"/><path d="m3 17 2 2 4-4"/><rect x="3" y="4" width="6" height="6" rx="1"/></svg></span>
                 <span class="nav-label">Tasks</span>

--- a/tasks/templates/tree/insight_edit.html
+++ b/tasks/templates/tree/insight_edit.html
@@ -1,60 +1,68 @@
 {% extends 'base.html' %}
-{% load render_assets %}
 
-{% block body_class %}page-daily{% endblock %}
+{% block body_class %}page-observation-edit{% endblock %}
 
 {% block title %}
-    {% if latest_insight %}
-        Edit Insight
-    {% else %}
-        Extract Insight
-    {% endif %}
+    {% if latest_insight %}Edit Insight{% else %}Extract Insight{% endif %}
 {% endblock %}
 
 {% block content %}
-<!-- Vue entry-point -->
 
-
-<div class="observations">
-    <div class="cont">
-    </div>
-
-<div class="observation-edit page">
-
-<form action="" method="POST">
+<form class="observation-editor" method="POST">
     {% csrf_token %}
 
-    <div class="form">
-
-        <div class="left">
-            <h3>Insight</h3>
-            <p class="meta">{{ instance.event_stream_id }} <br>Refine the situation and approach from your observation.</p>
-            {{ form.as_p }}
+    {# --- Topbar: original situation (left) + Save (right) --- #}
+    <div class="topbar">
+        <div class="upper-pane">
+            <a class="back-chevron" href="{% url 'public-insights-list' %}" aria-label="Back to insights">&lsaquo;</a>
+            <div class="editor-title">{{ instance.situation|truncatechars:100 }}</div>
+            <div class="editor-actions on-right">
+                <button type="submit" class="btn-primary">Save</button>
+            </div>
         </div>
-
-        <div class="right">
-            <h3>Original Observation</h3>
-            <p class="meta">Closed on {{ instance.published|date }}</p>
-            <div class="situation">
-                <strong>Situation</strong>
-                {{ instance.situation|linebreaks }}
-            </div>
-            <div class="interpretation">
-                <strong>Interpretation</strong>
-                {{ instance.interpretation|linebreaks }}
-            </div>
-            <div class="approach">
-                <strong>Approach</strong>
-                {{ instance.approach|linebreaks }}
-            </div>
+        <div class="lower-pane">
+            <span class="stream-id">{{ instance.event_stream_id }}</span>
+            <span class="closed-meta">{% if latest_insight %}Insight{% else %}New insight{% endif %} &middot; closed {{ instance.published|date }}</span>
         </div>
     </div>
-    <div class="submit">
-        <div class="submit-buttons">
-            <button class="submit">Save</button>
+
+    {# --- Left: editable insight fields --- #}
+    <div class="editor-form">
+        {{ form.non_field_errors }}
+
+        <div class="field">
+            <label for="{{ form.approach.id_for_label }}">Approach</label>
+            {{ form.approach }}
+            {{ form.approach.errors }}
+        </div>
+
+        <div class="field">
+            <label for="{{ form.situation.id_for_label }}">Situation</label>
+            {{ form.situation }}
+            {{ form.situation.errors }}
         </div>
     </div>
-    <div class="updates">
+
+    {# --- Right: original observation + history --- #}
+    <div class="editor-updates">
+        <h3>Original Observation</h3>
+
+        <div class="field-readonly">
+            <div class="label">Situation</div>
+            <div class="value">{{ instance.situation|linebreaks }}</div>
+        </div>
+        <div class="field-readonly">
+            <div class="label">Interpretation</div>
+            <div class="value">{{ instance.interpretation|linebreaks }}</div>
+        </div>
+        <div class="field-readonly">
+            <div class="label">Approach</div>
+            <div class="value">{{ instance.approach|linebreaks }}</div>
+        </div>
+
+        <hr class="just-line">
+
+        <h3>History</h3>
         {% for event in events %}
             <div class="event">
                 {% if event.template %}
@@ -65,8 +73,6 @@
             </div>
         {% endfor %}
     </div>
-</form>
-</div>
 
-</div>
+</form>
 {% endblock %}

--- a/tasks/templates/tree/observation_edit.html
+++ b/tasks/templates/tree/observation_edit.html
@@ -1,7 +1,6 @@
 {% extends 'base.html' %}
-{% load render_assets %}
 
-{% block body_class %}page-daily{% endblock %}
+{% block body_class %}page-observation-edit{% endblock %}
 
 {% block title %}
     {% if instance.situation %}
@@ -12,623 +11,177 @@
 {% endblock %}
 
 {% block content %}
-<!-- Vue entry-point -->
 
-
-<div class="observations">
-    <div class="cont">
-    </div>
-
-<div class="observation-edit page">
-
-{% if instance.pk %}
-<!-- Complex Observations Toggle Button -->
-<button type="button" id="complex-panel-toggle" class="panel-toggle">
-    <span class="toggle-text">{% if complex_presenter and complex_presenter.total_unique_observations_count > 0 %}Hide{% else %}Complex{% endif %}</span>
-</button>
-
-
-<!-- Complex Observations Side Panel -->
-<div id="complex-panel" class="complex-panel {% if complex_presenter and complex_presenter.total_unique_observations_count > 0 %}active{% endif %}">
-    <div class="complex-panel-header">
-        <h3>Complex Observation</h3>
-    </div>
-    
-    <div class="complex-panel-content">
-        {% if instance.pk %}
-        <!-- Search Bar -->
-        <div class="search-section">
-            <h4>Attach Observations</h4>
-            <div class="search-container">
-                <input type="text" id="observation-search" placeholder="Search observations..." autocomplete="off">
-                <div id="search-results" class="search-results"></div>
-            </div>
-        </div>
-        
-        <!-- Attached Observations -->
-        <div class="attached-section">
-            <h4>Attached Observations
-                {% if complex_presenter %}
-                    ({{ complex_presenter.total_unique_observations_count }})
-                {% endif %}
-            </h4>
-            <div id="attached-observations">
-                {% if complex_presenter %}
-                    {% for attached_info in complex_presenter.all_attached_observations_with_status %}
-                    <div class="attached-observation {% if attached_info.is_closed %}closed{% endif %}" data-stream-id="{{ attached_info.event_stream_id }}">
-                        <div class="attached-obs-header">
-                            {% if attached_info.is_closed %}
-                                <strong>[CLOSED] {{ attached_info.observation_closed.situation_truncated }}</strong>
-                            {% else %}
-                                <strong>{{ attached_info.observation.situation_truncated }}</strong>
-                            {% endif %}
-                            <button type="button" class="detach-btn" data-stream-id="{{ attached_info.event_stream_id }}">×</button>
-                        </div>
-                        <div class="attached-obs-content">
-                            {% if attached_info.is_closed %}
-                                <div class="attached-obs-situation">
-                                    <strong>Situation:</strong> {{ attached_info.observation_closed.situation|default:"—" }}
-                                </div>
-                                <div class="attached-obs-interpretation">
-                                    <strong>Interpretation:</strong> {{ attached_info.observation_closed.interpretation|default:"—" }}
-                                </div>
-                                <div class="attached-obs-approach">
-                                    <strong>Approach:</strong> {{ attached_info.observation_closed.approach|default:"—" }}
-                                </div>
-                            {% else %}
-                                <div class="attached-obs-situation">
-                                    <strong>Situation:</strong> {{ attached_info.observation.situation|default:"—" }}
-                                </div>
-                                <div class="attached-obs-interpretation">
-                                    <strong>Interpretation:</strong> {{ attached_info.observation.interpretation|default:"—" }}
-                                </div>
-                                <div class="attached-obs-approach">
-                                    <strong>Approach:</strong> {{ attached_info.observation.approach|default:"—" }}
-                                </div>
-                            {% endif %}
-                        </div>
-                    </div>
-                    {% empty %}
-                    <p class="no-attached">No observations attached yet.</p>
-                    {% endfor %}
-                {% else %}
-                    <p class="no-attached">Save observation first to enable complex features.</p>
-                {% endif %}
-            </div>
-        </div>
-        
-        <!-- Events from Attached Observations -->
-        {% if complex_presenter %}
-        <div class="attached-events-section">
-            <h4>Events from Attached Observations</h4>
-            <div class="attached-events">
-                {% for event in complex_presenter.all_attached_events_chronological %}
-                <div class="attached-event">
-                    <div class="event-meta">{{ event.published|date:"M d, Y H:i" }}</div>
-                    {% if event.template %}
-                        {% include event.template %}
-                    {% else %}
-                        {{ event }}
-                    {% endif %}
-                </div>
-                {% empty %}
-                <p class="no-events">No events from attached observations.</p>
-                {% endfor %}
-            </div>
-        </div>
-        {% endif %}
-        {% else %}
-        <p class="save-first">Save this observation first to enable complex observation features.</p>
-        {% endif %}
-    </div>
-</div>
-{% endif %}
-
-
-
-<form action="" method="POST">
+<form class="observation-editor{% if instance.pk %} with-drawer{% endif %}"
+      method="POST"
+      data-observation-id="{{ instance.pk|default:'' }}">
     {% csrf_token %}
 
-    <div class="form">
+    {# --- Topbar: truncated situation (left) + Close / Save actions (right) --- #}
+    <div class="topbar">
+        <div class="upper-pane">
+            <div class="editor-title">
+                {% if instance.situation %}{{ instance.situation|truncatechars:100 }}{% else %}Add an observation{% endif %}
+            </div>
 
-        <div class="left">
-            <h3>Observation</h3>
-            <p class="meta">{{ instance.event_stream_id }} <br>Provide situation, then interpretation and approach.</p>
-            {{ form.as_p }}     
-        </div>
+            <div class="editor-actions on-right">
+                {% if instance.pk %}
+                <div class="split-action">
+                    <button type="button" class="btn-secondary" hx-post="{% url 'public-observation-close' instance.pk %}">Close</button>
+                    <button type="button" class="btn-secondary burger" data-menu="menu-close" aria-label="More close options">☰</button>
+                    <div class="action-menu" id="menu-close" hidden>
+                        <button type="button" hx-post="{% url 'public-observation-close-and-extract' instance.pk %}">Close and extract insight</button>
+                    </div>
+                </div>
+                {% endif %}
 
-        <div class="right">
-            <h3>Updates</h3>
-            <p class="meta">Optional. All existing updates and up to 3 extra are here.</p>
-            {{ formset }}
+                <div class="split-action">
+                    <button type="submit" class="btn-primary">Save</button>
+                    <button type="button" class="btn-primary burger" data-menu="menu-save" aria-label="More save options">☰</button>
+                    <div class="action-menu" id="menu-save" hidden>
+                        <button type="submit" name="save_and_close" value="1">Save and go back</button>
+                    </div>
+                </div>
+            </div>
         </div>
-    </div>
-    <div class="submit">
-        <div class="submit-buttons">
-            <button class="submit">Save</button>
-            <button class="submit" name="save_and_close">Save and go back</button>
-        </div>
-        
-        {% if instance.pk %}
-        <div class="close">
-            <button class="close" hx-post="{% url 'public-observation-close' instance.pk %}">
-                Close observation
-            </button>
-            <button class="close" hx-post="{% url 'public-observation-close-and-extract' instance.pk %}">
-                Close and Extract Insight
-            </button>
+        {% if instance.event_stream_id %}
+        <div class="lower-pane">
+            <span class="stream-id">{{ instance.event_stream_id }}</span>
         </div>
         {% endif %}
     </div>
-    <div class="updates">
-        {% for event in events %}
-            <div class="event">
-                {% if event.template %}
-                    {% include event.template %}
-                {% else %}
-                    {{ event }}
+
+    {# --- Left column: the observation itself --- #}
+    <div class="editor-form">
+        {{ form.non_field_errors }}
+
+        <div class="field">
+            <label for="{{ form.situation.id_for_label }}">Situation</label>
+            {{ form.situation }}
+            {{ form.situation.errors }}
+        </div>
+
+        <div class="field">
+            <label for="{{ form.interpretation.id_for_label }}">How you saw it, what you felt?</label>
+            {{ form.interpretation }}
+            {{ form.interpretation.errors }}
+        </div>
+
+        <div class="field">
+            <label for="{{ form.approach.id_for_label }}">How should you approach it in the future?</label>
+            {{ form.approach }}
+            {{ form.approach.errors }}
+        </div>
+
+        <div class="field-meta">
+            <div class="field">
+                <label for="{{ form.pub_date.id_for_label }}">Date</label>
+                {{ form.pub_date }}
+                {{ form.pub_date.errors }}
+            </div>
+            <div class="field">
+                <label for="{{ form.type.id_for_label }}">Type</label>
+                {{ form.type }}
+                {{ form.type.errors }}
+            </div>
+            <div class="field">
+                <label for="{{ form.thread.id_for_label }}">Thread</label>
+                {{ form.thread }}
+                {{ form.thread.errors }}
+            </div>
+        </div>
+    </div>
+
+    {# --- Middle column: editable updates --- #}
+    <div class="editor-updates">
+        <h3>Updates</h3>
+        <p class="meta">All existing updates and up to 3 extra.</p>
+
+        {{ formset.management_form }}
+        {{ formset.non_form_errors }}
+
+        {% for update_form in formset %}
+            <div class="update-form">
+                {{ update_form.id }}
+                {{ update_form.comment }}
+                {{ update_form.comment.errors }}
+                {% if update_form.instance.pk %}
+                    <label class="delete-update">{{ update_form.DELETE }} delete</label>
                 {% endif %}
             </div>
         {% endfor %}
     </div>
-</form>
-</div>
 
-</div>
-{% endblock %}
+    {# --- Right column: collapsible drawer (History / Complex) --- #}
+    {% if instance.pk %}
+    <div class="editor-drawer">
+        <div class="drawer-panels">
+            <div class="drawer-panel drawer-history">
+                <h3>History</h3>
+                {% for event in events %}
+                    <div class="event">
+                        {% if event.template %}
+                            {% include event.template %}
+                        {% else %}
+                            {{ event }}
+                        {% endif %}
+                    </div>
+                {% empty %}
+                    <p class="drawer-empty">No history yet.</p>
+                {% endfor %}
+            </div>
 
-<!-- Load Vue app -->
-{% block extrajs %}
-{% if instance.pk %}
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    // Complex panel toggle functionality
-    const panelToggle = document.getElementById('complex-panel-toggle');
-    const complexPanel = document.getElementById('complex-panel');
-    const toggleText = panelToggle.querySelector('.toggle-text');
-    
-    // Initialize button visibility based on initial panel state
-    if (complexPanel.classList.contains('active')) {
-        panelToggle.style.display = 'none';
-    }
-    
-    panelToggle.addEventListener('click', function() {
-        complexPanel.classList.toggle('active');
-        const isActive = complexPanel.classList.contains('active');
-        toggleText.textContent = isActive ? 'Hide' : 'Complex';
-        panelToggle.style.display = isActive ? 'none' : 'block';
-    });
-    
-    // Search functionality
-    const searchInput = document.getElementById('observation-search');
-    const searchResults = document.getElementById('search-results');
-    let searchTimeout;
-    
-    searchInput.addEventListener('input', function() {
-        const query = this.value.trim();
-        
-        // Clear previous timeout
-        clearTimeout(searchTimeout);
-        
-        if (query.length < 2) {
-            searchResults.innerHTML = '';
-            searchResults.style.display = 'none';
-            return;
-        }
-        
-        // Debounce search
-        searchTimeout = setTimeout(() => {
-            const currentObsId = {{ instance.pk }};
-            fetch(`/observations/search/?q=${encodeURIComponent(query)}&observation=${currentObsId}`)
-                .then(response => response.json())
-                .then(data => {
-                    displaySearchResults(data.results || data);
-                })
-                .catch(error => {
-                    console.error('Search error:', error);
-                    searchResults.innerHTML = '<div class="search-error">Search error occurred</div>';
-                    searchResults.style.display = 'block';
-                });
-        }, 300);
-    });
-    
-    function displaySearchResults(results) {
-        if (results.length === 0) {
-            searchResults.innerHTML = '<div class="no-results">No observations found</div>';
-            searchResults.style.display = 'block';
-            return;
-        }
-        
-        const currentObsId = {{ instance.pk }};
-        const attachedStreamIds = Array.from(document.querySelectorAll('.attached-observation')).map(el => el.dataset.streamId);
-        
-        const truncate = (text, length) => {
-            return text.length > length ? text.slice(0, length) + '…' : text;
-        }
+            <div class="drawer-panel drawer-complex">
+                <h3>Complex Observation</h3>
 
-        const resultHtml = results
-            .filter(obs => obs.id !== currentObsId && !attachedStreamIds.includes(obs.event_stream_id))
-            .slice(0, 5) // Show max 5 results
-            .map(obs => `
-                <div class="search-result" data-obs-id="${obs.id}" data-stream-id="${obs.event_stream_id}">
-                    <div class="result-situation"><strong>#${obs.id}:</strong> ${truncate(obs.situation, 100) || 'No situation'}</div>
-                    <div class="result-meta">${obs.pub_date} - ${obs.thread}</div>
-                    <button type="button" class="attach-btn" data-obs-id="${obs.id}">Attach</button>
+                <div class="search-section">
+                    <div class="search-container">
+                        <input type="text" id="observation-search" placeholder="Search observations to attach…" autocomplete="off">
+                        <div id="search-results" class="search-results"></div>
+                    </div>
                 </div>
-            `).join('');
-        
-        if (resultHtml) {
-            searchResults.innerHTML = resultHtml;
-            searchResults.style.display = 'block';
-            
-            // Add click handlers for attach buttons
-            searchResults.querySelectorAll('.attach-btn').forEach(btn => {
-                btn.addEventListener('click', function() {
-                    const obsId = this.dataset.obsId;
-                    attachObservation(obsId);
-                });
-            });
-        } else {
-            searchResults.innerHTML = '<div class="no-results">All matching observations already attached</div>';
-            searchResults.style.display = 'block';
-        }
-    }
-    
-    // Hide search results when clicking outside
-    document.addEventListener('click', function(e) {
-        if (!e.target.closest('.search-container')) {
-            searchResults.style.display = 'none';
-        }
-    });
-    
-    // Attach observation function
-    function attachObservation(obsId) {
-        const currentObsId = {{ instance.pk }};
-        
-        fetch(`/observations/${currentObsId}/attach/`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value
-            },
-            body: JSON.stringify({
-                other_observation_id: obsId
-            })
-        })
-        .then(response => response.json())
-        .then(data => {
-            if (data.id) {
-                // Success - reload page to show updated attachments
-                window.location.reload();
-            } else {
-                alert('Error attaching observation: ' + (data.error || 'Unknown error'));
-            }
-        })
-        .catch(error => {
-            console.error('Attach error:', error);
-            alert('Error attaching observation');
-        });
-    }
-    
-    // Detach observation function
-    document.addEventListener('click', function(e) {
-        if (e.target.classList.contains('detach-btn')) {
-            const streamId = e.target.dataset.streamId;
-            const currentObsId = {{ instance.pk }};
-            
-            if (confirm('Are you sure you want to detach this observation?')) {
-                fetch(`/observations/${currentObsId}/detach/`, {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-CSRFToken': document.querySelector('[name=csrfmiddlewaretoken]').value
-                    },
-                    body: JSON.stringify({
-                        other_event_stream_id: streamId
-                    })
-                })
-                .then(response => response.json())
-                .then(data => {
-                    if (data.id) {
-                        // Success - reload page to show updated attachments
-                        window.location.reload();
-                    } else {
-                        alert('Error detaching observation: ' + (data.error || 'Unknown error'));
-                    }
-                })
-                .catch(error => {
-                    console.error('Detach error:', error);
-                    alert('Error detaching observation');
-                });
-            }
-        }
-    });
-    
-    // Accordion functionality for attached observations
-    document.addEventListener('click', function(e) {
-        if (e.target.closest('.attached-obs-header') && !e.target.closest('.detach-btn')) {
-            const header = e.target.closest('.attached-obs-header');
-            const attachedObs = header.closest('.attached-observation');
-            const content = attachedObs.querySelector('.attached-obs-content');
-            
-            // Toggle the content visibility
-            if (content.style.display === 'none') {
-                content.style.display = 'block';
-                attachedObs.classList.remove('collapsed');
-            } else {
-                content.style.display = 'none';
-                attachedObs.classList.add('collapsed');
-            }
-        }
-    });
-    
-    // Initialize all attached observations as collapsed
-    document.querySelectorAll('.attached-observation').forEach(function(attachedObs) {
-        const content = attachedObs.querySelector('.attached-obs-content');
-        if (content) {
-            content.style.display = 'none';
-            attachedObs.classList.add('collapsed');
-        }
-    });
-});
-</script>
 
-<style>
-/* Complex Panel Styles */
-.complex-panel {
-    position: fixed;
-    top: 0;
-    width: 400px;
-    height: 100vh;
-    left: -400px;
-    background: #f8f9fa;
-    border-right: 1px solid #dee2e6;
-    transition: left 0.3s ease;
-    z-index: 1000;
-    overflow-y: auto;
-    box-shadow: 2px 0 5px rgba(0,0,0,0.1);
-}
+                <div class="attached-section">
+                    <h4>Attached{% if complex_presenter %} ({{ complex_presenter.total_unique_observations_count }}){% endif %}</h4>
+                    <div id="attached-observations" class="attached-list">
+                        {% if complex_presenter %}
+                            {% for attached_info in complex_presenter.all_attached_observations_with_status %}
+                                <div class="attached-row{% if attached_info.is_closed %} closed{% endif %}" data-stream-id="{{ attached_info.event_stream_id }}">
+                                    <span class="attached-sit">{% if attached_info.is_closed %}[closed] {{ attached_info.observation_closed.situation_truncated }}{% else %}{{ attached_info.observation.situation_truncated }}{% endif %}</span>
+                                    <button type="button" class="detach-btn" data-stream-id="{{ attached_info.event_stream_id }}" aria-label="Detach">×</button>
+                                </div>
+                            {% empty %}
+                                <p class="no-attached">No observations attached yet.</p>
+                            {% endfor %}
+                        {% endif %}
+                    </div>
+                </div>
 
-.complex-panel.active {
-    left: 0;
-}
+                {% if complex_presenter %}
+                <div class="attached-events-section">
+                    <h4>Events from attached</h4>
+                    <div class="attached-events">
+                        {% for event in complex_presenter.all_attached_events_chronological %}
+                            <div class="attached-event">
+                                <div class="event-meta">{{ event.published|date:"M d, Y H:i" }}</div>
+                                {% if event.template %}{% include event.template %}{% else %}{{ event }}{% endif %}
+                            </div>
+                        {% empty %}
+                            <p class="no-events">No events from attached observations.</p>
+                        {% endfor %}
+                    </div>
+                </div>
+                {% endif %}
+            </div>
+        </div>
 
-.complex-panel-header {
-    padding: 1rem;
-    background: #343a40;
-    color: white;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
+        <div class="drawer-rail">
+            <button type="button" data-drawer="history">History</button>
+            <button type="button" data-drawer="complex">Complex</button>
+        </div>
+    </div>
+    {% endif %}
 
-.complex-panel-header h3 {
-    margin: 0;
-    font-size: 1.1rem;
-}
+</form>
 
-.panel-toggle {
-    position: fixed;
-    left: 10px;
-    top: 50%;
-    transform: translateY(-50%);
-    background: #6c757d;
-    color: white;
-    border: none;
-    padding: 0.5rem 1rem;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 0.9rem;
-    z-index: 1001;
-    writing-mode: vertical-lr;
-    text-orientation: mixed;
-    box-shadow: 2px 0 5px rgba(0,0,0,0.2);
-}
-
-.panel-toggle:hover {
-    background: #5a6268;
-}
-
-.complex-panel-content {
-    padding: 1rem;
-}
-
-.complex-panel h4 {
-    margin: 1.5rem 0 0.5rem 0;
-    font-size: 1rem;
-    color: #343a40;
-}
-
-.complex-panel h4:first-child {
-    margin-top: 0;
-}
-
-/* Search Styles */
-.search-container {
-    position: relative;
-    margin-bottom: 1rem;
-}
-
-#observation-search {
-    width: 100%;
-    padding: 0.5rem;
-    border: 1px solid #ced4da;
-    border-radius: 4px;
-    font-size: 0.9rem;
-}
-
-.search-results {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    background: white;
-    border: 1px solid #ced4da;
-    border-top: none;
-    border-radius: 0 0 4px 4px;
-    max-height: 300px;
-    overflow-y: auto;
-    z-index: 1001;
-    display: none;
-}
-
-.search-result {
-    padding: 0.75rem;
-    border-bottom: 1px solid #e9ecef;
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-}
-
-.search-result:hover {
-    background: #f8f9fa;
-}
-
-.result-situation {
-    font-weight: 500;
-    color: #343a40;
-    font-size: 0.9rem;
-}
-
-.result-meta {
-    font-size: 0.8rem;
-    color: #6c757d;
-}
-
-.attach-btn {
-    align-self: flex-start;
-    background: #007bff;
-    color: white;
-    border: none;
-    padding: 0.25rem 0.5rem;
-    border-radius: 3px;
-    cursor: pointer;
-    font-size: 0.8rem;
-    margin-top: 0.25rem;
-}
-
-.attach-btn:hover {
-    background: #0056b3;
-}
-
-.no-results, .search-error {
-    padding: 0.75rem;
-    text-align: center;
-    color: #6c757d;
-    font-size: 0.9rem;
-}
-
-/* Attached Observations Styles */
-.attached-observation {
-    background: white;
-    border: 1px solid #dee2e6;
-    border-radius: 4px;
-    margin-bottom: 0.75rem;
-    overflow: hidden;
-}
-
-.attached-observation.closed {
-    background: #f8f9fa;
-    border-left: 3px solid #6c757d;
-}
-
-.attached-observation.closed .attached-obs-header {
-    background: #e9ecef;
-    color: #6c757d;
-}
-
-.attached-obs-header {
-    padding: 0.75rem;
-    background: #e9ecef;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    font-size: 0.9rem;
-    cursor: pointer;
-    position: relative;
-}
-
-.attached-obs-header:hover {
-    background: #dee2e6;
-}
-
-.attached-obs-header::before {
-    content: '▼';
-    font-size: 0.7rem;
-    color: #6c757d;
-    margin-right: 0.5rem;
-    transition: transform 0.2s ease;
-    order: -1;
-}
-
-.attached-observation.collapsed .attached-obs-header::before {
-    transform: rotate(-90deg);
-}
-
-.detach-btn {
-    background: #dc3545;
-    color: white;
-    border: none;
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
-    cursor: pointer;
-    font-size: 0.9rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.detach-btn:hover {
-    background: #c82333;
-}
-
-.attached-obs-content {
-    padding: 0.75rem;
-    font-size: 0.85rem;
-}
-
-.attached-obs-content > div {
-    margin-bottom: 0.5rem;
-}
-
-.attached-obs-content > div:last-child {
-    margin-bottom: 0;
-}
-
-.attached-obs-content strong {
-    color: #495057;
-}
-
-/* Attached Events Styles */
-.attached-event {
-    background: white;
-    border: 1px solid #dee2e6;
-    border-radius: 4px;
-    margin-bottom: 0.5rem;
-    padding: 0.5rem;
-    font-size: 0.85rem;
-}
-
-.event-meta {
-    color: #6c757d;
-    font-size: 0.8rem;
-    margin-bottom: 0.25rem;
-}
-
-.no-attached, .no-events, .save-first {
-    color: #6c757d;
-    font-style: italic;
-    text-align: center;
-    padding: 1rem;
-}
-
-/* Adjust main content when panel is active */
-body:has(.complex-panel.active) .observation-edit {
-    /*margin-left: 400px;
-    transition: margin-left 0.3s ease;*/
-}
-</style>
-{% endif %}
 {% endblock %}
-

--- a/tasks/templates/tree/observationclosed_detail.html
+++ b/tasks/templates/tree/observationclosed_detail.html
@@ -1,61 +1,56 @@
 {% extends 'base.html' %}
-{% load render_assets %}
 
-{% block body_class %}page-daily{% endblock %}
+{% block body_class %}page-observation-edit{% endblock %}
 
-{% block title %}
-    {{ instance.situation_truncated }}
-{% endblock %}
+{% block title %}{{ instance.situation_truncated }}{% endblock %}
 
 {% block content %}
-<!-- Vue entry-point -->
 
+<div class="observation-closed">
 
-<div class="observations">
-    <div class="cont">
-    </div>
+    {# --- Topbar: truncated situation (left) + Insight action (right) --- #}
+    <div class="topbar">
+        <div class="upper-pane">
+            <a class="back-chevron" href="{% url 'public-observation-list-closed' %}" aria-label="Back to closed observations">&lsaquo;</a>
+            <div class="editor-title">{{ instance.situation|truncatechars:100 }}</div>
 
-<div class="observation-edit page">
-    <div class="form">
-
-        <div class="left">
-            <h3>Observation</h3>
-            <p class="meta">Opened for {{ time_to_closed }}</p>
-            <div class="situation">
-                {{ instance.situation|linebreaks }}
-            </div>
-            <div class="interpretation">
-                {{ instance.interpretation|linebreaks }}
-            </div>
-            <div class="approach">
-                {{ instance.approach|linebreaks }}
-            </div>
-
-            <div class="submit" style="margin-top: 1rem;">
+            <div class="editor-actions on-right">
                 {% if insight %}
-                    <a href="{% url 'public-insight-edit' instance.event_stream_id %}" class="btn btn-sm btn-outline-secondary">Edit Insight</a>
+                    <a class="btn-primary" href="{% url 'public-insight-edit' instance.event_stream_id %}">Insight</a>
                 {% else %}
-                    <form method="POST" action="{% url 'public-observation-extract-insight' instance.event_stream_id %}">
+                    <form method="post" action="{% url 'public-observation-extract-insight' instance.event_stream_id %}">
                         {% csrf_token %}
-                        <button type="submit" class="btn btn-sm btn-outline-primary">Extract Insight</button>
+                        <button type="submit" class="btn-primary">Extract insight</button>
                     </form>
                 {% endif %}
             </div>
         </div>
-
-        <div class="right">
-            <h3>Updates</h3>
-            <p class="meta"></p>
-            {% for update in updates %}
-                <div class="update">
-                    {{ update.comment|linebreaks }}
-                </div>
-            {% endfor %}
+        <div class="lower-pane">
+            <span class="stream-id">{{ instance.event_stream_id }}</span>
+            <span class="closed-meta">Opened for {{ time_to_closed }}</span>
         </div>
     </div>
-    <div class="updates">
-        <p class="meta">{{ events|length }} events total</p>
 
+    {# --- Left: the final, read-only observation --- #}
+    <div class="closed-fields">
+        <div class="field-readonly">
+            <div class="label">Situation</div>
+            <div class="value">{{ instance.situation|linebreaks }}</div>
+        </div>
+        <div class="field-readonly">
+            <div class="label">How you saw it, what you felt?</div>
+            <div class="value">{{ instance.interpretation|linebreaks }}</div>
+        </div>
+        <div class="field-readonly">
+            <div class="label">How should you approach it in the future?</div>
+            <div class="value">{{ instance.approach|linebreaks }}</div>
+        </div>
+    </div>
+
+    {# --- Right: the full event history --- #}
+    <div class="closed-history">
+        <h3>History</h3>
+        <p class="meta">{{ events|length }} event{{ events|length|pluralize }} total</p>
         {% for event in events %}
             <div class="event">
                 {% if event.template %}
@@ -66,7 +61,6 @@
             </div>
         {% endfor %}
     </div>
-</div>
 
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary

Redesigns the single observation **edit** page and aligns the **closed-observation** and **insight** pages to the same workspace layout (topbar over columns, scrolling independently). Also adds an **Insights** item to the sidebar.

## Editor (`/observations/<id>/`)
The `<form>` is the grid container, so the topbar buttons submit it and the htmx Close buttons carry the CSRF token.
- **Topbar**: truncated situation (left); **Close** (secondary) + burger → *Close and extract insight*, and **Save** (primary) + burger → *Save and go back* (right); `event_stream_id` in the lower pane.
- **Left** — situation / interpretation / approach as Daily-style orange-underline textareas (transparent), with a compact date/type/thread row.
- **Middle** — editable updates (white).
- **Right** — a collapsible **History / Complex** drawer (rail of vertical tabs; default closed). Attached observations are now compact **one-line** rows.
- The old inline `<style>`/`<script>` moved to `_observations.scss` and a new `observation_edit.js` module.

## Closed observation (`/observations/closed/<id>/`)
- Read-only situation/interpretation/approach (transparent left, **black labels + orange values**) | event **History** (white right).
- **Insight** action in the topbar (link if it exists, else *Extract insight*), and a back **chevron** to the closed list.

## Insight (`/insights/<id>/`)
- Editable **Approach / Situation** (left) | **Original Observation** + divider + **History** (right).
- **Save** in the topbar; back chevron to the insights list.

## Shared / sidebar
- Factored shared topbar bits out: `.editor-title` / `.editor-actions`, `.field-readonly`, and a reusable `.back-chevron` in `_general.scss`.
- Added an **Insights** sub-item under Observations in the left sidebar (lightbulb icon).

## Verification
- `npm run build` clean; **211 tree tests pass**.
- Editor (existing + new), closed detail (insight / no-insight branches) and insight edit all render **200** with the expected structure; both the editor and insight **forms round-trip (POST → 302)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)