### PR TITLE
feat(trips): add OpenStreetMap POI map to trip detail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "UNLICENSED",
       "dependencies": {
         "deep-equal": "^2.2.3",
+        "leaflet": "^1.9.4",
+        "leaflet.markercluster": "^1.5.3",
         "lunr": "^2.3.9",
         "lunr-languages": "^1.20.0",
         "moment": "^2.30.1",
@@ -2385,6 +2387,21 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/leaflet.markercluster": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+      "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "leaflet": "^1.3.1"
       }
     },
     "node_modules/loader-runner": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   },
   "dependencies": {
     "deep-equal": "^2.2.3",
+    "leaflet": "^1.9.4",
+    "leaflet.markercluster": "^1.5.3",
     "lunr": "^2.3.9",
     "lunr-languages": "^1.20.0",
     "moment": "^2.30.1",

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       app: './tasks/assets/app.js',
       hello_world_mount: './tasks/assets/components/hello_world_mount.js',
       enfp_mount: './tasks/assets/components/enfp_mount.js',
+      trip_map: './tasks/assets/trip_map.js',
     },
   },
 
@@ -40,7 +41,7 @@ export default defineConfig({
       );
 
       // Generate separate JS and CSS tag files for each entry point
-      const entryPoints = ['app', 'hello_world_mount', 'enfp_mount'];
+      const entryPoints = ['app', 'hello_world_mount', 'enfp_mount', 'trip_map'];
 
       entryPoints.forEach(entryName => {
         config.plugins.push(

--- a/tasks/apps/tree/tests/test_trip_web.py
+++ b/tasks/apps/tree/tests/test_trip_web.py
@@ -130,9 +130,9 @@ class TripWebTestCase(TestCase):
         # A single-day trip hides the day-jump nav.
         self.assertNotContains(r, 'aside class="days"')
 
-    def test_trip_detail_multi_day_has_no_rail(self):
-        # The trip detail page is full-width (no-rail): no day-jump rail even
-        # when the trip spans several days.
+    def test_trip_detail_uses_map_layout_without_day_rail(self):
+        # The trip detail page is a two-column map (left) + history (right)
+        # layout — no day-jump rail even when the trip spans several days.
         self._note("Day one", published=timezone.now() - timedelta(days=2))
         self._note("Day three", published=timezone.now())
 
@@ -140,8 +140,25 @@ class TripWebTestCase(TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertContains(r, "Day one")
         self.assertContains(r, "Day three")
-        self.assertContains(r, "content-rail no-rail")
+        self.assertContains(r, "trip-map-layout")
+        self.assertContains(r, 'id="trip-map"')
+        self.assertContains(r, 'id="trip-map-data"')
         self.assertNotContains(r, 'aside class="days"')
+
+    def test_trip_detail_map_points_only_for_entries_with_coords(self):
+        # Notes carrying a #poi/#coords line become map points (id + lat/lng);
+        # notes without coordinates are left off the map.
+        located = self._note("#coords lat=38.71 lng=-9.14\nMiradouro")
+        self._note("Just a plain note, no location")
+
+        r = self.client.get(reverse("trip-detail", args=[self.story.pk]))
+        self.assertEqual(r.status_code, 200)
+        points = r.context["map_points"]
+        self.assertEqual([p["id"] for p in points], [located.pk])
+        self.assertAlmostEqual(points[0]["lat"], 38.71)
+        self.assertAlmostEqual(points[0]["lng"], -9.14)
+        self.assertEqual(points[0]["note"], "Miradouro")
+        self.assertFalse(points[0]["is_photo"])
 
     def test_trip_detail_same_day_shows_single_date(self):
         # A trip that starts and stops on the same (UTC) day shows one date,

--- a/tasks/apps/tree/tests/test_trip_web.py
+++ b/tasks/apps/tree/tests/test_trip_web.py
@@ -131,10 +131,13 @@ class TripWebTestCase(TestCase):
         self.assertNotContains(r, 'aside class="days"')
 
     def test_trip_detail_uses_map_layout_without_day_rail(self):
-        # The trip detail page is a two-column map (left) + history (right)
-        # layout — no day-jump rail even when the trip spans several days.
-        self._note("Day one", published=timezone.now() - timedelta(days=2))
-        self._note("Day three", published=timezone.now())
+        # With located entries the trip detail page is a two-column map (left) +
+        # history (right) layout — no day-jump rail even across several days.
+        self._note(
+            "#poi lat=38.7 lng=-9.1\nDay one",
+            published=timezone.now() - timedelta(days=2),
+        )
+        self._note("#poi lat=38.8 lng=-9.2\nDay three", published=timezone.now())
 
         r = self.client.get(reverse("trip-detail", args=[self.story.pk]))
         self.assertEqual(r.status_code, 200)
@@ -144,6 +147,20 @@ class TripWebTestCase(TestCase):
         self.assertContains(r, 'id="trip-map"')
         self.assertContains(r, 'id="trip-map-data"')
         self.assertNotContains(r, 'aside class="days"')
+
+    def test_trip_detail_without_pois_shows_no_map(self):
+        # A trip whose entries carry no coordinates renders the plain
+        # full-width history — no map column and no Leaflet payload.
+        self._note("Just a walk, no location recorded")
+
+        r = self.client.get(reverse("trip-detail", args=[self.story.pk]))
+        self.assertEqual(r.status_code, 200)
+        self.assertContains(r, "Just a walk, no location recorded")
+        self.assertEqual(r.context["map_points"], [])
+        self.assertNotContains(r, 'id="trip-map"')
+        self.assertNotContains(r, "trip-map-layout")
+        # Falls back to the full-width content layout.
+        self.assertContains(r, "content-rail no-rail")
 
     def test_trip_detail_map_points_only_for_entries_with_coords(self):
         # Notes carrying a #poi/#coords line become map points (id + lat/lng);

--- a/tasks/apps/tree/views_trip.py
+++ b/tasks/apps/tree/views_trip.py
@@ -6,6 +6,8 @@ of the user's trips and a per-trip page that reuses the journal-entry
 partial to render notes and photo miniatures. Nothing here mutates state.
 """
 
+import re
+
 from django.contrib.auth.decorators import login_required
 from django.http import Http404
 from django.shortcuts import render
@@ -14,6 +16,17 @@ from django.template.defaultfilters import date as date_filter
 from .models import PhotoAdded, Story, StoryEvent
 from .services.photos import storage as photo_storage
 from .services.trips import operations as trip_ops
+
+# Trip notes/photos prepend a machine line like "#poi lat=.. lng=..". This is
+# the server-side twin of POI_LINE_RE in tasks/assets/app.js — keep the two in
+# sync. We parse coordinates here (rather than scraping the rendered DOM) so the
+# map gets clean data; app.js mutates that DOM to strip the same line.
+POI_LINE_RE = re.compile(
+    r"#(?:poi|coords|coordinates|latlng)\b"
+    r"[^\n]*?\blat\s*=\s*(-?\d+(?:\.\d+)?)"
+    r"[^\n]*?\blng\s*=\s*(-?\d+(?:\.\d+)?)",
+    re.IGNORECASE,
+)
 
 
 def attach_photo_urls(events):
@@ -59,6 +72,41 @@ def _cover_photos_by_story(user):
         latest.setdefault(story_id, event_id)
     photos = PhotoAdded.objects.in_bulk(latest.values())
     return {sid: photos[eid] for sid, eid in latest.items() if eid in photos}
+
+
+def _map_points(events):
+    """POIs to plot on the trip map, one per event that carries coordinates.
+
+    Each point is JSON-serialisable for ``json_script`` and carries enough to
+    render a marker (photo miniature or note pin), a popup, and to cross-link
+    the history list on the right via the event id. ``attach_photo_urls`` must
+    have run first so photo events already have ``thumbnail_url``/``original_url``.
+    """
+    points = []
+    for event in events:
+        match = POI_LINE_RE.search(event.comment or "")
+        if not match:
+            continue
+
+        # The machine "#poi ..." line is the first line; the user's note (if
+        # any) is whatever follows it — mirrors app.js's DOM stripping.
+        _, _, note = (event.comment or "").partition("\n")
+        is_photo = bool(getattr(event, "is_photo", False))
+
+        points.append(
+            {
+                "id": event.id,
+                "lat": float(match.group(1)),
+                "lng": float(match.group(2)),
+                "is_photo": is_photo,
+                "thumbnail_url": getattr(event, "thumbnail_url", None)
+                or getattr(event, "original_url", None),
+                "note": note.strip(),
+                "date": date_filter(event.published, "d M Y"),
+                "time": date_filter(event.published, "H:i"),
+            }
+        )
+    return points
 
 
 def _trip_date_label(story):
@@ -121,5 +169,6 @@ def trip_detail(request, story_id):
         {
             "story": story,
             "events": events,
+            "map_points": _map_points(events),
         },
     )

--- a/tasks/assets/styles/_daily.scss
+++ b/tasks/assets/styles/_daily.scss
@@ -554,6 +554,7 @@ section.journal {
 
 // Journal photo miniatures (shared by the journal feed and trip entries).
 .journal-photo {
+    display: inline-block;
     margin: 0.4rem 0;
 
     img {

--- a/tasks/assets/styles/_trips.scss
+++ b/tasks/assets/styles/_trips.scss
@@ -73,6 +73,172 @@
     }
 }
 
+// === Trip detail: map (left) + scrolling history (right) ===
+// A fixed-height app frame so the map fills its column while the history
+// scrolls independently. Built on .split-layout from _layouts.scss; the map
+// gets the wider column.
+.trip-map-layout {
+    --split-cols: minmax(0, 3fr) minmax(26rem, 2fr);
+
+    height: 100vh;
+    overflow: hidden;
+
+    .split-left {
+        min-height: 0;
+    }
+
+    .split-right {
+        min-height: 0;
+        height: 100%;
+        overflow-y: auto;
+
+        background: #fff;
+        padding: 1.25rem 1.5rem;
+
+        // Let the embedded journal fill the column instead of rendering as its
+        // own centered card (matches the content-rail treatment).
+        section.journal {
+            max-width: none;
+            margin: 0;
+            padding: 0;
+            background: transparent;
+        }
+    }
+}
+
+#trip-map {
+    width: 100%;
+    height: 100%;
+    min-height: 360px;
+    background: #e8eaed;
+    z-index: 0; // keep Leaflet panes/controls below the app sidebar
+}
+
+#trip-map.trip-map-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+    color: #999;
+    font-size: 0.95rem;
+    text-align: center;
+}
+
+// Markers: photos as circular miniatures, notes as a small pin dot.
+.trip-map-marker {
+    background: transparent;
+    border: 0;
+}
+
+.trip-map-pin {
+    display: block;
+    box-sizing: border-box;
+}
+
+.trip-map-pin--photo {
+    width: 46px;
+    height: 46px;
+    border-radius: 50%;
+    overflow: hidden;
+    border: 2px solid #fff;
+    box-shadow: 0 1px 5px rgba(0, 0, 0, 0.4);
+    background: #f3f4f6;
+
+    img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+    }
+}
+
+.trip-map-pin--note {
+    width: 18px;
+    height: 18px;
+    margin: 2px;
+    border-radius: 50%;
+    background: #3367d6;
+    border: 2px solid #fff;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+}
+
+// Marker popup (photo thumb + date/time + note).
+.trip-popup {
+    font-size: 0.85rem;
+
+    .trip-popup-photo {
+        width: 100%;
+        border-radius: 4px;
+        display: block;
+        margin-bottom: 0.4rem;
+    }
+
+    .trip-popup-meta {
+        color: #999;
+        font-size: 0.78rem;
+    }
+
+    .trip-popup-note {
+        margin-top: 0.25rem;
+        white-space: pre-wrap;
+    }
+}
+
+// History list cross-linking with the map. A selected entry is flagged by
+// turning its time marker (the [data-time]::before time gutter from _daily)
+// into a yellow badge — no row background.
+.trip-map-layout {
+    .trip-entry {
+        cursor: pointer;
+    }
+
+    .trip-entry.is-located [data-time]::before {
+        color: #fff;
+        background: #f0b429;
+        padding: 0.05rem 0.45rem;
+        border-radius: 999px;
+    }
+
+    .trip-entry.is-filtered-out,
+    .trip-day.is-filtered-out {
+        display: none;
+    }
+}
+
+// Banner shown while a cluster filter is active.
+.trip-history-filter {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+    padding: 0.45rem 0.7rem;
+
+    background: #eef3fd;
+    border: 1px solid #c7d8f5;
+    border-radius: 6px;
+
+    font-size: 0.85rem;
+    color: #3367d6;
+
+    .trip-history-filter-text {
+        flex: 1;
+    }
+
+    .trip-history-filter-reset {
+        border: 1px solid #c7d8f5;
+        border-radius: 999px;
+        background: #fff;
+        color: #3367d6;
+        font-size: 0.8rem;
+        padding: 0.1rem 0.6rem;
+        cursor: pointer;
+
+        &:hover {
+            background: #e0eaff;
+        }
+    }
+}
+
 // Trips index: month sections of clickable tiles (cover photo + title + dates).
 .trip-month {
     margin-bottom: 1.5rem;

--- a/tasks/assets/styles/_trips.scss
+++ b/tasks/assets/styles/_trips.scss
@@ -114,16 +114,6 @@
     z-index: 0; // keep Leaflet panes/controls below the app sidebar
 }
 
-#trip-map.trip-map-empty {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 2rem;
-    color: #999;
-    font-size: 0.95rem;
-    text-align: center;
-}
-
 // Markers: photos as circular miniatures, notes as a small pin dot.
 .trip-map-marker {
     background: transparent;

--- a/tasks/assets/trip_map.js
+++ b/tasks/assets/trip_map.js
@@ -1,0 +1,222 @@
+// Trip detail map: plot every POI (note or photo) from the trip's journal on
+// an OpenStreetMap (Leaflet) map in the left column, cross-linked with the
+// history list on the right.
+//
+//   - photos render as a small circular miniature, notes as a pin dot;
+//   - dense areas collapse into clusters (leaflet.markercluster);
+//   - clicking a marker selects + scrolls its entry in the history;
+//   - clicking a cluster filters the history down to that cluster's entries.
+//
+// Coordinates are parsed server-side (see _map_points in views_trip.py) and
+// handed to us as JSON, so we never depend on the comment DOM that app.js
+// rewrites.
+
+import L from 'leaflet';
+import 'leaflet.markercluster';
+
+import 'leaflet/dist/leaflet.css';
+import 'leaflet.markercluster/dist/MarkerCluster.css';
+import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
+
+const mapEl = document.getElementById('trip-map');
+const dataEl = document.getElementById('trip-map-data');
+
+const showEmpty = () => {
+    mapEl.classList.add('trip-map-empty');
+    mapEl.textContent = mapEl.dataset.emptyText || '';
+};
+
+if (mapEl && dataEl) {
+    let points = [];
+    try {
+        points = JSON.parse(dataEl.textContent) || [];
+    } catch (e) {
+        points = [];
+    }
+
+    if (points.length === 0) {
+        showEmpty();
+    } else {
+        initMap(points);
+    }
+}
+
+function initMap(points) {
+    const map = L.map(mapEl, { scrollWheelZoom: true });
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+    }).addTo(map);
+
+    // Indexes for cross-linking markers <-> history entries.
+    const markersById = new Map();
+    const entriesById = new Map();
+    document.querySelectorAll('.trip-entry[data-event-id]').forEach((li) => {
+        entriesById.set(String(li.dataset.eventId), li);
+    });
+
+    const cluster = L.markerClusterGroup({
+        // We handle cluster clicks ourselves (filter the history) instead of
+        // the default zoom-to-bounds.
+        zoomToBoundsOnClick: false,
+        maxClusterRadius: 45,
+    });
+
+    points.forEach((point) => {
+        const marker = L.marker([point.lat, point.lng], { icon: iconFor(point) });
+        marker.eventId = String(point.id);
+        marker.bindPopup(popupFor(point), { minWidth: 160, maxWidth: 240 });
+        marker.on('click', () => selectEntry(marker.eventId));
+        markersById.set(marker.eventId, marker);
+        cluster.addLayer(marker);
+    });
+
+    map.addLayer(cluster);
+    fitToAll();
+
+    cluster.on('clusterclick', (event) => {
+        const ids = event.layer.getAllChildMarkers().map((m) => m.eventId);
+        filterHistory(ids);
+        map.fitBounds(event.layer.getBounds(), { padding: [40, 40] });
+    });
+
+    // History -> map: tapping a POI pin (the 📍 added by app.js) navigates the
+    // embedded map to that coordinate instead of opening an external map site;
+    // tapping an entry's body does the same. The photo link/image and buttons
+    // keep their own behaviour.
+    document.querySelector('.trip-entries main').addEventListener('click', (e) => {
+        const li = e.target.closest('.trip-entry[data-event-id]');
+        if (!li) {
+            return;
+        }
+        if (e.target.closest('.trip-pin')) {
+            e.preventDefault(); // don't follow the external map link
+            locateOnMap(li);
+            return;
+        }
+        if (e.target.closest('a, img, button')) {
+            return;
+        }
+        locateOnMap(li);
+    });
+
+    function locateOnMap(li) {
+        const marker = markersById.get(String(li.dataset.eventId));
+        if (!marker) {
+            return;
+        }
+        cluster.zoomToShowLayer(marker, () => marker.openPopup());
+        highlightEntry(li);
+    }
+
+    const filterBanner = document.getElementById('trip-history-filter');
+    if (filterBanner) {
+        filterBanner
+            .querySelector('.trip-history-filter-reset')
+            .addEventListener('click', clearFilter);
+    }
+
+    // Leaflet needs a re-measure if the column was still settling at init.
+    setTimeout(() => map.invalidateSize(), 0);
+    window.addEventListener('resize', () => map.invalidateSize());
+
+    function fitToAll() {
+        const bounds = L.latLngBounds(points.map((p) => [p.lat, p.lng]));
+        map.fitBounds(bounds, { padding: [40, 40], maxZoom: 16 });
+    }
+
+    // Select a single entry from a marker click: clear any filter, scroll the
+    // entry into view, highlight it, and open the marker's popup.
+    function selectEntry(id) {
+        clearFilter();
+        const li = entriesById.get(String(id));
+        if (!li) {
+            return;
+        }
+        li.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        highlightEntry(li);
+    }
+
+    function highlightEntry(li) {
+        entriesById.forEach((entry) => entry.classList.remove('is-located'));
+        li.classList.add('is-located');
+    }
+
+    // Cluster click: show only the entries whose ids are in `ids`, collapse
+    // day groups that end up empty, and surface a reset banner.
+    function filterHistory(ids) {
+        const keep = new Set(ids.map(String));
+        entriesById.forEach((li, id) => {
+            li.classList.toggle('is-filtered-out', !keep.has(id));
+        });
+        document.querySelectorAll('.trip-day').forEach((day) => {
+            const anyVisible = day.querySelector('.trip-entry:not(.is-filtered-out)');
+            day.classList.toggle('is-filtered-out', !anyVisible);
+        });
+        if (filterBanner) {
+            filterBanner.querySelector('.trip-history-filter-text').textContent =
+                `Showing ${keep.size} of ${points.length} places`;
+            filterBanner.classList.remove('hidden');
+        }
+    }
+
+    function clearFilter() {
+        document
+            .querySelectorAll('.is-filtered-out')
+            .forEach((el) => el.classList.remove('is-filtered-out'));
+        if (filterBanner) {
+            filterBanner.classList.add('hidden');
+        }
+    }
+}
+
+// A circular photo miniature for photo entries; a small pin dot for notes.
+function iconFor(point) {
+    if (point.is_photo && point.thumbnail_url) {
+        return L.divIcon({
+            className: 'trip-map-marker',
+            html: `<span class="trip-map-pin trip-map-pin--photo"><img src="${encodeURI(
+                point.thumbnail_url
+            )}" alt=""></span>`,
+            iconSize: [46, 46],
+            iconAnchor: [23, 23],
+            popupAnchor: [0, -24],
+        });
+    }
+    return L.divIcon({
+        className: 'trip-map-marker',
+        html: '<span class="trip-map-pin trip-map-pin--note"></span>',
+        iconSize: [22, 22],
+        iconAnchor: [11, 11],
+        popupAnchor: [0, -10],
+    });
+}
+
+// Build popup content as DOM nodes so user note text can't inject markup.
+function popupFor(point) {
+    const root = document.createElement('div');
+    root.className = 'trip-popup';
+
+    if (point.is_photo && point.thumbnail_url) {
+        const img = document.createElement('img');
+        img.className = 'trip-popup-photo';
+        img.src = point.thumbnail_url;
+        img.alt = '';
+        root.appendChild(img);
+    }
+
+    const meta = document.createElement('div');
+    meta.className = 'trip-popup-meta';
+    meta.textContent = [point.date, point.time].filter(Boolean).join(' · ');
+    root.appendChild(meta);
+
+    if (point.note) {
+        const note = document.createElement('div');
+        note.className = 'trip-popup-note';
+        note.textContent = point.note;
+        root.appendChild(note);
+    }
+
+    return root;
+}

--- a/tasks/assets/trip_map.js
+++ b/tasks/assets/trip_map.js
@@ -21,11 +21,8 @@ import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
 const mapEl = document.getElementById('trip-map');
 const dataEl = document.getElementById('trip-map-data');
 
-const showEmpty = () => {
-    mapEl.classList.add('trip-map-empty');
-    mapEl.textContent = mapEl.dataset.emptyText || '';
-};
-
+// The template only renders the map (and loads this bundle) when the trip has
+// located entries, but guard anyway so a stray empty payload is a no-op.
 if (mapEl && dataEl) {
     let points = [];
     try {
@@ -34,9 +31,7 @@ if (mapEl && dataEl) {
         points = [];
     }
 
-    if (points.length === 0) {
-        showEmpty();
-    } else {
+    if (points.length > 0) {
         initMap(points);
     }
 }

--- a/tasks/templates/tree/trips/trip_detail.html
+++ b/tasks/templates/tree/trips/trip_detail.html
@@ -1,13 +1,13 @@
 {% extends 'base.html' %}
 {% load render_assets %}
 
-{% block body_class %}page-rail trip-map-page{% endblock %}
+{% block body_class %}page-rail{% endblock %}
 
 {% block title %}{{ story }} | Trips{% endblock %}
 
 {% block content %}
 
-<div class="split-layout trip-map-layout">
+<div class="split-layout {% if map_points %}trip-map-layout{% else %}content-rail no-rail{% endif %}">
 
 <div class="topbar">
     <div class="upper-pane">
@@ -25,16 +25,20 @@
     </div>
 </div>
 
+{% if map_points %}
 <div class="split-left">
-    <div id="trip-map" data-empty-text="No locations recorded for this trip yet."></div>
+    <div id="trip-map"></div>
 </div>
+{% endif %}
 
-<div class="split-right">
+<div class="{% if map_points %}split-right{% else %}split-left{% endif %}">
     <section class="journal trip-entries">
+        {% if map_points %}
         <div id="trip-history-filter" class="trip-history-filter hidden">
             <span class="trip-history-filter-text"></span>
             <button type="button" class="trip-history-filter-reset">Show all</button>
         </div>
+        {% endif %}
         <main>
             <ul>
                 {% regroup events by published.date as entries_by_date %}
@@ -59,13 +63,13 @@
 
 </div>
 
-{{ map_points|json_script:"trip-map-data" }}
+{% if map_points %}{{ map_points|json_script:"trip-map-data" }}{% endif %}
 {% endblock %}
 
 {% block extracss %}
-    {% render_css 'trip_map' %}
+    {% if map_points %}{% render_css 'trip_map' %}{% endif %}
 {% endblock %}
 
 {% block extrajs %}
-    {% render_js 'trip_map' %}
+    {% if map_points %}{% render_js 'trip_map' %}{% endif %}
 {% endblock %}

--- a/tasks/templates/tree/trips/trip_detail.html
+++ b/tasks/templates/tree/trips/trip_detail.html
@@ -1,12 +1,13 @@
 {% extends 'base.html' %}
+{% load render_assets %}
 
-{% block body_class %}page-rail{% endblock %}
+{% block body_class %}page-rail trip-map-page{% endblock %}
 
 {% block title %}{{ story }} | Trips{% endblock %}
 
 {% block content %}
 
-<div class="split-layout content-rail no-rail">
+<div class="split-layout trip-map-layout">
 
 <div class="topbar">
     <div class="upper-pane">
@@ -25,16 +26,24 @@
 </div>
 
 <div class="split-left">
+    <div id="trip-map" data-empty-text="No locations recorded for this trip yet."></div>
+</div>
+
+<div class="split-right">
     <section class="journal trip-entries">
+        <div id="trip-history-filter" class="trip-history-filter hidden">
+            <span class="trip-history-filter-text"></span>
+            <button type="button" class="trip-history-filter-reset">Show all</button>
+        </div>
         <main>
             <ul>
                 {% regroup events by published.date as entries_by_date %}
                 {% for date, day_events in entries_by_date %}
-                    <li id="{{ date|date:"b-d" }}">
+                    <li id="{{ date|date:"b-d" }}" class="trip-day">
                         <strong>{{ date|date:"d F Y" }}</strong>
                         <ul>
                             {% for event in day_events %}
-                                <li>
+                                <li class="trip-entry" data-event-id="{{ event.id }}">
                                     {% include "tree/events/journal_added.html" with readonly=True hide_trip_marker=True %}
                                 </li>
                             {% endfor %}
@@ -49,4 +58,14 @@
 </div>
 
 </div>
+
+{{ map_points|json_script:"trip-map-data" }}
+{% endblock %}
+
+{% block extracss %}
+    {% render_css 'trip_map' %}
+{% endblock %}
+
+{% block extrajs %}
+    {% render_js 'trip_map' %}
 {% endblock %}


### PR DESCRIPTION
## Summary

Adds an OpenStreetMap map of all POIs to the trip detail page, in a new left column alongside the journal history (which moves to the right). Built on the `.split-layout` 2-column grid; the map gets the wider column and stays fixed while the history scrolls.

## What's on the map

- **Photos** render as circular miniatures (the presigned WebP thumbnail); **notes** render as pin dots.
- **Dense areas cluster** via `leaflet.markercluster`.
- **Click a marker** → scrolls the matching history entry into view and flags it with a yellow time badge; opens a popup (thumbnail + date/time + note).
- **Click a cluster** → filters the history down to that cluster's entries, zooms to it, and shows a "Showing N of M places — Show all" reset banner.
- **Tap a 📍 POI pin** (the one `app.js` adds in the history) → drives the embedded map to that coordinate instead of opening an external map site. Tapping an entry body does the same.
- Empty state when a trip has no coordinates.

## How coordinates flow

Coordinates aren't a DB field — they live in the comment as `#poi lat=.. lng=..`, and the global `app.js` *strips* that line from the rendered DOM. So they're parsed **server-side** (`_map_points` + `POI_LINE_RE` in `views_trip.py`, kept in sync with the regex in `app.js`) and handed to the map as `json_script`. The map never scrapes the comment DOM.

## Build / assets

- New `leaflet` + `leaflet.markercluster` deps and a `trip_map` rsbuild entry, loaded only on the trip page via `extracss`/`extrajs` — the global `app` bundle is unchanged (Leaflet's vendor chunk is not pulled into `app`, so no double-load).
- `.journal-photo` is now `inline-block` so trip photos hug the thumbnail instead of claiming the whole column (visually unchanged in the diary).

## Tests

- `python manage.py check` clean; all `test_trip_web` tests pass.
- Updated the stale `no-rail` layout assertion to the new map layout and added a `_map_points` test (coords parsed, plain notes excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
