### PR TITLE
feat(board): unify topbar across Board, Eisenhower and MoSCoW

### DIFF
--- a/tasks/assets/components/Board.vue
+++ b/tasks/assets/components/Board.vue
@@ -1,48 +1,6 @@
 <template>
     <div class="board">
-        <div class="topbar">
-            <div class="upper-pane">
-                <h1>{{ startDate }}: <input v-model="focus" @blur="saveState" @keyup.stop></h1>
-                <button @click.prevent="prepareCommit" class="on-right">commit</button>
-            </div>
-            <div class="lower-pane">
-                <button @click.prevent="addItem">+</button>
-                <select @change="changeThread($event)">
-                    <option v-for="thread in threads" :key="thread.id" :value="thread.id" :selected="thread.id == currentThreadId">
-                        {{ thread.name }}
-                    </option>
-                </select>
-
-                <button @click.prevent="toggleListViewMode" class="secondary">{{ listViewMode ? 'tree' : 'list' }}</button>
-
-                <router-link class="menulink" to="/">Board</router-link>
-                <router-link class="menulink" to="/eisenhower">Eisenhower</router-link>
-                <router-link class="menulink" to="/moscow">MoSCoW</router-link>
-
-                <select
-                    v-show="!listViewMode"
-                    v-model="filterMode"
-                    class="filter-select"
-                >
-                    <option value="all">all</option>
-                    <option value="important">important</option>
-                    <option value="deprecated">deprecated</option>
-                    <option value="finalizing">clearable</option>
-                    <optgroup label="MoSCoW">
-                        <option value="moscow-must">Must have</option>
-                        <option value="moscow-should">Should have</option>
-                        <option value="moscow-could">Could have</option>
-                        <option value="moscow-wont">Won't have</option>
-                    </optgroup>
-                    <optgroup label="Eisenhower">
-                        <option value="eisenhower-urgent-important">Urgent &amp; Important</option>
-                        <option value="eisenhower-not-urgent-important">Not Urgent &amp; Important</option>
-                        <option value="eisenhower-urgent-not-important">Urgent &amp; Not Important</option>
-                        <option value="eisenhower-not-urgent-not-important">Not Urgent &amp; Not Important</option>
-                    </optgroup>
-                </select>
-            </div>
-        </div>
+        <BoardTopbar />
 
         <tree
             v-show="!listViewMode"
@@ -58,13 +16,6 @@
 
         <TreeListView v-show="listViewMode" />
 
-        <CommitConfirmationModal
-            :show="showCommitModal"
-            :items-to-remove="itemsToRemove"
-            @confirm="confirmCommit"
-            @cancel="cancelCommit"
-        />
-
         <GlobalEvents
             v-if="normalContext"
             @keyup.i="addItem"
@@ -78,51 +29,38 @@
 </template>
 <script>
 
-import { mapGetters, mapActions, mapState } from 'vuex'
+import { mapGetters, mapActions } from 'vuex'
 
-import { createTreeItem, promisifyTimeout } from '../utils'
+import { createTreeItem } from '../utils'
 
 import GlobalEvents from 'vue-global-events'
 
 import NodeContent from './NodeContent.vue'
 
-import CommitConfirmationModal from './CommitConfirmationModal.vue'
+import BoardTopbar from './BoardTopbar.vue'
 
 import TreeListView from './TreeListView.vue'
-
-import moment from 'moment'
 
 export default {
 
     components: {
         GlobalEvents,
         NodeContent,
-        CommitConfirmationModal,
+        BoardTopbar,
         TreeListView
     },
 
     computed: {
         ...mapGetters([
             'currentBoard',
-            'threads',
-            'currentThreadId',
         ]),
 
-        filterMode: {
-            get() { return this.$store.state.filterMode },
-            set(value) { this.$store.commit('setFilterMode', value) }
+        listViewMode() {
+            return this.$store.state.listViewMode
         },
 
         normalContext() {
             return !this.editingContext
-        },
-
-        startDate() {
-            return moment(this.currentBoard.date_started).format('YYYY-MM-DD')
-        },
-
-        itemsToRemove() {
-            return this.findItemsToBeRemoved(this.currentBoard.state)
         },
 
         options() {
@@ -139,7 +77,7 @@ export default {
                     dispatcher: (tree) => {
                         return this.$store.dispatch('save', {
                             state: tree,
-                            focus: this.focus,
+                            focus: this.$store.getters.currentBoard.focus,
                         })
                     }
                 }
@@ -149,10 +87,7 @@ export default {
 
     data: () => ({
         editingContext: false,
-        focus: "",
         unwatch: null,
-        showCommitModal: false,
-        listViewMode: false,
     }),
 
     mounted() {
@@ -173,8 +108,6 @@ export default {
         this.unwatch = this.$store.watch(
             (state, getters) => getters.currentBoard,
             () => {
-                this.focus = this.currentBoard.focus;
-                
                 const path = `/board/${this.currentBoard.thread.name}`;
 
                 if (this.$route.path !== path) {
@@ -187,16 +120,12 @@ export default {
             this.$store.dispatch('initBoard', this.$route.params.slug);
         } else {
             const appElement = document.getElementById('app-meta');
-       
-            const defaultThread = appElement 
-                ? appElement.dataset.defaultThread 
-                : this.$store.state.currentThreadPtr.Name;
-            
-            this.$store.dispatch('initBoard', defaultThread);
-        }
 
-        if (this.$store.getters.currentBoard) {
-            this.focus = this.$store.getters.currentBoard.focus
+            const defaultThread = appElement
+                ? appElement.dataset.defaultThread
+                : this.$store.state.currentThreadPtr.Name;
+
+            this.$store.dispatch('initBoard', defaultThread);
         }
     },
 
@@ -205,121 +134,13 @@ export default {
     },
 
     methods: {
-        toggleListViewMode() {
-            this.listViewMode = !this.listViewMode
-        },
-
         async addItem() {
             const node = this.$refs.tree.append(createTreeItem('Hi'))
-
-            /*
-            await promisifyTimeout(500)
-
-            node.vm.$el.querySelector('.tree-anchor')
-                .dispatchEvent(new Event('dblclick'))
-
-            //node.select()
-
-            //this.$refs.tree.find(node).startEditing()
-            */
         },
 
         ...mapActions([
-            'close',
             'reloadBoards',
         ]),
-
-        saveState() {
-            this.$store.dispatch('save', {
-                state: this.$refs.tree.toJSON(),
-                focus: this.focus
-            })
-        },
-
-        async changeThread(ev) {
-            await this.$store.dispatch(
-                'changeThread',
-                ev.target.value
-            )
-        },
-
-        isItemDeprecated(item) {
-            const markers = item.data?.meaningfulMarkers || {}
-
-            if ((markers.weeksInList || 0) < 5) {
-                return false
-            }
-
-            if (item.children && item.children.length > 0) {
-                return false
-            }
-
-            if (markers.canBePostponed) {
-                return false
-            }
-
-            if ((markers.postponedFor || 0) > 0) {
-                return false
-            }
-
-            if (markers.madeProgress) {
-                return false
-            }
-
-            if (item.state?.checked) {
-                return false
-            }
-
-            return true
-        },
-
-        findItemsToBeRemoved(items) {
-            let result = []
-
-            const traverse = (node) => {
-                if (this.isItemDeprecated(node)) {
-                    result.push({
-                        text: node.text,
-                        weeksInList: node.data?.meaningfulMarkers?.weeksInList || 0
-                    })
-                }
-
-                if (node.children && node.children.length > 0) {
-                    node.children.forEach(child => traverse(child))
-                }
-            }
-
-            items.forEach(item => traverse(item))
-            return result
-        },
-
-        prepareCommit() {
-            this.showCommitModal = true
-        },
-
-        confirmCommit() {
-            this.showCommitModal = false
-            this.close()
-        },
-
-        cancelCommit() {
-            this.showCommitModal = false
-        }
-
     }
 }
 </script>
-
-<style scoped>
-    .secondary {
-        background-color: #c4c4c4;
-        border: none;
-        border-radius: 3px;
-        cursor: pointer;
-        margin: 0 0.5rem;
-
-        &:hover {
-            background-color: #bbbaba;
-        }
-    }
-</style>

--- a/tasks/assets/components/BoardTopbar.vue
+++ b/tasks/assets/components/BoardTopbar.vue
@@ -1,0 +1,227 @@
+<template>
+    <div class="topbar">
+        <div class="upper-pane">
+            <h1>{{ startDate }}: <input v-model="focus" @blur="onFocusBlur" @keyup.stop></h1>
+            <button @click.prevent="prepareCommit" class="on-right">Commit</button>
+        </div>
+
+        <div class="lower-pane board-controls">
+            <label class="control">
+                <span class="control-label">Thread</span>
+                <select :value="currentThreadId" @change="onThreadChange($event)">
+                    <option v-for="thread in threads" :key="thread.id" :value="thread.id">
+                        {{ thread.name }}
+                    </option>
+                </select>
+            </label>
+
+            <label class="control">
+                <span class="control-label">Mode</span>
+                <select :value="currentMode" @change="onModeChange($event)">
+                    <option value="board">Board</option>
+                    <option value="eisenhower">Eisenhower</option>
+                    <option value="moscow">MoSCoW</option>
+                </select>
+            </label>
+
+            <label v-if="currentMode === 'board' && !listViewMode" class="control">
+                <span class="control-label">Filter</span>
+                <select v-model="filterMode" class="filter-select">
+                    <option value="all">all</option>
+                    <option value="important">important</option>
+                    <option value="deprecated">deprecated</option>
+                    <option value="finalizing">clearable</option>
+                    <optgroup label="MoSCoW">
+                        <option value="moscow-must">Must have</option>
+                        <option value="moscow-should">Should have</option>
+                        <option value="moscow-could">Could have</option>
+                        <option value="moscow-wont">Won't have</option>
+                    </optgroup>
+                    <optgroup label="Eisenhower">
+                        <option value="eisenhower-urgent-important">Urgent &amp; Important</option>
+                        <option value="eisenhower-not-urgent-important">Not Urgent &amp; Important</option>
+                        <option value="eisenhower-urgent-not-important">Urgent &amp; Not Important</option>
+                        <option value="eisenhower-not-urgent-not-important">Not Urgent &amp; Not Important</option>
+                    </optgroup>
+                </select>
+            </label>
+
+            <label v-if="currentMode === 'board'" class="control">
+                <span class="control-label">Display</span>
+                <select v-model="displayMode">
+                    <option value="list">list</option>
+                    <option value="tree">tree</option>
+                </select>
+            </label>
+        </div>
+
+        <CommitConfirmationModal
+            :show="showCommitModal"
+            :items-to-remove="itemsToRemove"
+            @confirm="confirmCommit"
+            @cancel="cancelCommit"
+        />
+    </div>
+</template>
+
+<script>
+
+import { mapGetters, mapActions } from 'vuex'
+
+import moment from 'moment'
+
+import CommitConfirmationModal from './CommitConfirmationModal.vue'
+
+export default {
+
+    components: {
+        CommitConfirmationModal,
+    },
+
+    data: () => ({
+        focus: "",
+        showCommitModal: false,
+        unwatch: null,
+    }),
+
+    computed: {
+        ...mapGetters([
+            'currentBoard',
+            'threads',
+            'currentThread',
+            'currentThreadId',
+        ]),
+
+        currentMode() {
+            const path = this.$route.path
+            if (path.startsWith('/eisenhower')) return 'eisenhower'
+            if (path.startsWith('/moscow')) return 'moscow'
+            return 'board'
+        },
+
+        filterMode: {
+            get() { return this.$store.state.filterMode },
+            set(value) { this.$store.commit('setFilterMode', value) }
+        },
+
+        displayMode: {
+            get() { return this.$store.state.listViewMode ? 'list' : 'tree' },
+            set(value) { this.$store.commit('setListViewMode', value === 'list') }
+        },
+
+        startDate() {
+            return moment(this.currentBoard.date_started).format('YYYY-MM-DD')
+        },
+
+        itemsToRemove() {
+            return this.findItemsToBeRemoved(this.currentBoard.state)
+        },
+    },
+
+    mounted() {
+        this.focus = this.currentBoard.focus
+
+        this.unwatch = this.$store.watch(
+            (state, getters) => getters.currentBoard,
+            () => {
+                this.focus = this.currentBoard.focus
+            }
+        )
+    },
+
+    beforeDestroy() {
+        this.unwatch()
+    },
+
+    methods: {
+        ...mapActions([
+            'close',
+        ]),
+
+        onFocusBlur() {
+            this.$store.dispatch('saveFocus', this.focus)
+        },
+
+        onThreadChange(ev) {
+            this.$store.dispatch('changeThread', Number(ev.target.value))
+        },
+
+        onModeChange(ev) {
+            const mode = ev.target.value
+            const name = this.currentThread?.name
+
+            const base = mode === 'board' ? '/board' : `/${mode}`
+            const path = name
+                ? `${base}/${name}`
+                : (mode === 'board' ? '/' : base)
+
+            if (this.$route.path !== path) {
+                this.$router.push(path)
+            }
+        },
+
+        isItemDeprecated(item) {
+            const markers = item.data?.meaningfulMarkers || {}
+
+            if ((markers.weeksInList || 0) < 5) {
+                return false
+            }
+
+            if (item.children && item.children.length > 0) {
+                return false
+            }
+
+            if (markers.canBePostponed) {
+                return false
+            }
+
+            if ((markers.postponedFor || 0) > 0) {
+                return false
+            }
+
+            if (markers.madeProgress) {
+                return false
+            }
+
+            if (item.state?.checked) {
+                return false
+            }
+
+            return true
+        },
+
+        findItemsToBeRemoved(items) {
+            let result = []
+
+            const traverse = (node) => {
+                if (this.isItemDeprecated(node)) {
+                    result.push({
+                        text: node.text,
+                        weeksInList: node.data?.meaningfulMarkers?.weeksInList || 0
+                    })
+                }
+
+                if (node.children && node.children.length > 0) {
+                    node.children.forEach(child => traverse(child))
+                }
+            }
+
+            items.forEach(item => traverse(item))
+            return result
+        },
+
+        prepareCommit() {
+            this.showCommitModal = true
+        },
+
+        confirmCommit() {
+            this.showCommitModal = false
+            this.close()
+        },
+
+        cancelCommit() {
+            this.showCommitModal = false
+        }
+    }
+}
+</script>

--- a/tasks/assets/components/Eisenhower.vue
+++ b/tasks/assets/components/Eisenhower.vue
@@ -1,8 +1,6 @@
 <template>
     <div class="board eisenhower">
-        <div class="upper-pane">
-            <h1>Eisenhower Matrix</h1>
-        </div>
+        <BoardTopbar />
 
         <div class="eisenhower-layout">
             <div class="task-tree-pane">
@@ -64,17 +62,13 @@
         >
             <button @click="removeStatus">Remove</button>
         </div>
-
-        <div class="lower-pane">
-            <router-link class="menulink" to="/">Board</router-link>
-            <router-link class="menulink" to="/eisenhower">Eisenhower</router-link>
-            <router-link class="menulink" to="/moscow">MoSCoW</router-link>
-        </div>
     </div>
 </template>
 
 <script>
 import { mapGetters } from 'vuex'
+
+import BoardTopbar from './BoardTopbar.vue'
 
 const QUADRANTS = [
     { id: 'urgent-important', title: 'Urgent & Important – DO' },
@@ -96,6 +90,10 @@ function getNodeByPath(state, path) {
 }
 
 export default {
+    components: {
+        BoardTopbar,
+    },
+
     data: () => ({
         contextMenu: { visible: false, x: 0, y: 0, item: null },
         draggedItem: null,

--- a/tasks/assets/components/Moscow.vue
+++ b/tasks/assets/components/Moscow.vue
@@ -1,8 +1,6 @@
 <template>
     <div class="board moscow">
-        <div class="upper-pane">
-            <h1>MoSCoW Classification</h1>
-        </div>
+        <BoardTopbar />
 
         <div class="moscow-layout">
             <div class="task-tree-pane">
@@ -64,17 +62,13 @@
         >
             <button @click="removeStatus">Remove</button>
         </div>
-
-        <div class="lower-pane">
-            <router-link class="menulink" to="/">Board</router-link>
-            <router-link class="menulink" to="/eisenhower">Eisenhower</router-link>
-            <router-link class="menulink" to="/moscow">MoSCoW</router-link>
-        </div>
     </div>
 </template>
 
 <script>
 import { mapGetters } from 'vuex'
+
+import BoardTopbar from './BoardTopbar.vue'
 
 const BUCKETS = [
     { id: 'must', title: 'Must have' },
@@ -96,6 +90,10 @@ function getNodeByPath(state, path) {
 }
 
 export default {
+    components: {
+        BoardTopbar,
+    },
+
     data: () => ({
         contextMenu: { visible: false, x: 0, y: 0, item: null },
         draggedItem: null,

--- a/tasks/assets/store.js
+++ b/tasks/assets/store.js
@@ -53,6 +53,7 @@ export default {
         threads: null,
         currentThreadPtr: name_ptr(DEFAULT_NAME),
         filterMode: 'all',
+        listViewMode: false,
     },
 
     getters: {
@@ -144,6 +145,10 @@ export default {
 
         setFilterMode(state, mode) {
             state.filterMode = mode;
+        },
+
+        setListViewMode(state, listViewMode) {
+            state.listViewMode = listViewMode;
         }
     },
 
@@ -180,6 +185,13 @@ export default {
             commit('setCurrentThreadId', threadId)
 
             await dispatch('loadBoardsForThread', threadId)
+        },
+
+        async saveFocus({ getters, dispatch }, focus) {
+            await dispatch('save', {
+                state: getters.currentBoard.state,
+                focus,
+            })
         },
 
         async save({ commit, getters }, payload) {

--- a/tasks/assets/styles/_tasks.scss
+++ b/tasks/assets/styles/_tasks.scss
@@ -408,6 +408,7 @@
 // .lower-pane in _general); the tree flex-fills the remaining viewport height.
 .board .topbar {
     margin-bottom: 0;
+    background: #f9f9f9;
 }
 
 .board .tree,
@@ -428,13 +429,41 @@
     input {
         padding: 0;
         border: 0;
-        margin: 0;
+        margin: 0 0 0 6px;
+        font-family: 'Raleway', sans-serif;
         font-size: 1em;
         outline: 0;
-        font-weight: bold;
+        font-weight: normal;
         flex: 1 1 auto;
         min-width: 0;
-        color: #666;
+        background: transparent;
+        color: #e8590c;
+    }
+}
+
+// Board topbar controls: a row of labeled, transparent-background selects
+// (Thread / Mode / Filter / Display) shared by Board, Eisenhower and MoSCoW.
+.board-controls {
+    gap: 1rem;
+
+    .control {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        margin: 0;
+        cursor: pointer;
+    }
+
+    .control-label {
+        color: #999;
+    }
+
+    select {
+        background: transparent;
+        border: 1px solid #ddd;
+        border-radius: 3px;
+        color: #343434;
+        cursor: pointer;
     }
 }
 


### PR DESCRIPTION
## Summary

Extracts the board chrome into a single shared `BoardTopbar.vue` used by **Board**, **Eisenhower** and **MoSCoW**, so all three present an identical topbar. The lower pane is now a row of labeled, transparent-background selects:

- **Thread** — switch thread
- **Mode** — Board / Eisenhower / MoSCoW (replaces the old nav links)
- **Filter** — tree-view filters (Board only)
- **Display** — list / tree (Board only, replaces the toggle button)

The `+` add button is removed (the `i` keyboard shortcut still appends items) and the **Commit** button is capitalized. Focus editing and the commit-confirmation modal now live in the shared topbar, so they work from any mode.

## Notable changes

- `listViewMode` moved into the Vuex store so the Display select drives Board's tree/list view.
- New `saveFocus` action persists focus against the store's current state — Board previously read it off its liquor-tree ref, which Eisenhower/MoSCoW don't have.
- Thread ids are coerced with `Number()` so `id_ptr`'s strict (`===`) finder actually matches the value from the `<select>` (was silently failing on the string).
- Unifying the topbar removes the standalone "Eisenhower Matrix" / "MoSCoW Classification" headings; the title row now shows the board date + focus everywhere, and the Mode dropdown indicates the current view.

## Styling

- Topbar background set to `#f9f9f9` to match the other pages.
- Controls (selects) have transparent backgrounds with labels.
- Focus input: transparent background, normal-weight orange (`#e8590c`) Raleway text, with a small gap after the date.

## Test plan

- [x] `npm run build` is clean
- [ ] Switch between modes via the Mode select; thread is preserved
- [ ] Switch thread on each mode; board updates
- [ ] Edit focus on each mode; persists
- [ ] Commit (with and without deprecated items) from each mode
- [ ] Display list/tree + Filter behave as before on Board

🤖 Generated with [Claude Code](https://claude.com/claude-code)