### PR TITLE
perf(fonts): preconnect and load Raleway in head to stop flicker

### DIFF
--- a/tasks/assets/app.scss
+++ b/tasks/assets/app.scss
@@ -1,7 +1,5 @@
 // Load specific styles from styles/ here.
 
-@import url('https://fonts.googleapis.com/css?family=Raleway:300,400,400i,500,700&display=swap&subset=latin-ext');
-
 @import '~vue-context/src/sass/vue-context.scss';
 
 $lower-pane: 40px;

--- a/tasks/templates/base.html
+++ b/tasks/templates/base.html
@@ -9,6 +9,10 @@
         <title>{% block title %}Tasks Collector{% endblock %}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Raleway:300,400,400i,500,700&display=swap&subset=latin-ext">
+
         {# Restore the collapsed sidebar state before paint to avoid a flash. #}
         <script>
             (function () {


### PR DESCRIPTION
## Summary

Fixes the Raleway font flickering (FOUT) on page load.

The font URL was buried inside the compiled CSS bundle as an `@import`, so the browser couldn't discover it until the whole stylesheet had been downloaded and parsed — a serial waterfall (`bundle → Google CSS → font file`). That left fallback text visible long enough to produce a visible swap on every load.

This moves the Google Fonts `<link>` into `base.html`'s `<head>` and adds `preconnect` hints:

- The browser now fetches the font CSS at initial HTML parse, in parallel with the main bundle.
- `preconnect` warms the TLS connections to `fonts.googleapis.com` (serves the CSS) and `fonts.gstatic.com` (serves the `woff2`, hence `crossorigin`), so the font bytes arrive sooner and the swap window shrinks to near-invisible.

Same weights (`300,400,400i,500,700`), `latin-ext` subset, and `display=swap` as before — only the loading path changes.

## Changes

- `tasks/templates/base.html` — add `preconnect` + Raleway stylesheet `<link>` in `<head>`.
- `tasks/assets/app.scss` — remove the render-blocking `@import url(...)` for Google Fonts.

## Notes

- The frontend assets need a rebuild (`npm run build` / `build-dist`) for the `app.scss` change to land in the compiled CSS.
- No hardcoded `woff2` `preload` was added on purpose: Google's `gstatic.com` font URLs are version-hashed and rotate, so a hardcoded preload would silently rot. The `preconnect` to `gstatic.com` captures most of the benefit without the brittleness. A self-hosted approach would allow a stable preload (zero flicker, no CDN dependency) if desired later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)