### PR TITLE
chore: remove unused Bootstrap dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
-        "bootstrap": "^4.6.2",
         "deep-equal": "^2.2.3",
         "lunr": "^2.3.9",
         "lunr-languages": "^1.20.0",
@@ -1285,25 +1284,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/bootstrap": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
-      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/twbs"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/bootstrap"
-        }
-      ],
-      "peerDependencies": {
-        "jquery": "1.9.1 - 3",
-        "popper.js": "^1.16.1"
-      }
-    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -2376,13 +2356,6 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -2701,17 +2674,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "sass": "^1.79.3"
   },
   "dependencies": {
-    "bootstrap": "^4.6.2",
     "deep-equal": "^2.2.3",
     "lunr": "^2.3.9",
     "lunr-languages": "^1.20.0",

--- a/tasks/settings/base.py
+++ b/tasks/settings/base.py
@@ -51,8 +51,6 @@ INSTALLED_APPS = [
     "tasks.apps.enfp",
 ]
 
-CRISPY_TEMPLATE_PACK = "bootstrap4"
-
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",


### PR DESCRIPTION
## Summary

Removes Bootstrap 4 from the project. It was unused dead weight:

- `app.scss` never imported it — it was never in the compiled CSS
- No template loaded it (no CDN, no static)
- No JS imported `bootstrap`
- The bootstrap-ish class names in templates (`navbar`, `btn-primary`, `row`, …) are styled by the project's own SCSS in `tasks/assets/styles/`, not by Bootstrap

The only other trace was `CRISPY_TEMPLATE_PACK = "bootstrap4"` in `base.py` — an orphan setting, since `crispy_forms` isn't in `INSTALLED_APPS` and no template uses `{% crispy %}`.

## Changes

- `package.json` / `package-lock.json` — removed the `bootstrap` dependency
- `tasks/settings/base.py` — removed the dead `CRISPY_TEMPLATE_PACK` setting

## Notes

Since nothing imported Bootstrap, no rendered output changes. A frontend build (`npm run build`) regenerates assets clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)