### PR TITLE
feat(ui): auto-size textareas to fit their content

### DIFF
--- a/tasks/assets/app.js
+++ b/tasks/assets/app.js
@@ -8,6 +8,10 @@ import "./app.scss";
 import "./observation_search.js";
 import "./observation_master_detail.js";
 import "./observation_edit.js";
+import { autosizeAll, resizeTextarea } from "./autosize.js";
+
+// Grow/shrink every server-rendered textarea to fit its content.
+autosizeAll();
 
 const nodeList = document.querySelectorAll(
     'article.observation'
@@ -125,32 +129,20 @@ const onBreakthroughAdded = (element) => {
 
 window.onBreakthroughAdded = onBreakthroughAdded;
 
-document.querySelectorAll('.breakthrough textarea').forEach((textarea) => {
-    textarea.addEventListener('input', () => {
-        textarea.style.height = 'auto';
-        textarea.style.height = `${textarea.scrollHeight}px`;
-    });
-
-    textarea.dispatchEvent(new Event('input'));
-});
-
-
 document.querySelectorAll('.breakthrough-outcome').forEach((outcome) => {
     const button = outcome.querySelector('button.accordion');
-    const textarea = outcome.querySelectorAll('textarea');
+    const textareas = outcome.querySelectorAll('textarea');
 
     if (!button) {
         return;
     }
-    
+
     button.addEventListener('click', (event) => {
         outcome.classList.toggle('open');
         event.stopPropagation();
         event.preventDefault();
 
-        textarea.forEach((textarea) => {
-            textarea.dispatchEvent(new Event('input'));
-        });
+        textareas.forEach(resizeTextarea);
     });
 
     const confidenceLevel = outcome.querySelector('.breakthrough-outcome-confidence input[type="range"]');

--- a/tasks/assets/autosize.js
+++ b/tasks/assets/autosize.js
@@ -1,0 +1,112 @@
+// Make textareas grow and shrink to fit their content.
+//
+// One shared ResizeObserver reacts to anything that changes a textarea's WIDTH
+// — window resizes, layout shifts (e.g. the observation editor's History drawer
+// squeezing the form column), and visibility toggles — while an input listener
+// handles typing. The CSS min-height (or the textarea's `rows` attribute)
+// provides the minimum size; the box itself never scrolls.
+
+const tracked = new Set();
+const lastWidth = new WeakMap();
+let observer = null;
+
+// Fit a textarea's height to its content. box-sizing is border-box app-wide
+// (see styles/_general.scss), so the height must include the borders that
+// scrollHeight omits; the content-box branch is kept for completeness.
+const measure = (el) => {
+    const cs = getComputedStyle(el);
+    el.style.height = "auto";
+    if (cs.boxSizing === "border-box") {
+        const border =
+            parseFloat(cs.borderTopWidth) + parseFloat(cs.borderBottomWidth);
+        el.style.height = `${el.scrollHeight + border}px`;
+    } else {
+        const padding =
+            parseFloat(cs.paddingTop) + parseFloat(cs.paddingBottom);
+        el.style.height = `${el.scrollHeight - padding}px`;
+    }
+};
+
+const onInput = (event) => measure(event.target);
+
+const getObserver = () => {
+    if (observer) {
+        return observer;
+    }
+    observer = new ResizeObserver((entries) => {
+        entries.forEach((entry) => {
+            const el = entry.target;
+            // Our own height writes also notify the observer; only re-fit when
+            // the width (and therefore the text wrapping) actually changed, so
+            // we never feed back into ourselves.
+            if (lastWidth.get(el) === el.clientWidth) {
+                return;
+            }
+            lastWidth.set(el, el.clientWidth);
+            measure(el);
+        });
+    });
+    return observer;
+};
+
+// Re-fit a textarea on demand (e.g. after a layout change JS triggers itself).
+export const resizeTextarea = (el) => {
+    if (el) {
+        measure(el);
+    }
+};
+
+export const attach = (el) => {
+    if (!el || tracked.has(el)) {
+        return;
+    }
+    tracked.add(el);
+    el.classList.add("js-autosize");
+    el.addEventListener("input", onInput);
+    measure(el);
+    lastWidth.set(el, el.clientWidth);
+    getObserver().observe(el);
+};
+
+export const detach = (el) => {
+    if (!el || !tracked.has(el)) {
+        return;
+    }
+    tracked.delete(el);
+    el.removeEventListener("input", onInput);
+    el.classList.remove("js-autosize");
+    if (observer) {
+        observer.unobserve(el);
+    }
+};
+
+// Attach to every textarea under `root` (the whole document by default).
+export const autosizeAll = (root = document) => {
+    root.querySelectorAll("textarea").forEach(attach);
+};
+
+// Web fonts load after the first measurement and reflow the text taller without
+// changing the textarea width, so the ResizeObserver never sees it. Re-fit every
+// tracked textarea once the fonts are ready (resolves immediately when cached).
+if (typeof document !== "undefined" && document.fonts) {
+    document.fonts.ready.then(() => tracked.forEach(measure));
+}
+
+// Vue 2 directive: <textarea v-autosize>. componentUpdated re-fits when the
+// bound value changes from outside an input event (e.g. a form reset clearing
+// v-model).
+export const autosizeDirective = {
+    inserted(el) {
+        const ta = el.tagName === "TEXTAREA" ? el : el.querySelector("textarea");
+        el._autosizeTarget = ta;
+        attach(ta);
+    },
+    componentUpdated(el) {
+        if (el._autosizeTarget) {
+            measure(el._autosizeTarget);
+        }
+    },
+    unbind(el) {
+        detach(el._autosizeTarget);
+    },
+};

--- a/tasks/assets/components/EnfpDashboard.vue
+++ b/tasks/assets/components/EnfpDashboard.vue
@@ -143,6 +143,7 @@
                             <textarea
                                 id="enfp-description"
                                 v-model="form.description"
+                                v-autosize
                                 class="form-control"
                                 rows="2"
                             ></textarea>

--- a/tasks/assets/components/enfp_mount.js
+++ b/tasks/assets/components/enfp_mount.js
@@ -1,7 +1,10 @@
 import Vue from 'vue'
 import EnfpDashboard from './EnfpDashboard.vue'
+import { autosizeDirective } from '../autosize.js'
 
 import "../app.scss";
+
+Vue.directive('autosize', autosizeDirective)
 
 new Vue({
   render: h => h(EnfpDashboard),

--- a/tasks/assets/components/hello_world_mount.js
+++ b/tasks/assets/components/hello_world_mount.js
@@ -10,12 +10,15 @@ import store from '../store'
 
 import LiquorTree from '../liquor-tree/src/main.js'
 
+import { autosizeDirective } from '../autosize.js'
+
 import "../app.scss";
 import "../scripts/shared.js";
 
 Vue.use(LiquorTree)
 Vue.use(Vuex)
 Vue.use(VueRouter)
+Vue.directive('autosize', autosizeDirective)
 
 // Helper function to get CSRF token and make fetch requests
 const apiRequest = async (url, options = {}) => {

--- a/tasks/assets/styles/_daily.scss
+++ b/tasks/assets/styles/_daily.scss
@@ -59,7 +59,7 @@ body.page-daily {
         }
 
         textarea {
-            height: 8rem;
+            min-height: 8rem;
         }
 
         .helptext {

--- a/tasks/assets/styles/_general.scss
+++ b/tasks/assets/styles/_general.scss
@@ -8,6 +8,13 @@
 
 }
 
+// Textareas managed by the JS autosizer (assets/autosize.js): height is driven
+// from content, so the box must not scroll or expose a manual resize grabber.
+textarea.js-autosize {
+    overflow: hidden;
+    resize: none;
+}
+
 
 body, html {
     margin: 0;


### PR DESCRIPTION
## Summary

Textareas across the app now grow and shrink to fit their content, with a minimum-size floor. They re-fit on the three triggers requested: **window resize**, **layout changes**, and panels opening — specifically the **History drawer in the observation editor** squeezing the form column narrower.

## How it works

A single shared module — `tasks/assets/autosize.js` — is the source of truth for both server-rendered Django pages and Vue components:

- **Measurement** is box-sizing aware (`box-sizing: border-box` is global, so the height includes the borders `scrollHeight` omits).
- **One shared `ResizeObserver`** re-fits on anything that changes a textarea's *width* — window resize, layout shift (drawer squeeze), visibility toggle. An **`input` listener** handles typing. A **width-guard** stops the observer feeding back on its own height writes.
- **`document.fonts.ready` re-fit**: the web font loads after the first measure and reflows text taller *without changing width*, so the observer wouldn't catch it and long fields clipped their last lines on first paint. This hook fixes that.
- A **Vue `v-autosize` directive** is exported and registered in both mount files; it also re-fits when `v-model` is cleared programmatically (e.g. a form reset).

**Minimum size** comes from existing CSS `min-height` or the `rows` attribute. Daily plan/reflection switches from a fixed `height: 8rem` to `min-height: 8rem` so it keeps its comfortable floor but can still grow. Managed textareas get `overflow: hidden` and `resize: none`.

The breakthrough page's one-off resize handler is replaced by the shared utility.

## Files

- `tasks/assets/autosize.js` *(new)* — the autosizer + Vue directive.
- `tasks/assets/app.js` — `autosizeAll()` on every page; breakthrough one-off → shared `resizeTextarea`.
- `tasks/assets/components/{enfp_mount,hello_world_mount}.js` — register `v-autosize`.
- `tasks/assets/components/EnfpDashboard.vue` — apply `v-autosize`.
- `tasks/assets/styles/_general.scss` — `textarea.js-autosize { overflow: hidden; resize: none; }`.
- `tasks/assets/styles/_daily.scss` — fixed height → `min-height`.

## Verification

Drove the live observation editor (1883-char observation) in Chrome via Playwright:

- Initial load: all 3 textareas fit exactly, no inner scrollbar (`scrollHeight === clientHeight`).
- History drawer opened: form column width `410 → 268px`, heights grew to re-fit (situation `1450 → 1954px`, interpretation `292 → 412`, approach `244 → 292`), still no scrollbar.
- Closing the drawer reverted heights exactly; typing grew the box and deleting shrank it.

The font-load clipping bug above was found and fixed during this verification.

> Note: requires a frontend asset rebuild (`npm run build` / `build-dist`) on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)