### PR TITLE
fix(trips): make trip map photo markers load and fill the circle

### DIFF
--- a/tasks/assets/styles/_trips.scss
+++ b/tasks/assets/styles/_trips.scss
@@ -132,14 +132,15 @@
     overflow: hidden;
     border: 2px solid #fff;
     box-shadow: 0 1px 5px rgba(0, 0, 0, 0.4);
-    background: #f3f4f6;
-
-    img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-        display: block;
-    }
+    // Render the photo as a background rather than an <img>. Leaflet's
+    // `.leaflet-marker-pane img` rule forces width:auto on every marker image
+    // (higher specificity, and trip_map.css loads after app.css), so an <img>
+    // can't fill the circle without !important. A background sidesteps that
+    // entirely. The URL is set inline by iconFor() in trip_map.js.
+    background-color: #f3f4f6;
+    background-position: center;
+    background-size: cover;
+    background-repeat: no-repeat;
 }
 
 .trip-map-pin--note {

--- a/tasks/assets/trip_map.js
+++ b/tasks/assets/trip_map.js
@@ -169,11 +169,17 @@ function initMap(points) {
 // A circular photo miniature for photo entries; a small pin dot for notes.
 function iconFor(point) {
     if (point.is_photo && point.thumbnail_url) {
+        // Render the miniature as a background image on the <span> rather than
+        // an <img>: Leaflet's `.leaflet-marker-pane img` rule forces width:auto
+        // on marker images, so an <img> won't fill the circle. Setting the
+        // presigned S3 URL inline and verbatim (no encodeURI) keeps the SigV4
+        // signature intact — encodeURI double-encoded %2F -> %252F (S3 -> 400).
+        const span = document.createElement('span');
+        span.className = 'trip-map-pin trip-map-pin--photo';
+        span.style.backgroundImage = `url("${point.thumbnail_url}")`;
         return L.divIcon({
             className: 'trip-map-marker',
-            html: `<span class="trip-map-pin trip-map-pin--photo"><img src="${encodeURI(
-                point.thumbnail_url
-            )}" alt=""></span>`,
+            html: span,
             iconSize: [46, 46],
             iconAnchor: [23, 23],
             popupAnchor: [0, -24],


### PR DESCRIPTION
## Summary

Two bugs in the trip detail map photo markers (`trip_map.js` / `_trips.scss`):

1. **Markers 400'd from S3.** `iconFor()` wrapped the presigned S3 thumbnail URL in `encodeURI()`, which re-encodes `%` → `%25`, turning the `%2F` slashes in the SigV4 `X-Amz-Credential` into `%252F`. That corrupts the signed query string, so S3 returned **400 (SignatureDoesNotMatch)** and no marker thumbnails loaded. The history column (`journal_added.html`) and the map popup (`popupFor`) use the URL verbatim, which is why they worked.

2. **Photo didn't fill the circle.** Even once loading, an `<img>` inside a marker is forced to `width: auto` by Leaflet's `.leaflet-marker-pane img` rule — higher specificity `(0,2,1)`, and `trip_map.css` loads after `app.css` — so the photo sat letterboxed in the circle instead of covering it.

## Fix

Render the photo as a **background image** on the marker `<span>` instead of an `<img>`:
- the presigned URL is set inline and verbatim (`span.style.backgroundImage`), keeping the signature intact;
- Leaflet's `img` rule no longer applies, so `background-size: cover` fills and crops the circle — no `!important`, no specificity fight.

The popup still uses a real `<img>` (it lives in the popup pane, which Leaflet doesn't style).

## Test plan

- [ ] Rebuild assets (`npm run dev` / `build`), open a trip detail page with photo POIs.
- [ ] Confirm photo markers load (no S3 400s in the network tab) and fill the circular pin (cropped, not letterboxed).
- [ ] Click a marker → popup shows the photo + date/note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)