### PR TITLE
feat(breakthrough): workspace layout for projected outcome history

### DIFF
--- a/tasks/assets/styles/_breakthrough.scss
+++ b/tasks/assets/styles/_breakthrough.scss
@@ -28,55 +28,63 @@
     }
 }
 
-// Projected Outcome Events History styles
-.projected-outcome-history {
-    max-width: 900px;
-    margin: 0 auto;
-    padding: 20px;
+// Projected Outcome event history — same workspace layout as the observation
+// editor: current status (transparent left) + event history (white right).
+body.page-outcome-history {
+    background: #f9f9f9;
 }
 
-.outcome-summary {
-    background: #f8f9fa;
-    padding: 20px;
-    border-radius: 8px;
-    margin-bottom: 30px;
+.projected-outcome-workspace {
+    height: 100vh;
+    overflow: hidden;
 
-    .outcome-info p {
-        margin-bottom: 10px;
+    display: grid;
+    grid-template-rows: auto 1fr;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
+    grid-template-areas:
+        "header header"
+        "status history";
+
+    > .topbar {
+        grid-area: header;
+        margin-bottom: 0;
     }
-}
 
-.timeline {
-    position: relative;
-    padding-left: 30px;
+    .outcome-status {
+        grid-area: status;
+        background: transparent;
+        border-right: 1px solid #e6e6e6;
+    }
 
-    &::before {
-        content: '';
-        position: absolute;
-        left: 15px;
-        top: 0;
-        bottom: 0;
-        width: 2px;
-        background: #dee2e6;
+    .outcome-history {
+        grid-area: history;
+        background: #fff;
+    }
+
+    .outcome-status,
+    .outcome-history {
+        min-height: 0;
+        overflow-y: auto;
+        padding: 1.5rem 2rem;
+    }
+
+    // Column headings (not the per-event headings inside the timeline).
+    .outcome-status > h3,
+    .outcome-history > h3 {
+        margin-top: 0;
+        color: #999;
+    }
+
+    // Status fields use the shared .field-readonly style (black label + orange
+    // 1.3rem value, matching the observation fields).
+    .meta {
+        color: #999;
+        font-size: 0.9rem;
     }
 }
 
 .timeline-event {
-    position: relative;
     margin-bottom: 30px;
-
-    &::before {
-        content: '';
-        position: absolute;
-        left: -8px;
-        top: 10px;
-        width: 12px;
-        height: 12px;
-        border-radius: 50%;
-        background: #007bff;
-        border: 2px solid white;
-        box-shadow: 0 0 0 2px #dee2e6;
-    }
 }
 
 .event-date {
@@ -88,14 +96,9 @@
     color: #6c757d;
 }
 
-.projected-outcome-history .event-content {
-    background: white;
-    border: 1px solid #dee2e6;
-    border-radius: 8px;
-    padding: 20px;
-}
-
 .event-type {
+    padding-left: 1rem;
+
     h3 {
         margin: 0 0 15px 0;
         font-size: 1.1em;

--- a/tasks/templates/tree/observation_list.html
+++ b/tasks/templates/tree/observation_list.html
@@ -35,7 +35,7 @@
                     <div class="situation-meta">
                         {{ observation.pub_date }} ·
                         <span class="type" style="color: {{ observation.type.color }};">{{ observation.type }}</span> ·
-                        #{{ observation.pk }}{% if observation.attached_count %} · <span class="complex-badge" title="{{ observation.attached_count }} attached">&#128206; {{ observation.attached_count }}</span>{% endif %}
+                        #{{ observation.pk }}{% with update_count=observation.observationupdated_set.all|length %}{% if update_count %} · {{ update_count }} update{{ update_count|pluralize }}{% endif %}{% endwith %}{% if observation.attached_count %} · <span class="complex-badge" title="{{ observation.attached_count }} attached">&#128206; {{ observation.attached_count }}</span>{% endif %}
                     </div>
                 </li>
             {% empty %}

--- a/tasks/templates/tree/projected_outcome_events_history.html
+++ b/tasks/templates/tree/projected_outcome_events_history.html
@@ -1,173 +1,189 @@
 {% extends 'base.html' %}
 {% load render_assets model_presenters humanize %}
 
-{% block body_class %}page-daily{% endblock %}
+{% block body_class %}page-outcome-history{% endblock %}
 
 {% block title %}
     {% if projected_outcome %}{{ projected_outcome.name }}{% elif latest_closed_event %}{{ latest_closed_event.name }} (Closed){% else %}Projected Outcome{% endif %} - Event History
 {% endblock %}
 
 {% block content %}
-<div class="container">
-    <main class="projected-outcome-history">
-        <header>
-            <h1>{% if projected_outcome %}{{ projected_outcome.name }}{% elif latest_closed_event %}{{ latest_closed_event.name }} (Closed){% else %}Projected Outcome{% endif %} - Event History</h1>
-            <p class="meta">
-                {% if projected_outcome %}
-                    <a href="{% url 'breakthrough' year=projected_outcome.breakthrough.published.year %}">&larr; Back to {{ projected_outcome.breakthrough.published.year }} Breakthrough</a>
-                {% else %}
-                    <a href="javascript:history.back()">&larr; Back</a>
-                {% endif %}
-            </p>
-        </header>
 
-        {% if projected_outcome %}
-        <div class="projected-outcome-details">
-            <section class="outcome-summary">
-                <h2>Current Status</h2>
-                <div class="outcome-info">
-                    <p><strong>Name:</strong> {{ projected_outcome.name }}</p>
-                    <p><strong>Target Date:</strong> {{ projected_outcome.resolved_by }}</p>
-                    <p><strong>Confidence Level:</strong> {{ projected_outcome.confidence_level|floatformat }}%</p>
-                    <p><strong>Description:</strong> {{ projected_outcome.description|linebreaksbr }}</p>
-                    {% if projected_outcome.success_criteria %}
-                        <p><strong>Success Criteria:</strong> {{ projected_outcome.success_criteria|linebreaksbr }}</p>
-                    {% endif %}
-                </div>
-            </section>
-        </div>
-        {% elif latest_closed_event %}
-        <div class="projected-outcome-details">
-            <section class="outcome-summary closed-outcome">
-                <h2>Final Status (Closed)</h2>
-                <div class="outcome-info">
-                    <p><strong>Final Name:</strong> {{ latest_closed_event.name }}</p>
-                    <p><strong>Final Target Date:</strong> {{ latest_closed_event.resolved_by }}</p>
-                    <p><strong>Final Description:</strong> {{ latest_closed_event.description|linebreaksbr }}</p>
-                    {% if latest_closed_event.success_criteria %}
-                        <p><strong>Final Success Criteria:</strong> {{ latest_closed_event.success_criteria|linebreaksbr }}</p>
-                    {% endif %}
-                    <p class="meta">
-                        <em>This projected outcome was closed on {{ latest_closed_event.published|date:"M d, Y \a\t H:i" }}. 
-                        The above represents the final state at the time of closure.</em>
-                    </p>
-                </div>
-            </section>
-        </div>
-        {% else %}
-        <div class="projected-outcome-details">
-            <section class="outcome-summary">
-                <h2>Archived Projected Outcome</h2>
-                <p class="meta">This projected outcome has been removed, but its event history is preserved below.</p>
-            </section>
-        </div>
-        {% endif %}
+<div class="projected-outcome-workspace">
 
-        <div class="events-timeline">
-            <h2>Event History</h2>
-            
-            {% if all_events %}
-                <div class="timeline">
-                    {% for event in all_events %}
-                        <div class="timeline-event">
-                            <div class="event-date">
-                                <span class="date">{{ event.published|date:"M d, Y" }}</span>
-                                <span class="time">{{ event.published|date:"H:i" }}</span>
-                            </div>
-                            
-                            <div class="event-content">
-                                {% if event in made_events %}
-                                    <div class="event-type event-made">
-                                        <h3>📝 Projected Outcome Created</h3>
-                                        <div class="event-details">
-                                            <p><strong>Name:</strong> {{ event.name }}</p>
-                                            <p><strong>Target Date:</strong> {{ event.resolved_by }}</p>
-                                            <p><strong>Description:</strong> {{ event.description|linebreaksbr }}</p>
-                                            {% if event.success_criteria %}
-                                                <p><strong>Success Criteria:</strong> {{ event.success_criteria|linebreaksbr }}</p>
-                                            {% endif %}
-                                        </div>
-                                    </div>
-                                {% elif event in redefined_events %}
-                                    <div class="event-type event-redefined">
-                                        <h3>✏️ Projected Outcome Redefined</h3>
-                                        <div class="event-details">
-                                            {% if event.old_name and event.new_name and event.old_name != event.new_name %}
-                                                <p><strong>Name changed:</strong> 
-                                                    <del>{{ event.old_name }}</del> → <ins>{{ event.new_name }}</ins>
-                                                </p>
-                                            {% endif %}
-                                            {% if event.old_description and event.new_description and event.old_description != event.new_description %}
-                                                <p><strong>Description changed:</strong></p>
-                                                <div class="change-diff">
-                                                    <div class="old-value"><del>{{ event.old_description|linebreaksbr }}</del></div>
-                                                    <div class="new-value"><ins>{{ event.new_description|linebreaksbr }}</ins></div>
-                                                </div>
-                                            {% endif %}
-                                            {% if event.old_success_criteria != event.new_success_criteria %}
-                                                <p><strong>Success Criteria changed:</strong></p>
-                                                <div class="change-diff">
-                                                    {% if event.old_success_criteria %}
-                                                        <div class="old-value"><del>{{ event.old_success_criteria|linebreaksbr }}</del></div>
-                                                    {% endif %}
-                                                    {% if event.new_success_criteria %}
-                                                        <div class="new-value"><ins>{{ event.new_success_criteria|linebreaksbr }}</ins></div>
-                                                    {% endif %}
-                                                </div>
-                                            {% endif %}
-                                        </div>
-                                    </div>
-                                {% elif event in rescheduled_events %}
-                                    <div class="event-type event-rescheduled">
-                                        <h3>📅 Projected Outcome Rescheduled</h3>
-                                        <div class="event-details">
-                                            <p><strong>Target Date changed:</strong> 
-                                                <del>{{ event.old_resolved_by }}</del> → <ins>{{ event.new_resolved_by }}</ins>
-                                            </p>
-                                        </div>
-                                    </div>
-                                {% elif event in closed_events %}
-                                    <div class="event-type event-closed">
-                                        <h3>✅ Projected Outcome Closed</h3>
-                                        <div class="event-details">
-                                            <p><strong>Final Name:</strong> {{ event.name }}</p>
-                                            <p><strong>Final Target Date:</strong> {{ event.resolved_by }}</p>
-                                            <p><strong>Final Description:</strong> {{ event.description|linebreaksbr }}</p>
-                                            {% if event.success_criteria %}
-                                                <p><strong>Final Success Criteria:</strong> {{ event.success_criteria|linebreaksbr }}</p>
-                                            {% endif %}
-                                        </div>
-                                    </div>
-                                {% elif event in moved_events %}
-                                    <div class="event-type event-moved">
-                                        <h3>➡️ Projected Outcome Moved</h3>
-                                        <div class="event-details">
-                                            <p><strong>Moved from:</strong> {{ event.old_breakthrough.slug }} → <strong>{{ event.new_breakthrough.slug }}</strong></p>
-                                            <p><strong>Confidence at move:</strong> {{ event.confidence_level|floatformat }}%</p>
-                                            <p><strong>Name:</strong> {{ event.name }}</p>
-                                            <p><strong>Target Date:</strong> {{ event.resolved_by }}</p>
-                                            <p><strong>Description:</strong> {{ event.description|linebreaksbr }}</p>
-                                            {% if event.success_criteria %}
-                                                <p><strong>Success Criteria:</strong> {{ event.success_criteria|linebreaksbr }}</p>
-                                            {% endif %}
-                                        </div>
-                                    </div>
-                                {% elif event in evolved_events %}
-                                    <div class="event-type event-evolved">
-                                        <h3>🌱 Projected Outcome Evolved</h3>
-                                        <div class="event-details">
-                                            <p>{{ event.note }}</p>
-                                        </div>
-                                    </div>
-                                {% endif %}
-                            </div>
-                        </div>
-                    {% endfor %}
-                </div>
+    {# --- Topbar: outcome name (left) + back chevron --- #}
+    <div class="topbar">
+        <div class="upper-pane">
+            {% if projected_outcome %}
+                <a class="back-chevron" href="{% url 'breakthrough' year=projected_outcome.breakthrough.published.year %}" aria-label="Back to Breakthrough">&lsaquo;</a>
             {% else %}
-                <p class="no-events">No events found for this projected outcome.</p>
+                <a class="back-chevron" href="javascript:history.back()" aria-label="Back">&lsaquo;</a>
             {% endif %}
+            <div class="editor-title">{% if projected_outcome %}{{ projected_outcome.name }}{% elif latest_closed_event %}{{ latest_closed_event.name }} (Closed){% else %}Projected Outcome{% endif %}</div>
         </div>
-    </main>
+    </div>
+
+    {# --- Left: current status --- #}
+    <div class="outcome-status">
+        {% if projected_outcome %}
+            <h3>Current Status</h3>
+            <div class="field-readonly">
+                <div class="label">Name</div>
+                <div class="value">{{ projected_outcome.name }}</div>
+            </div>
+            <div class="field-readonly">
+                <div class="label">Target Date</div>
+                <div class="value">{{ projected_outcome.resolved_by }}</div>
+            </div>
+            <div class="field-readonly">
+                <div class="label">Confidence Level</div>
+                <div class="value">{{ projected_outcome.confidence_level|floatformat }}%</div>
+            </div>
+            <div class="field-readonly">
+                <div class="label">Description</div>
+                <div class="value">{{ projected_outcome.description|linebreaksbr }}</div>
+            </div>
+            {% if projected_outcome.success_criteria %}
+                <div class="field-readonly">
+                    <div class="label">Success Criteria</div>
+                    <div class="value">{{ projected_outcome.success_criteria|linebreaksbr }}</div>
+                </div>
+            {% endif %}
+        {% elif latest_closed_event %}
+            <h3>Final Status (Closed)</h3>
+            <div class="field-readonly">
+                <div class="label">Final Name</div>
+                <div class="value">{{ latest_closed_event.name }}</div>
+            </div>
+            <div class="field-readonly">
+                <div class="label">Final Target Date</div>
+                <div class="value">{{ latest_closed_event.resolved_by }}</div>
+            </div>
+            <div class="field-readonly">
+                <div class="label">Final Description</div>
+                <div class="value">{{ latest_closed_event.description|linebreaksbr }}</div>
+            </div>
+            {% if latest_closed_event.success_criteria %}
+                <div class="field-readonly">
+                    <div class="label">Final Success Criteria</div>
+                    <div class="value">{{ latest_closed_event.success_criteria|linebreaksbr }}</div>
+                </div>
+            {% endif %}
+            <p class="meta">
+                <em>Closed on {{ latest_closed_event.published|date:"M d, Y \a\t H:i" }}. The above is the final state at closure.</em>
+            </p>
+        {% else %}
+            <h3>Archived Projected Outcome</h3>
+            <p class="meta">This projected outcome has been removed, but its event history is preserved.</p>
+        {% endif %}
+    </div>
+
+    {# --- Right: event history --- #}
+    <div class="outcome-history">
+        <h3>Event History</h3>
+
+        {% if all_events %}
+            <div class="timeline">
+                {% for event in all_events %}
+                    <div class="timeline-event">
+                        <div class="event-date">
+                            <span class="date">{{ event.published|date:"M d, Y" }}</span>
+                            <span class="time">{{ event.published|date:"H:i" }}</span>
+                        </div>
+
+                        <div class="event-content">
+                            {% if event in made_events %}
+                                <div class="event-type event-made">
+                                    <h3>📝 Projected Outcome Created</h3>
+                                    <div class="event-details">
+                                        <p><strong>Name:</strong> {{ event.name }}</p>
+                                        <p><strong>Target Date:</strong> {{ event.resolved_by }}</p>
+                                        <p><strong>Description:</strong> {{ event.description|linebreaksbr }}</p>
+                                        {% if event.success_criteria %}
+                                            <p><strong>Success Criteria:</strong> {{ event.success_criteria|linebreaksbr }}</p>
+                                        {% endif %}
+                                    </div>
+                                </div>
+                            {% elif event in redefined_events %}
+                                <div class="event-type event-redefined">
+                                    <h3>✏️ Projected Outcome Redefined</h3>
+                                    <div class="event-details">
+                                        {% if event.old_name and event.new_name and event.old_name != event.new_name %}
+                                            <p><strong>Name changed:</strong>
+                                                <del>{{ event.old_name }}</del> → <ins>{{ event.new_name }}</ins>
+                                            </p>
+                                        {% endif %}
+                                        {% if event.old_description and event.new_description and event.old_description != event.new_description %}
+                                            <p><strong>Description changed:</strong></p>
+                                            <div class="change-diff">
+                                                <div class="old-value"><del>{{ event.old_description|linebreaksbr }}</del></div>
+                                                <div class="new-value"><ins>{{ event.new_description|linebreaksbr }}</ins></div>
+                                            </div>
+                                        {% endif %}
+                                        {% if event.old_success_criteria != event.new_success_criteria %}
+                                            <p><strong>Success Criteria changed:</strong></p>
+                                            <div class="change-diff">
+                                                {% if event.old_success_criteria %}
+                                                    <div class="old-value"><del>{{ event.old_success_criteria|linebreaksbr }}</del></div>
+                                                {% endif %}
+                                                {% if event.new_success_criteria %}
+                                                    <div class="new-value"><ins>{{ event.new_success_criteria|linebreaksbr }}</ins></div>
+                                                {% endif %}
+                                            </div>
+                                        {% endif %}
+                                    </div>
+                                </div>
+                            {% elif event in rescheduled_events %}
+                                <div class="event-type event-rescheduled">
+                                    <h3>📅 Projected Outcome Rescheduled</h3>
+                                    <div class="event-details">
+                                        <p><strong>Target Date changed:</strong>
+                                            <del>{{ event.old_resolved_by }}</del> → <ins>{{ event.new_resolved_by }}</ins>
+                                        </p>
+                                    </div>
+                                </div>
+                            {% elif event in closed_events %}
+                                <div class="event-type event-closed">
+                                    <h3>✅ Projected Outcome Closed</h3>
+                                    <div class="event-details">
+                                        <p><strong>Final Name:</strong> {{ event.name }}</p>
+                                        <p><strong>Final Target Date:</strong> {{ event.resolved_by }}</p>
+                                        <p><strong>Final Description:</strong> {{ event.description|linebreaksbr }}</p>
+                                        {% if event.success_criteria %}
+                                            <p><strong>Final Success Criteria:</strong> {{ event.success_criteria|linebreaksbr }}</p>
+                                        {% endif %}
+                                    </div>
+                                </div>
+                            {% elif event in moved_events %}
+                                <div class="event-type event-moved">
+                                    <h3>➡️ Projected Outcome Moved</h3>
+                                    <div class="event-details">
+                                        <p><strong>Moved from:</strong> {{ event.old_breakthrough.slug }} → <strong>{{ event.new_breakthrough.slug }}</strong></p>
+                                        <p><strong>Confidence at move:</strong> {{ event.confidence_level|floatformat }}%</p>
+                                        <p><strong>Name:</strong> {{ event.name }}</p>
+                                        <p><strong>Target Date:</strong> {{ event.resolved_by }}</p>
+                                        <p><strong>Description:</strong> {{ event.description|linebreaksbr }}</p>
+                                        {% if event.success_criteria %}
+                                            <p><strong>Success Criteria:</strong> {{ event.success_criteria|linebreaksbr }}</p>
+                                        {% endif %}
+                                    </div>
+                                </div>
+                            {% elif event in evolved_events %}
+                                <div class="event-type event-evolved">
+                                    <h3>🌱 Projected Outcome Evolved</h3>
+                                    <div class="event-details">
+                                        <p>{{ event.note }}</p>
+                                    </div>
+                                </div>
+                            {% endif %}
+                        </div>
+                    </div>
+                {% endfor %}
+            </div>
+        {% else %}
+            <p class="no-events">No events found for this projected outcome.</p>
+        {% endif %}
+    </div>
+
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary

Brings the **Projected Outcome — Event History** page onto the same two-column workspace layout used by the observation editor / closed / insight pages, and adds an update count to the active observations list.

## Projected outcome history (`/projected-outcome/<id>/events/`)
- Topbar with the outcome name and a back **chevron** (to the Breakthrough year, or history-back for archived outcomes).
- **Left (transparent)** — **Current Status** (or Final Status / Archived). The fields reuse the shared `.field-readonly` style: label on its own line, **value in orange at `1.3rem`** (matching the observation input fields).
- **Right (white)** — the **Event History** timeline.
- Flattened the timeline: removed the connector line (`.timeline::before`) and the event dots (`.timeline-event::before`), dropped the `.event-content` border/padding, and gave each `.event-type` `padding-left: 1rem` so the colored left bar is the only marker.

## Active observations list
- Show the **update count after the `#id`** in each situation row (e.g. `#324 · 3 updates`, pluralized, only when there are updates). Uses the prefetched `observationupdated_set`, so no extra queries.

## Notes
- Reuses `.field-readonly`, `.back-chevron` and `.editor-title` introduced in the observation-editor PR (already merged to `main`).

## Verification
- `npm run build` clean; **211 tree tests pass**.
- Both the active and closed projected-outcome pages render **200** with the status/history columns, back chevron and timeline; the observation list shows the update count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)