### PR TITLE
feat(android): capture standalone photos with no trip attached

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/MainActivity.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/MainActivity.kt
@@ -3,7 +3,10 @@ package org.polybrain.tasks.health
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -24,6 +27,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -40,6 +44,8 @@ import org.polybrain.tasks.health.ui.HealthScreen
 import org.polybrain.tasks.health.ui.MainViewModel
 import org.polybrain.tasks.health.ui.SettingsScreen
 import org.polybrain.tasks.health.ui.TodayScreen
+import org.polybrain.tasks.health.ui.photo.AddPhotoViewModel
+import org.polybrain.tasks.health.ui.trip.AddPhotoDialog
 import org.polybrain.tasks.health.ui.trip.TripDetailScreen
 import org.polybrain.tasks.health.ui.trip.TripsScreen
 
@@ -74,6 +80,14 @@ private fun MainScaffold(vm: MainViewModel = viewModel()) {
     var boardPickerDate by remember { mutableStateOf<LocalDate?>(null) }
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val scope = rememberCoroutineScope()
+
+    // Standalone "Add Photo" flow, launched from the Today FAB. The picker
+    // hands a content Uri to the view model, which opens the photo dialog.
+    val addPhotoVm: AddPhotoViewModel = viewModel()
+    val photoDialogOpen by addPhotoVm.dialogOpen.collectAsState()
+    val photoPicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.PickVisualMedia(),
+    ) { uri -> if (uri != null) addPhotoVm.openAddPhoto(uri) }
 
     BackHandler(enabled = tripDetailId != null) {
         tripDetailId = null
@@ -150,7 +164,27 @@ private fun MainScaffold(vm: MainViewModel = viewModel()) {
                                 onCancel = { boardPickerDate = null },
                             )
                         } else {
-                            TodayScreen(onAddFromBoard = { boardPickerDate = it })
+                            TodayScreen(
+                                onAddFromBoard = { boardPickerDate = it },
+                                onAddPhoto = {
+                                    photoPicker.launch(
+                                        PickVisualMediaRequest(
+                                            ActivityResultContracts.PickVisualMedia.ImageOnly
+                                        )
+                                    )
+                                },
+                            )
+                        }
+                        if (photoDialogOpen) {
+                            val gps by addPhotoVm.gps.collectAsState()
+                            val selectedPhoto by addPhotoVm.selectedPhoto.collectAsState()
+                            AddPhotoDialog(
+                                selectedPhoto = selectedPhoto,
+                                gps = gps,
+                                onPermissionResult = addPhotoVm::onLocationPermissionResult,
+                                onSend = addPhotoVm::sendPhoto,
+                                onDismiss = addPhotoVm::closeAddPhoto,
+                            )
                         }
                     }
                     Destination.Trips -> {

--- a/android/app/src/main/java/org/polybrain/tasks/health/data/Outbox.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/Outbox.kt
@@ -46,7 +46,7 @@ class Outbox(private val dir: File) {
     }
 
     fun enqueuePhoto(
-        storyId: Long,
+        storyId: Long?,
         comment: String,
         published: String,
         contentType: String,

--- a/android/app/src/main/java/org/polybrain/tasks/health/data/OutboxItem.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/OutboxItem.kt
@@ -14,12 +14,16 @@ import kotlinx.serialization.Serializable
  *
  * [id] doubles as the server `idempotency_key`, so a retry whose first response
  * was lost re-uses the existing event instead of creating a duplicate.
+ *
+ * [storyId] is null for a standalone photo (a `PhotoTaken` with no trip): the
+ * drainer then delivers it through the storyless photo endpoints instead of the
+ * trip ones, and [forStory] never returns it.
  */
 @Serializable
 data class OutboxItem(
     val id: String,
     val kind: Kind,
-    val storyId: Long,
+    val storyId: Long?,
     val comment: String,
     val published: String,
     val createdAt: Long,

--- a/android/app/src/main/java/org/polybrain/tasks/health/data/TasksApi.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/TasksApi.kt
@@ -207,6 +207,22 @@ data class PhotoConfirmResponse(
     @SerialName("photo_id") val photoId: Long = 0,
 )
 
+// Standalone (storyless) photo upload: same two-phase flow as a trip photo,
+// but with no `story_id`. The confirm creates a PhotoTaken attached to no trip.
+@Serializable
+data class StandalonePhotoPresignRequest(
+    @SerialName("content_type") val contentType: String,
+)
+
+@Serializable
+data class StandalonePhotoConfirmRequest(
+    @SerialName("key") val key: String,
+    @SerialName("comment") val comment: String,
+    @SerialName("content_type") val contentType: String,
+    @SerialName("published") val published: String,
+    @SerialName("idempotency_key") val idempotencyKey: String,
+)
+
 @Serializable
 data class PhotoOriginalResponse(
     @SerialName("url") val url: String,
@@ -286,4 +302,14 @@ interface TasksApi {
 
     @GET("api/v1/android/trip/photo/{id}/original/")
     suspend fun photoOriginal(@Path("id") eventId: Long): PhotoOriginalResponse
+
+    @POST("api/v1/android/photo/presign/")
+    suspend fun presignStandalonePhoto(
+        @Body body: StandalonePhotoPresignRequest,
+    ): PhotoPresignResponse
+
+    @POST("api/v1/android/photo/")
+    suspend fun addStandalonePhoto(
+        @Body body: StandalonePhotoConfirmRequest,
+    ): PhotoConfirmResponse
 }

--- a/android/app/src/main/java/org/polybrain/tasks/health/location/GpsState.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/location/GpsState.kt
@@ -1,0 +1,26 @@
+package org.polybrain.tasks.health.location
+
+/**
+ * Where a Ready [GpsState] fix came from: a live GPS read (notes and standalone
+ * photos, recorded "now") or the trip's recorded breadcrumb track (trip photos,
+ * located at their capture time).
+ */
+enum class GpsSource { LIVE, TRACK }
+
+/**
+ * GPS resolution state shared by the add-note and add-photo dialogs. The dialog
+ * reads this to decide whether to enable the "Save with location" button and
+ * what hint to show.
+ */
+sealed class GpsState {
+    object Idle : GpsState()
+    object Waiting : GpsState()
+    data class Ready(
+        val fix: LocationFix,
+        val source: GpsSource = GpsSource.LIVE,
+        // For TRACK: the photo's capture time, shown in the dialog hint.
+        val atMillis: Long? = null,
+    ) : GpsState()
+    object Denied : GpsState()
+    object Unavailable : GpsState()
+}

--- a/android/app/src/main/java/org/polybrain/tasks/health/location/PoiComment.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/location/PoiComment.kt
@@ -1,0 +1,22 @@
+package org.polybrain.tasks.health.location
+
+import java.util.Locale
+
+/**
+ * Compose a journal comment from an optional location [fix] and the user's
+ * [text]. When a fix is present, a leading `#poi lat=… lng=…` line is prepended
+ * (the backend parses it into a HabitTracked); otherwise the trimmed text is
+ * used as-is. Shared by trip notes/photos and standalone photos so the marker
+ * format stays identical across all of them.
+ */
+fun composeComment(fix: LocationFix?, text: String): String {
+    val trimmed = text.trim()
+    return if (fix != null) {
+        val prefix = String.format(
+            Locale.US, "#poi lat=%.6f lng=%.6f", fix.lat, fix.lng,
+        )
+        if (trimmed.isEmpty()) prefix else "$prefix\n$trimmed"
+    } else {
+        trimmed
+    }
+}

--- a/android/app/src/main/java/org/polybrain/tasks/health/sync/OutboxDrainer.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/sync/OutboxDrainer.kt
@@ -5,6 +5,8 @@ import org.polybrain.tasks.health.data.Outbox
 import org.polybrain.tasks.health.data.OutboxItem
 import org.polybrain.tasks.health.data.PhotoConfirmRequest
 import org.polybrain.tasks.health.data.PhotoPresignRequest
+import org.polybrain.tasks.health.data.StandalonePhotoConfirmRequest
+import org.polybrain.tasks.health.data.StandalonePhotoPresignRequest
 import org.polybrain.tasks.health.data.TasksApi
 import org.polybrain.tasks.health.data.TripNoteRequest
 import retrofit2.HttpException
@@ -50,9 +52,12 @@ object OutboxDrainer {
         return try {
             when (item.kind) {
                 OutboxItem.Kind.NOTE -> {
+                    // Notes are always trip-bound; a storyless note is a bug.
                     api.addTripNote(
                         TripNoteRequest(
-                            storyId = item.storyId,
+                            storyId = requireNotNull(item.storyId) {
+                                "note ${item.id} has no story"
+                            },
                             comment = item.comment,
                             published = item.published,
                             idempotencyKey = item.id,
@@ -84,6 +89,10 @@ object OutboxDrainer {
      * straight to confirm and a PUT-failure retry re-presigns fresh. Returns the
      * (possibly updated) item so the caller's bookkeeping won't clobber the
      * resume flags.
+     *
+     * A null [OutboxItem.storyId] is a standalone photo (no trip): it goes
+     * through the storyless `photo/…` endpoints instead of the trip ones. The
+     * resume logic is identical for both — only the two API calls differ.
      */
     private suspend fun sendPhoto(
         item: OutboxItem,
@@ -93,27 +102,47 @@ object OutboxDrainer {
     ): OutboxItem {
         var current = item
         val contentType = current.contentType ?: "image/jpeg"
+        val storyId = current.storyId
         if (!current.uploaded) {
             val bytes = outbox.photoBytes(current)
                 ?: throw PermanentFailure("photo file missing for ${current.id}")
-            val presign = api.presignPhoto(
-                PhotoPresignRequest(storyId = current.storyId, contentType = contentType)
-            )
+            val presign = if (storyId != null) {
+                api.presignPhoto(
+                    PhotoPresignRequest(storyId = storyId, contentType = contentType)
+                )
+            } else {
+                api.presignStandalonePhoto(
+                    StandalonePhotoPresignRequest(contentType = contentType)
+                )
+            }
             put.put(presign.uploadUrl, bytes, contentType)
             // Persist immediately so a process kill after PUT still resumes at confirm.
             current = current.copy(presignedKey = presign.key, uploaded = true)
             outbox.update(current)
         }
-        api.addTripPhoto(
-            PhotoConfirmRequest(
-                storyId = current.storyId,
-                key = current.presignedKey!!,
-                comment = current.comment,
-                contentType = contentType,
-                published = current.published,
-                idempotencyKey = current.id,
+        val key = current.presignedKey!!
+        if (storyId != null) {
+            api.addTripPhoto(
+                PhotoConfirmRequest(
+                    storyId = storyId,
+                    key = key,
+                    comment = current.comment,
+                    contentType = contentType,
+                    published = current.published,
+                    idempotencyKey = current.id,
+                )
             )
-        )
+        } else {
+            api.addStandalonePhoto(
+                StandalonePhotoConfirmRequest(
+                    key = key,
+                    comment = current.comment,
+                    contentType = contentType,
+                    published = current.published,
+                    idempotencyKey = current.id,
+                )
+            )
+        }
         return current
     }
 

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayScreen.kt
@@ -1,11 +1,15 @@
 package org.polybrain.tasks.health.ui
 
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -19,6 +23,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
@@ -31,6 +36,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SmallFloatingActionButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -43,6 +50,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
@@ -58,6 +67,7 @@ import org.polybrain.tasks.health.data.TodayTask
 fun TodayScreen(
     vm: TodayViewModel = viewModel(),
     onAddFromBoard: (LocalDate) -> Unit = {},
+    onAddPhoto: () -> Unit = {},
 ) {
     val tasks by vm.tasks.collectAsState()
     val weekPlan by vm.weekPlan.collectAsState()
@@ -67,7 +77,12 @@ fun TodayScreen(
     val pendingComplete by vm.pendingComplete.collectAsState()
     val selectedDate by vm.selectedDate.collectAsState()
 
+    var fabExpanded by remember { mutableStateOf(false) }
+
     LaunchedEffect(Unit) { vm.refresh() }
+
+    // Back collapses the speed-dial before bubbling up to the nav drawer.
+    BackHandler(enabled = fabExpanded) { fabExpanded = false }
 
     Box(modifier = Modifier.fillMaxSize()) {
         Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
@@ -135,20 +150,16 @@ fun TodayScreen(
             }
         }
 
-        // FAB opens the board picker for the currently-viewed day. Hidden
-        // until configured, matching the disabled add-task row above.
+        // Speed-dial FAB: tapping it reveals "Add Task" (board picker, the old
+        // FAB action) and "Add Photo" (a standalone photo). Hidden until
+        // configured, matching the disabled add-task row above.
         if (configured) {
-            FloatingActionButton(
-                onClick = { onAddFromBoard(selectedDate) },
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(24.dp),
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Add,
-                    contentDescription = stringResource(R.string.today_board_fab_label),
-                )
-            }
+            AddSpeedDial(
+                expanded = fabExpanded,
+                onExpandedChange = { fabExpanded = it },
+                onAddTask = { onAddFromBoard(selectedDate) },
+                onAddPhoto = onAddPhoto,
+            )
         }
     }
 
@@ -432,6 +443,99 @@ private fun EmptyState(text: String) {
         contentAlignment = Alignment.Center,
     ) {
         Text(text)
+    }
+}
+
+/**
+ * Expanding speed-dial in the bottom-end corner. Collapsed it's a single "+"
+ * FAB; expanded it dims the screen with a tap-to-dismiss scrim and reveals the
+ * "Add Task" and "Add Photo" mini-actions, with the main button flipping to "×".
+ */
+@Composable
+private fun BoxScope.AddSpeedDial(
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+    onAddTask: () -> Unit,
+    onAddPhoto: () -> Unit,
+) {
+    if (expanded) {
+        // Full-screen scrim; tapping anywhere outside the actions collapses it.
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.32f))
+                .clickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                ) { onExpandedChange(false) },
+        )
+    }
+    Column(
+        modifier = Modifier
+            .align(Alignment.BottomEnd)
+            .padding(24.dp),
+        horizontalAlignment = Alignment.End,
+    ) {
+        AnimatedVisibility(visible = expanded) {
+            Column(
+                horizontalAlignment = Alignment.End,
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.padding(bottom = 12.dp),
+            ) {
+                SpeedDialItem(
+                    label = stringResource(R.string.today_fab_add_task),
+                    icon = Icons.Filled.Add,
+                    onClick = {
+                        onExpandedChange(false)
+                        onAddTask()
+                    },
+                )
+                SpeedDialItem(
+                    label = stringResource(R.string.today_fab_add_photo),
+                    icon = Icons.Filled.Add,
+                    onClick = {
+                        onExpandedChange(false)
+                        onAddPhoto()
+                    },
+                )
+            }
+        }
+        FloatingActionButton(onClick = { onExpandedChange(!expanded) }) {
+            Icon(
+                imageVector = if (expanded) Icons.Filled.Close else Icons.Filled.Add,
+                contentDescription = stringResource(
+                    if (expanded) R.string.today_fab_close else R.string.today_fab_expand,
+                ),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SpeedDialItem(
+    label: String,
+    icon: ImageVector,
+    onClick: () -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Surface(
+            shape = MaterialTheme.shapes.small,
+            color = MaterialTheme.colorScheme.surface,
+            tonalElevation = 3.dp,
+            shadowElevation = 2.dp,
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelLarge,
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            )
+        }
+        SmallFloatingActionButton(onClick = onClick) {
+            Icon(imageVector = icon, contentDescription = null)
+        }
     }
 }
 

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/photo/AddPhotoViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/photo/AddPhotoViewModel.kt
@@ -1,0 +1,122 @@
+package org.polybrain.tasks.health.ui.photo
+
+import android.app.Application
+import android.net.Uri
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import java.io.IOException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.polybrain.tasks.health.data.Outbox
+import org.polybrain.tasks.health.location.GpsState
+import org.polybrain.tasks.health.location.LocationProvider
+import org.polybrain.tasks.health.location.composeComment
+import org.polybrain.tasks.health.sync.SyncScheduler
+
+/**
+ * Drives the standalone "Add Photo" flow opened from the main-screen FAB: a
+ * photo queued with **no** trip (a storyless `PhotoTaken`), an optional note,
+ * and an optional **live** GPS fix — there is no trip track to resolve against,
+ * so unlike [org.polybrain.tasks.health.ui.trip.TripDetailViewModel] the
+ * location always comes from a fresh fix taken "now".
+ *
+ * The photo is enqueued with `storyId = null`; [org.polybrain.tasks.health.sync.OutboxDrainer]
+ * then delivers it through the storyless `photo/…` endpoints.
+ */
+class AddPhotoViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val locationProvider = LocationProvider(application)
+    private val outbox = Outbox(application)
+
+    /** Open/closed state for the add-photo dialog and the picked image. */
+    private val _dialogOpen = MutableStateFlow(false)
+    val dialogOpen: StateFlow<Boolean> = _dialogOpen.asStateFlow()
+
+    private val _selectedPhoto = MutableStateFlow<Uri?>(null)
+    val selectedPhoto: StateFlow<Uri?> = _selectedPhoto.asStateFlow()
+
+    private val _gps = MutableStateFlow<GpsState>(GpsState.Idle)
+    val gps: StateFlow<GpsState> = _gps.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    /** Open the dialog for a picked image and start resolving a live GPS fix. */
+    fun openAddPhoto(uri: Uri) {
+        _selectedPhoto.value = uri
+        _dialogOpen.value = true
+        startGpsResolution()
+    }
+
+    fun closeAddPhoto() {
+        _dialogOpen.value = false
+        _selectedPhoto.value = null
+        _gps.value = GpsState.Idle
+    }
+
+    private fun startGpsResolution() {
+        _gps.value = GpsState.Waiting
+        viewModelScope.launch {
+            if (!locationProvider.hasFineLocationPermission()) {
+                _gps.value = GpsState.Denied
+                return@launch
+            }
+            val fix = locationProvider.currentFix()
+            _gps.value = if (fix != null) GpsState.Ready(fix) else GpsState.Unavailable
+        }
+    }
+
+    /** Called by the screen after the runtime permission request finishes. */
+    fun onLocationPermissionResult(granted: Boolean) {
+        if (!_dialogOpen.value) return
+        if (!granted) {
+            _gps.value = GpsState.Denied
+            return
+        }
+        _gps.value = GpsState.Waiting
+        viewModelScope.launch {
+            val fix = locationProvider.currentFix()
+            _gps.value = if (fix != null) GpsState.Ready(fix) else GpsState.Unavailable
+        }
+    }
+
+    /**
+     * Enqueue the photo with no story. [includeLocation] is the explicit "Save
+     * with location" choice; the default "Send" attaches no `#poi`. Bytes are
+     * read now because the picker's content `Uri` is only readable this session.
+     */
+    fun sendPhoto(text: String, includeLocation: Boolean) {
+        val uri = _selectedPhoto.value ?: return
+        val fix = if (includeLocation) (_gps.value as? GpsState.Ready)?.fix else null
+        val comment = composeComment(fix, text)
+        _dialogOpen.value = false
+        _selectedPhoto.value = null
+        _gps.value = GpsState.Idle
+
+        viewModelScope.launch {
+            try {
+                val resolver = getApplication<Application>().contentResolver
+                val contentType = resolver.getType(uri) ?: "image/jpeg"
+                val bytes = withContext(Dispatchers.IO) {
+                    resolver.openInputStream(uri)?.use { it.readBytes() }
+                } ?: throw IOException("could not read the selected photo")
+                val published = withContext(Dispatchers.IO) { captureTimeFor(resolver, uri) }
+                withContext(Dispatchers.IO) {
+                    // storyId = null -> delivered through the storyless endpoints.
+                    outbox.enqueuePhoto(null, comment, published, contentType, bytes)
+                }
+                SyncScheduler.drainOutbox(getApplication())
+            } catch (t: Throwable) {
+                _error.value = t.message ?: t.javaClass.simpleName
+            }
+        }
+    }
+
+    fun clearError() {
+        _error.value = null
+    }
+}

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/photo/AddPhotoViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/photo/AddPhotoViewModel.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import java.io.IOException
+import java.time.OffsetDateTime
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -93,6 +94,9 @@ class AddPhotoViewModel(application: Application) : AndroidViewModel(application
         val uri = _selectedPhoto.value ?: return
         val fix = if (includeLocation) (_gps.value as? GpsState.Ready)?.fix else null
         val comment = composeComment(fix, text)
+        // A standalone photo is timestamped when it's added (now), not by the
+        // image's capture/EXIF time — unlike a trip photo.
+        val published = OffsetDateTime.now().toString()
         _dialogOpen.value = false
         _selectedPhoto.value = null
         _gps.value = GpsState.Idle
@@ -104,7 +108,6 @@ class AddPhotoViewModel(application: Application) : AndroidViewModel(application
                 val bytes = withContext(Dispatchers.IO) {
                     resolver.openInputStream(uri)?.use { it.readBytes() }
                 } ?: throw IOException("could not read the selected photo")
-                val published = withContext(Dispatchers.IO) { captureTimeFor(resolver, uri) }
                 withContext(Dispatchers.IO) {
                     // storyId = null -> delivered through the storyless endpoints.
                     outbox.enqueuePhoto(null, comment, published, contentType, bytes)

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/photo/PhotoCaptureTime.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/photo/PhotoCaptureTime.kt
@@ -1,0 +1,47 @@
+package org.polybrain.tasks.health.ui.photo
+
+import android.content.ContentResolver
+import android.net.Uri
+import android.provider.MediaStore
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneId
+
+/**
+ * The gallery's `DATE_TAKEN` (epoch millis, UTC) for a picked image, or null
+ * when absent. Shared by the trip-photo and standalone-photo flows.
+ */
+fun captureMillisFor(resolver: ContentResolver, uri: Uri): Long? =
+    runCatching {
+        resolver.query(
+            uri,
+            arrayOf(MediaStore.Images.Media.DATE_TAKEN),
+            null,
+            null,
+            null,
+        )?.use { cursor ->
+            val index = cursor.getColumnIndex(MediaStore.Images.Media.DATE_TAKEN)
+            if (index >= 0 && cursor.moveToFirst() && !cursor.isNull(index)) {
+                cursor.getLong(index)
+            } else {
+                null
+            }
+        }
+    }.getOrNull()?.takeIf { it > 0 }
+
+/**
+ * Best-effort ISO-8601 capture time of a picked image: the gallery's
+ * `DATE_TAKEN` when present, else now. The backend overrides this with the
+ * original's EXIF `DateTimeOriginal` when the file carries one.
+ */
+fun captureTimeFor(resolver: ContentResolver, uri: Uri): String {
+    val millis = captureMillisFor(resolver, uri)
+    return if (millis != null) {
+        OffsetDateTime.ofInstant(
+            Instant.ofEpochMilli(millis),
+            ZoneId.systemDefault(),
+        ).toString()
+    } else {
+        OffsetDateTime.now().toString()
+    }
+}

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/AddNoteDialog.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/AddNoteDialog.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import org.polybrain.tasks.health.R
+import org.polybrain.tasks.health.location.GpsState
 
 @Composable
 fun AddNoteDialog(vm: TripDetailViewModel) {
@@ -64,7 +65,7 @@ fun AddNoteDialog(vm: TripDetailViewModel) {
             ) {
                 TextButton(
                     onClick = { vm.sendNote(draft, includeLocation = true) },
-                    enabled = gps is TripDetailViewModel.GpsState.Ready,
+                    enabled = gps is GpsState.Ready,
                 ) {
                     Text(stringResource(R.string.trip_save_with_location))
                 }
@@ -86,24 +87,24 @@ fun AddNoteDialog(vm: TripDetailViewModel) {
 
 @Composable
 internal fun GpsStatusBlock(
-    state: TripDetailViewModel.GpsState,
+    state: GpsState,
     onRequestPermission: () -> Unit,
 ) {
     when (state) {
-        TripDetailViewModel.GpsState.Idle,
-        TripDetailViewModel.GpsState.Waiting -> Text(
+        GpsState.Idle,
+        GpsState.Waiting -> Text(
             text = stringResource(R.string.trip_note_gps_waiting),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        is TripDetailViewModel.GpsState.Ready -> Text(
+        is GpsState.Ready -> Text(
             text = stringResource(R.string.trip_note_gps_ready).format(
                 state.fix.lat, state.fix.lng,
             ),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        TripDetailViewModel.GpsState.Denied -> Column {
+        GpsState.Denied -> Column {
             Text(
                 text = stringResource(R.string.trip_note_gps_missing),
                 style = MaterialTheme.typography.bodySmall,
@@ -113,7 +114,7 @@ internal fun GpsStatusBlock(
                 Text(stringResource(R.string.trip_note_grant_location))
             }
         }
-        TripDetailViewModel.GpsState.Unavailable -> Text(
+        GpsState.Unavailable -> Text(
             text = stringResource(R.string.trip_note_gps_missing),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.error,

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/AddPhotoDialog.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/AddPhotoDialog.kt
@@ -1,6 +1,7 @@
 package org.polybrain.tasks.health.ui.trip
 
 import android.Manifest
+import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -14,7 +15,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -30,20 +30,31 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import org.polybrain.tasks.health.R
+import org.polybrain.tasks.health.location.GpsSource
+import org.polybrain.tasks.health.location.GpsState
 
+/**
+ * Reusable add-photo dialog, decoupled from any specific ViewModel. Used both by
+ * the trip detail (location resolved from the trip track) and by the standalone
+ * photo flow (a live GPS fix). The TRACK hint only appears for trip photos; a
+ * standalone photo's [gps] is always LIVE, so it shows the [GpsStatusBlock].
+ */
 @Composable
-fun AddPhotoDialog(vm: TripDetailViewModel) {
-    val gps by vm.gps.collectAsState()
-    val selectedPhoto by vm.selectedPhoto.collectAsState()
-
+fun AddPhotoDialog(
+    selectedPhoto: Uri?,
+    gps: GpsState,
+    onPermissionResult: (Boolean) -> Unit,
+    onSend: (text: String, includeLocation: Boolean) -> Unit,
+    onDismiss: () -> Unit,
+) {
     var draft by remember { mutableStateOf("") }
 
     val permissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission(),
-    ) { granted -> vm.onLocationPermissionResult(granted) }
+    ) { granted -> onPermissionResult(granted) }
 
     AlertDialog(
-        onDismissRequest = { vm.closeAddPhoto() },
+        onDismissRequest = { onDismiss() },
         title = { Text(stringResource(R.string.trip_photo_dialog_title)) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -58,8 +69,8 @@ fun AddPhotoDialog(vm: TripDetailViewModel) {
                     )
                 }
                 val gpsState = gps
-                if (gpsState is TripDetailViewModel.GpsState.Ready &&
-                    gpsState.source == TripDetailViewModel.GpsSource.TRACK
+                if (gpsState is GpsState.Ready &&
+                    gpsState.source == GpsSource.TRACK
                 ) {
                     // A photo's location comes from the recorded trip track, not
                     // a live fix — say so, with the capture time it was matched to.
@@ -90,25 +101,25 @@ fun AddPhotoDialog(vm: TripDetailViewModel) {
             }
         },
         // "Send" is the default and attaches no location; "Save with location"
-        // is the explicit opt-in, enabled only when the track produced a fix.
+        // is the explicit opt-in, enabled only when a fix is ready.
         confirmButton = {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 TextButton(
-                    onClick = { vm.sendPhoto(draft, includeLocation = true) },
-                    enabled = gps is TripDetailViewModel.GpsState.Ready,
+                    onClick = { onSend(draft, true) },
+                    enabled = gps is GpsState.Ready,
                 ) {
                     Text(stringResource(R.string.trip_save_with_location))
                 }
-                TextButton(onClick = { vm.sendPhoto(draft, includeLocation = false) }) {
+                TextButton(onClick = { onSend(draft, false) }) {
                     Text(stringResource(R.string.trip_send))
                 }
             }
         },
         dismissButton = {
-            TextButton(onClick = { vm.closeAddPhoto() }) {
+            TextButton(onClick = { onDismiss() }) {
                 Text(stringResource(R.string.trip_note_cancel))
             }
         },

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripDetailScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripDetailScreen.kt
@@ -180,7 +180,15 @@ fun TripDetailScreen(
         AddNoteDialog(vm)
     }
     if (photoOpen) {
-        AddPhotoDialog(vm)
+        val gps by vm.gps.collectAsState()
+        val selectedPhoto by vm.selectedPhoto.collectAsState()
+        AddPhotoDialog(
+            selectedPhoto = selectedPhoto,
+            gps = gps,
+            onPermissionResult = vm::onLocationPermissionResult,
+            onSend = vm::sendPhoto,
+            onDismiss = vm::closeAddPhoto,
+        )
     }
     if (renameOpen && s != null) {
         RenameDialog(

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripDetailViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripDetailViewModel.kt
@@ -2,7 +2,6 @@ package org.polybrain.tasks.health.ui.trip
 
 import android.app.Application
 import android.net.Uri
-import android.provider.MediaStore
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.work.WorkInfo
@@ -11,8 +10,6 @@ import java.io.File
 import java.io.IOException
 import java.time.Instant
 import java.time.OffsetDateTime
-import java.time.ZoneId
-import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -34,11 +31,15 @@ import org.polybrain.tasks.health.data.TripEvent
 import org.polybrain.tasks.health.data.TripStoryIdRequest
 import org.polybrain.tasks.health.data.TripSummary
 import org.polybrain.tasks.health.data.TripUpdateRequest
-import org.polybrain.tasks.health.location.LocationFix
+import org.polybrain.tasks.health.location.GpsSource
+import org.polybrain.tasks.health.location.GpsState
 import org.polybrain.tasks.health.location.LocationProvider
 import org.polybrain.tasks.health.location.PhotoLocationResolver
 import org.polybrain.tasks.health.location.TripTracker
+import org.polybrain.tasks.health.location.composeComment
 import org.polybrain.tasks.health.sync.SyncScheduler
+import org.polybrain.tasks.health.ui.photo.captureMillisFor
+import org.polybrain.tasks.health.ui.photo.captureTimeFor
 
 class TripDetailViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -94,26 +95,8 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
     private val _viewerUrl = MutableStateFlow<String?>(null)
     val viewerUrl: StateFlow<String?> = _viewerUrl.asStateFlow()
 
-    /**
-     * GPS resolution state. The dialog reads this to decide whether to
-     * gate the Send button and what hint to show.
-     */
-    /** Where a Ready fix came from: a live GPS read (notes) or the trip's recorded track (photos). */
-    enum class GpsSource { LIVE, TRACK }
-
-    sealed class GpsState {
-        object Idle : GpsState()
-        object Waiting : GpsState()
-        data class Ready(
-            val fix: LocationFix,
-            val source: GpsSource = GpsSource.LIVE,
-            // For TRACK: the photo's capture time, shown in the dialog hint.
-            val atMillis: Long? = null,
-        ) : GpsState()
-        object Denied : GpsState()
-        object Unavailable : GpsState()
-    }
-
+    // GPS resolution state (see location/GpsState.kt); the dialog reads this to
+    // decide whether to enable "Save with location" and what hint to show.
     private val _gps = MutableStateFlow<GpsState>(GpsState.Idle)
     val gps: StateFlow<GpsState> = _gps.asStateFlow()
 
@@ -172,8 +155,9 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
         _photoDialogOpen.value = true
         _gps.value = GpsState.Waiting
         viewModelScope.launch {
+            val resolver = getApplication<Application>().contentResolver
             val captureMs = withContext(Dispatchers.IO) {
-                captureMillisFor(uri) ?: System.currentTimeMillis()
+                captureMillisFor(resolver, uri) ?: System.currentTimeMillis()
             }
             val fix = withContext(Dispatchers.IO) {
                 PhotoLocationResolver.resolve(breadcrumbStore.all(), captureMs)
@@ -269,7 +253,7 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
                 val bytes = withContext(Dispatchers.IO) {
                     resolver.openInputStream(uri)?.use { it.readBytes() }
                 } ?: throw IOException("could not read the selected photo")
-                val published = withContext(Dispatchers.IO) { captureTimeFor(uri) }
+                val published = withContext(Dispatchers.IO) { captureTimeFor(resolver, uri) }
                 withContext(Dispatchers.IO) {
                     outbox.enqueuePhoto(story.id, comment, published, contentType, bytes)
                 }
@@ -302,44 +286,6 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
 
     /** Local file backing a pending photo, for the timeline thumbnail. */
     fun pendingPhotoFile(item: OutboxItem): File? = outbox.photoFile(item)
-
-    /**
-     * Best-effort capture time of a picked image: the gallery's DATE_TAKEN
-     * (epoch millis, UTC) when present, else now. The backend overrides this
-     * with the original's EXIF DateTimeOriginal when the file carries one.
-     */
-    private fun captureTimeFor(uri: Uri): String {
-        val millis = captureMillisFor(uri)
-        return if (millis != null) {
-            OffsetDateTime.ofInstant(
-                Instant.ofEpochMilli(millis),
-                ZoneId.systemDefault(),
-            ).toString()
-        } else {
-            OffsetDateTime.now().toString()
-        }
-    }
-
-    /** The gallery's DATE_TAKEN (epoch millis), or null when absent. */
-    private fun captureMillisFor(uri: Uri): Long? {
-        val resolver = getApplication<Application>().contentResolver
-        return runCatching {
-            resolver.query(
-                uri,
-                arrayOf(MediaStore.Images.Media.DATE_TAKEN),
-                null,
-                null,
-                null,
-            )?.use { cursor ->
-                val index = cursor.getColumnIndex(MediaStore.Images.Media.DATE_TAKEN)
-                if (index >= 0 && cursor.moveToFirst() && !cursor.isNull(index)) {
-                    cursor.getLong(index)
-                } else {
-                    null
-                }
-            }
-        }.getOrNull()?.takeIf { it > 0 }
-    }
 
     /** Fetch a fresh presigned URL for a photo's original and open the viewer. */
     fun openPhoto(eventId: Long) {
@@ -462,18 +408,6 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
     }
 
     companion object {
-        internal fun composeComment(fix: LocationFix?, text: String): String {
-            val trimmed = text.trim()
-            return if (fix != null) {
-                val prefix = String.format(
-                    Locale.US, "#poi lat=%.6f lng=%.6f", fix.lat, fix.lng,
-                )
-                if (trimmed.isEmpty()) prefix else "$prefix\n$trimmed"
-            } else {
-                trimmed
-            }
-        }
-
         private fun instantOf(iso: String): Instant =
             runCatching { OffsetDateTime.parse(iso).toInstant() }.getOrDefault(Instant.EPOCH)
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -77,6 +77,10 @@
     <string name="today_top_bar_title">Tasks Collector</string>
 
     <string name="today_board_fab_label">Add from board</string>
+    <string name="today_fab_expand">Add</string>
+    <string name="today_fab_close">Close</string>
+    <string name="today_fab_add_task">Add Task</string>
+    <string name="today_fab_add_photo">Add Photo</string>
     <string name="board_picker_add_button">Add %1$d</string>
     <string name="board_picker_cancel">Cancel</string>
     <string name="board_picker_empty">This board has no items.</string>

--- a/android/app/src/test/java/org/polybrain/tasks/health/data/OutboxTest.kt
+++ b/android/app/src/test/java/org/polybrain/tasks/health/data/OutboxTest.kt
@@ -66,6 +66,19 @@ class OutboxTest {
     }
 
     @Test
+    fun `enqueuePhoto with null story is a standalone photo`() {
+        val bytes = byteArrayOf(4, 2)
+        val item = outbox.enqueuePhoto(null, "cap", "2026-06-06T10:00:00Z", "image/jpeg", bytes)
+        assertNull(item.storyId)
+        val reloaded = outbox.all().single()
+        assertNull(reloaded.storyId)
+        assertTrue(bytes.contentEquals(outbox.photoBytes(reloaded)))
+        // A storyless photo never shows under any trip, but is still drained.
+        assertTrue(outbox.forStory(0L).isEmpty())
+        assertEquals(1, outbox.all().size)
+    }
+
+    @Test
     fun `update rewrites the same file in place`() {
         val item = outbox.enqueueNote(1L, "x", "t")
         outbox.update(item.copy(attempts = 3, lastError = "boom"))

--- a/android/app/src/test/java/org/polybrain/tasks/health/location/PoiCommentTest.kt
+++ b/android/app/src/test/java/org/polybrain/tasks/health/location/PoiCommentTest.kt
@@ -1,0 +1,32 @@
+package org.polybrain.tasks.health.location
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PoiCommentTest {
+
+    @Test
+    fun `no fix returns the trimmed text`() {
+        assertEquals("hello", composeComment(null, "  hello  "))
+    }
+
+    @Test
+    fun `no fix and blank text returns empty`() {
+        assertEquals("", composeComment(null, "   "))
+    }
+
+    @Test
+    fun `a fix prepends a six-decimal poi line above the text`() {
+        val fix = LocationFix(40.7128, -74.006, 5f)
+        assertEquals(
+            "#poi lat=40.712800 lng=-74.006000\nat the pier",
+            composeComment(fix, "at the pier"),
+        )
+    }
+
+    @Test
+    fun `a fix with blank text is just the poi line`() {
+        val fix = LocationFix(1.5, 2.5, null)
+        assertEquals("#poi lat=1.500000 lng=2.500000", composeComment(fix, "  "))
+    }
+}

--- a/android/app/src/test/java/org/polybrain/tasks/health/sync/OutboxDrainerTest.kt
+++ b/android/app/src/test/java/org/polybrain/tasks/health/sync/OutboxDrainerTest.kt
@@ -20,6 +20,8 @@ import org.polybrain.tasks.health.data.PhotoOriginalResponse
 import org.polybrain.tasks.health.data.PhotoPresignRequest
 import org.polybrain.tasks.health.data.PhotoPresignResponse
 import org.polybrain.tasks.health.data.PlanListResponse
+import org.polybrain.tasks.health.data.StandalonePhotoConfirmRequest
+import org.polybrain.tasks.health.data.StandalonePhotoPresignRequest
 import org.polybrain.tasks.health.data.TaskCompleteRequest
 import org.polybrain.tasks.health.data.TaskTextRequest
 import org.polybrain.tasks.health.data.TasksApi
@@ -107,6 +109,28 @@ class OutboxDrainerTest {
     }
 
     @Test
+    fun `standalone photo presigns and confirms via storyless endpoints`() = runTest {
+        // storyId = null marks a standalone photo (a PhotoTaken with no trip).
+        val item = outbox.enqueuePhoto(null, "cap", "t", "image/jpeg", byteArrayOf(9))
+        val api = FakeApi(presignKey = "photos/7/k.jpg", presignUrl = "https://put/s")
+        var putCalls = 0
+        val put = OutboxDrainer.PhotoPutter { url, _, _ ->
+            putCalls++
+            assertEquals("https://put/s", url)
+        }
+        val outcome = OutboxDrainer.process(item, api, outbox, put)
+        assertTrue(outcome is OutboxDrainer.Outcome.Sent)
+        assertEquals(1, putCalls)
+        // The trip endpoints are never touched; the storyless ones are.
+        assertEquals(0, api.presignRequests.size)
+        assertEquals(0, api.confirmRequests.size)
+        assertEquals(1, api.standalonePresignRequests.size)
+        val confirm = api.standaloneConfirmRequests.single()
+        assertEquals("photos/7/k.jpg", confirm.key)
+        assertEquals(item.id, confirm.idempotencyKey)
+    }
+
+    @Test
     fun `4xx is permanent`() = runTest {
         val item = outbox.enqueueNote(1L, "x", "t")
         val api = FakeApi(noteError = httpException(409))
@@ -154,6 +178,8 @@ class OutboxDrainerTest {
         val noteRequests = mutableListOf<TripNoteRequest>()
         val presignRequests = mutableListOf<PhotoPresignRequest>()
         val confirmRequests = mutableListOf<PhotoConfirmRequest>()
+        val standalonePresignRequests = mutableListOf<StandalonePhotoPresignRequest>()
+        val standaloneConfirmRequests = mutableListOf<StandalonePhotoConfirmRequest>()
 
         override suspend fun addTripNote(body: TripNoteRequest): TripNoteResponse {
             noteError?.let { throw it }
@@ -169,6 +195,21 @@ class OutboxDrainerTest {
         override suspend fun addTripPhoto(body: PhotoConfirmRequest): PhotoConfirmResponse {
             photoError?.let { throw it }
             confirmRequests += body
+            return PhotoConfirmResponse(ok = true, photoId = 1)
+        }
+
+        override suspend fun presignStandalonePhoto(
+            body: StandalonePhotoPresignRequest,
+        ): PhotoPresignResponse {
+            standalonePresignRequests += body
+            return PhotoPresignResponse(key = presignKey, uploadUrl = presignUrl)
+        }
+
+        override suspend fun addStandalonePhoto(
+            body: StandalonePhotoConfirmRequest,
+        ): PhotoConfirmResponse {
+            photoError?.let { throw it }
+            standaloneConfirmRequests += body
             return PhotoConfirmResponse(ok = true, photoId = 1)
         }
 

--- a/tasks/apps/tree/services/photos/__init__.py
+++ b/tasks/apps/tree/services/photos/__init__.py
@@ -1,19 +1,36 @@
 from . import storage
+from .events import (
+    PhotoObjectMissingError,
+    capture_datetime_from_storage,
+    daily_thread,
+    existing_event,
+)
 from .keys import (
     CONTENT_TYPE_EXT,
     ext_for_content_type,
     key_belongs_to,
     original_key,
+    photo_key,
+    photo_key_belongs_to,
     thumbnail_key_for,
 )
 from .metadata import read_capture_datetime
+from .standalone import add_standalone_photo, presign_standalone_photo
 
 __all__ = [
     "storage",
+    "PhotoObjectMissingError",
+    "capture_datetime_from_storage",
+    "daily_thread",
+    "existing_event",
     "CONTENT_TYPE_EXT",
     "ext_for_content_type",
     "key_belongs_to",
     "original_key",
+    "photo_key",
+    "photo_key_belongs_to",
     "thumbnail_key_for",
     "read_capture_datetime",
+    "add_standalone_photo",
+    "presign_standalone_photo",
 ]

--- a/tasks/apps/tree/services/photos/events.py
+++ b/tasks/apps/tree/services/photos/events.py
@@ -1,0 +1,50 @@
+"""Shared helpers for creating photo events from confirmed S3 uploads.
+
+Extracted from ``services.trips.operations`` so the storyless photo path
+(``services.photos.standalone``) can reuse the exactly-once lookup, the EXIF
+capture-time read, and the Daily-thread resolution without importing the trips
+module — which would create a ``trips`` <-> ``photos`` circular import.
+"""
+
+from . import storage as photo_storage
+from .metadata import read_capture_datetime
+
+
+class PhotoObjectMissingError(Exception):
+    """The presigned upload was never completed (no object in the bucket)."""
+
+
+def daily_thread():
+    """The Daily thread, where diary-style journal/photo events land.
+
+    Deliberately *not* the user's ``Profile.default_board_thread`` (which
+    targets boards/tasks and may be the Inbox).
+    """
+    from ...models import Thread
+
+    return Thread.objects.get(name="Daily")
+
+
+def existing_event(model, idempotency_key):
+    """The event previously created for ``idempotency_key``, or None.
+
+    Used for exactly-once writes: a retried request (whose first response was
+    lost) re-uses the existing event instead of creating a duplicate.
+    """
+    if not idempotency_key:
+        return None
+    return model.objects.filter(idempotency_key=idempotency_key).first()
+
+
+def capture_datetime_from_storage(key):
+    """Best-effort EXIF capture time of the just-uploaded original.
+
+    Returns None on any failure (download error, non-image, no EXIF date) so a
+    missing or unreadable timestamp never blocks the confirm — the caller then
+    falls back to the client-supplied ``published``.
+    """
+    try:
+        raw = photo_storage.download_bytes(key)
+    except Exception:  # noqa: BLE001 - storage hiccups must not fail confirm
+        return None
+    return read_capture_datetime(raw)

--- a/tasks/apps/tree/services/photos/keys.py
+++ b/tasks/apps/tree/services/photos/keys.py
@@ -27,6 +27,12 @@ def original_key(user_id, story_id, content_type):
     return f"trips/{user_id}/{story_id}/{uuid.uuid4()}.{ext}"
 
 
+def photo_key(user_id, content_type):
+    """Allocate a fresh S3 key for a standalone (storyless) photo upload."""
+    ext = ext_for_content_type(content_type)
+    return f"photos/{user_id}/{uuid.uuid4()}.{ext}"
+
+
 def thumbnail_key_for(original):
     """Deterministic WebP thumbnail key derived from an original key."""
     base = original.rsplit(".", 1)[0]
@@ -36,3 +42,8 @@ def thumbnail_key_for(original):
 def key_belongs_to(key, user_id, story_id):
     """Guard: a confirmed key must live under this user's/story's prefix."""
     return key.startswith(f"trips/{user_id}/{story_id}/")
+
+
+def photo_key_belongs_to(key, user_id):
+    """Guard: a confirmed standalone key must live under this user's prefix."""
+    return key.startswith(f"photos/{user_id}/")

--- a/tasks/apps/tree/services/photos/standalone.py
+++ b/tasks/apps/tree/services/photos/standalone.py
@@ -20,12 +20,7 @@ from django.utils import timezone
 from ...models import PhotoAdded
 from ..journalling import process_journal_entry
 from . import storage as photo_storage
-from .events import (
-    PhotoObjectMissingError,
-    capture_datetime_from_storage,
-    daily_thread,
-    existing_event,
-)
+from .events import PhotoObjectMissingError, daily_thread, existing_event
 from .keys import photo_key, photo_key_belongs_to
 
 
@@ -53,6 +48,10 @@ def add_standalone_photo(
     Raises ``PhotoObjectMissingError`` if the object isn't in the bucket (or the
     key doesn't belong to this user's ``photos/{user}/`` prefix).
 
+    Unlike a trip photo, a standalone photo is timestamped with when it was
+    *added* (the client-supplied ``published``, i.e. now), **not** the image's
+    EXIF/capture time — so its event_stream_id lands on the day it was filed.
+
     ``idempotency_key`` makes the confirm exactly-once: a retry carrying a key
     that already produced a photo returns that same photo.
     """
@@ -65,12 +64,6 @@ def add_standalone_photo(
     if not photo_storage.object_exists(key):
         raise PhotoObjectMissingError(f"no uploaded object at {key!r}")
 
-    # Prefer the time the photo was taken (EXIF) over upload time. Falls back
-    # to the client-supplied ``published`` (the gallery's DATE_TAKEN) and then
-    # to now. Done here so the pre_save signal computes event_stream_id from
-    # the correct date.
-    captured = capture_datetime_from_storage(key)
-
     try:
         # Nested savepoint so a unique-key collision (concurrent retry) rolls
         # back only this insert, leaving the outer transaction usable.
@@ -80,7 +73,7 @@ def add_standalone_photo(
                 comment=comment,
                 original_key=key,
                 content_type=content_type,
-                published=captured or published or timezone.now(),
+                published=published or timezone.now(),
                 idempotency_key=idempotency_key,
             )
             process_journal_entry(photo, story=None)

--- a/tasks/apps/tree/services/photos/standalone.py
+++ b/tasks/apps/tree/services/photos/standalone.py
@@ -1,0 +1,97 @@
+"""Standalone (storyless) photo operations.
+
+A standalone photo is the same ``PhotoAdded`` event as a trip photo — it lands
+on the Daily thread and runs through the journalling pipeline so a ``#poi`` line
+still creates a HabitTracked — except it is **not** linked to any Story (no
+``StoryEvent`` row). The only structural difference is the S3 key prefix
+(``photos/{user}/`` instead of ``trips/{user}/{story}/``), which doubles as the
+ownership signal for the full-original endpoint.
+
+Kept in the ``photos`` package (not ``trips``) so it shares the photo plumbing
+without importing the trips module, avoiding a ``trips`` <-> ``photos`` cycle.
+"""
+
+from datetime import timedelta
+
+from django.conf import settings
+from django.db import IntegrityError, transaction
+from django.utils import timezone
+
+from ...models import PhotoAdded
+from ..journalling import process_journal_entry
+from . import storage as photo_storage
+from .events import (
+    PhotoObjectMissingError,
+    capture_datetime_from_storage,
+    daily_thread,
+    existing_event,
+)
+from .keys import photo_key, photo_key_belongs_to
+
+
+@transaction.atomic
+def presign_standalone_photo(user, content_type):
+    """Allocate an S3 key and return a presigned PUT URL for a storyless photo.
+
+    Raises ``ValueError`` for an unsupported content type.
+    """
+    key = photo_key(user.pk, content_type)
+    url = photo_storage.presign_put(key, content_type)
+    expires_at = timezone.now() + timedelta(seconds=settings.PHOTO_PRESIGN_PUT_TTL)
+    return {"key": key, "upload_url": url, "expires_at": expires_at.isoformat()}
+
+
+@transaction.atomic
+def add_standalone_photo(
+    user, key, comment, content_type, published=None, idempotency_key=None
+):
+    """Confirm an uploaded storyless photo: create a ``PhotoAdded`` on the Daily
+    thread and run it through the journalling pipeline (so a ``#poi`` line in
+    ``comment`` still creates a HabitTracked). Enqueues the thumbnail task on
+    commit. Creates no ``StoryEvent`` — the photo belongs to no trip.
+
+    Raises ``PhotoObjectMissingError`` if the object isn't in the bucket (or the
+    key doesn't belong to this user's ``photos/{user}/`` prefix).
+
+    ``idempotency_key`` makes the confirm exactly-once: a retry carrying a key
+    that already produced a photo returns that same photo.
+    """
+    existing = existing_event(PhotoAdded, idempotency_key)
+    if existing is not None:
+        return existing
+
+    if not photo_key_belongs_to(key, user.pk):
+        raise PhotoObjectMissingError(f"key {key!r} not under this user's prefix")
+    if not photo_storage.object_exists(key):
+        raise PhotoObjectMissingError(f"no uploaded object at {key!r}")
+
+    # Prefer the time the photo was taken (EXIF) over upload time. Falls back
+    # to the client-supplied ``published`` (the gallery's DATE_TAKEN) and then
+    # to now. Done here so the pre_save signal computes event_stream_id from
+    # the correct date.
+    captured = capture_datetime_from_storage(key)
+
+    try:
+        # Nested savepoint so a unique-key collision (concurrent retry) rolls
+        # back only this insert, leaving the outer transaction usable.
+        with transaction.atomic():
+            photo = PhotoAdded.objects.create(
+                thread=daily_thread(),
+                comment=comment,
+                original_key=key,
+                content_type=content_type,
+                published=captured or published or timezone.now(),
+                idempotency_key=idempotency_key,
+            )
+            process_journal_entry(photo, story=None)
+    except IntegrityError:
+        existing = existing_event(PhotoAdded, idempotency_key)
+        if existing is not None:
+            return existing
+        raise
+
+    # Import here to avoid importing celery tasks at module load.
+    from ...tasks import generate_photo_thumbnail
+
+    transaction.on_commit(lambda: generate_photo_thumbnail.delay(photo.pk))
+    return photo

--- a/tasks/apps/tree/services/trips/operations.py
+++ b/tasks/apps/tree/services/trips/operations.py
@@ -11,11 +11,20 @@ from django.conf import settings
 from django.db import IntegrityError, transaction
 from django.utils import timezone
 
-from ...models import JournalAdded, PhotoAdded, Story, StoryEvent, Thread
+from ...models import JournalAdded, PhotoAdded, Story, StoryEvent
 from ..journalling import process_journal_entry
-from ..photos import key_belongs_to, original_key, read_capture_datetime
+from ..photos import key_belongs_to, original_key, photo_key_belongs_to
 from ..photos import storage as photo_storage
+from ..photos.events import (
+    PhotoObjectMissingError,
+    capture_datetime_from_storage,
+    daily_thread,
+    existing_event,
+)
 from .titles import default_title
+
+# ``PhotoObjectMissingError`` is imported from ``..photos.events`` and re-exported
+# here so ``services.trips`` keeps its existing public surface.
 
 
 class StoryNotFoundError(Exception):
@@ -26,22 +35,12 @@ class StoryStoppedError(Exception):
     """The Story is already stopped; no further events can be attached."""
 
 
-class PhotoObjectMissingError(Exception):
-    """The presigned upload was never completed (no object in the bucket)."""
-
-
-def _daily_thread():
-    return Thread.objects.get(name="Daily")
-
-
 def _journal_thread_for(user):
     """Resolve the Thread used for a trip note's/photo's JournalAdded.
 
-    Trip notes are diary-style entries, so they always go to the Daily
-    thread — deliberately *not* the user's ``Profile.default_board_thread``
-    (which targets boards/tasks and may be the Inbox).
+    Trip notes are diary-style entries, so they always go to the Daily thread.
     """
-    return _daily_thread()
+    return daily_thread()
 
 
 def _get_owned_story(user, story_id):
@@ -51,17 +50,6 @@ def _get_owned_story(user, story_id):
         raise StoryNotFoundError(
             f"Story #{story_id} not found for user {user.pk}"
         ) from e
-
-
-def _existing_event(model, idempotency_key):
-    """The event previously created for ``idempotency_key``, or None.
-
-    Used for exactly-once writes: a retried request (whose first response was
-    lost) re-uses the existing event instead of creating a duplicate.
-    """
-    if not idempotency_key:
-        return None
-    return model.objects.filter(idempotency_key=idempotency_key).first()
 
 
 @transaction.atomic
@@ -115,7 +103,7 @@ def add_trip_note(user, story_id, comment, published=None, idempotency_key=None)
     """
     story = _get_owned_story(user, story_id)
 
-    existing = _existing_event(JournalAdded, idempotency_key)
+    existing = existing_event(JournalAdded, idempotency_key)
     if existing is not None:
         return existing
 
@@ -135,7 +123,7 @@ def add_trip_note(user, story_id, comment, published=None, idempotency_key=None)
             )
             process_journal_entry(journal_added, story=story)
     except IntegrityError:
-        existing = _existing_event(JournalAdded, idempotency_key)
+        existing = existing_event(JournalAdded, idempotency_key)
         if existing is not None:
             return existing
         raise
@@ -158,20 +146,6 @@ def presign_photo_upload(user, story_id, content_type):
     return {"key": key, "upload_url": url, "expires_at": expires_at.isoformat()}
 
 
-def _capture_datetime_from_storage(key):
-    """Best-effort EXIF capture time of the just-uploaded original.
-
-    Returns None on any failure (download error, non-image, no EXIF date) so a
-    missing or unreadable timestamp never blocks the confirm — the caller then
-    falls back to the client-supplied ``published``.
-    """
-    try:
-        raw = photo_storage.download_bytes(key)
-    except Exception:  # noqa: BLE001 - storage hiccups must not fail confirm
-        return None
-    return read_capture_datetime(raw)
-
-
 @transaction.atomic
 def add_trip_photo(
     user, story_id, key, comment, content_type, published=None, idempotency_key=None
@@ -190,7 +164,7 @@ def add_trip_photo(
     """
     story = _get_owned_story(user, story_id)
 
-    existing = _existing_event(PhotoAdded, idempotency_key)
+    existing = existing_event(PhotoAdded, idempotency_key)
     if existing is not None:
         return existing
 
@@ -205,7 +179,7 @@ def add_trip_photo(
     # to the client-supplied ``published`` (the gallery's DATE_TAKEN) and then
     # to now. Done here so the pre_save signal computes event_stream_id from
     # the correct date.
-    captured = _capture_datetime_from_storage(key)
+    captured = capture_datetime_from_storage(key)
 
     try:
         # Nested savepoint so a unique-key collision (concurrent retry) rolls
@@ -221,7 +195,7 @@ def add_trip_photo(
             )
             process_journal_entry(photo, story=story)
     except IntegrityError:
-        existing = _existing_event(PhotoAdded, idempotency_key)
+        existing = existing_event(PhotoAdded, idempotency_key)
         if existing is not None:
             return existing
         raise
@@ -235,19 +209,26 @@ def add_trip_photo(
 
 def presign_photo_original(user, event_id):
     """Fresh presigned GET URL for the full-resolution original of a photo the
-    user owns (ownership resolved via StoryEvent -> Story.user).
+    user owns.
+
+    Ownership is resolved two ways so this serves both trip photos and
+    standalone ones: a trip photo is owned if a ``StoryEvent`` links it to one
+    of the user's Stories; a standalone photo (no ``StoryEvent``) is owned if
+    its ``original_key`` lives under the user's ``photos/{user}/`` prefix (the
+    Daily thread is global, so the key prefix is the only owner signal).
 
     Raises ``StoryNotFoundError`` if no such owned photo exists (404-safe).
     """
-    try:
-        entry = StoryEvent.objects.select_related("story").get(
-            event_id=event_id, story__user=user
-        )
-    except StoryEvent.DoesNotExist as e:
-        raise StoryNotFoundError(f"Photo #{event_id} not found for user") from e
-    photo = entry.event.get_real_instance()
-    if not isinstance(photo, PhotoAdded):
-        raise StoryNotFoundError(f"Event #{event_id} is not a photo")
+    photo = PhotoAdded.objects.filter(pk=event_id).first()
+    if photo is None:
+        raise StoryNotFoundError(f"Photo #{event_id} not found")
+    entry = StoryEvent.objects.select_related("story").filter(event_id=event_id).first()
+    if entry is not None:
+        owned = entry.story.user_id == user.id
+    else:
+        owned = photo_key_belongs_to(photo.original_key, user.pk)
+    if not owned:
+        raise StoryNotFoundError(f"Photo #{event_id} not found for user")
     return {"url": photo_storage.presign_get(photo.original_key)}
 
 

--- a/tasks/apps/tree/tests/test_standalone_photo_api.py
+++ b/tasks/apps/tree/tests/test_standalone_photo_api.py
@@ -1,0 +1,148 @@
+from datetime import datetime as datetime_cls
+from datetime import timezone as dt_timezone
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APITestCase
+
+from ..models import PhotoAdded, Profile, StoryEvent, Thread
+
+PUB_AT = datetime_cls(2026, 5, 25, 14, 30, tzinfo=dt_timezone.utc).isoformat()
+STORAGE = "tasks.apps.tree.services.photos.storage"
+
+
+class StandalonePhotoAPITestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        User = get_user_model()
+        cls.user = User.objects.create_user(username="phone", password="x")
+        cls.other = User.objects.create_user(username="other", password="x")
+        cls.token = Token.objects.create(user=cls.user)
+        cls.other_token = Token.objects.create(user=cls.other)
+        cls.daily, _ = Thread.objects.get_or_create(name="Daily")
+        Profile.objects.create(user=cls.user, default_board_thread=cls.daily)
+        Profile.objects.create(user=cls.other, default_board_thread=cls.daily)
+
+    def setUp(self):
+        self._auth()
+        patcher = mock.patch(f"{STORAGE}.download_bytes", return_value=b"")
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _auth(self, token=None):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {(token or self.token).key}")
+
+    def _presign(self, content_type="image/jpeg"):
+        return self.client.post(
+            reverse("android-photo-presign"),
+            {"content_type": content_type},
+            format="json",
+        )
+
+    def _confirm(
+        self,
+        key,
+        comment="",
+        content_type="image/jpeg",
+        published=PUB_AT,
+        idempotency_key=None,
+    ):
+        payload = {
+            "key": key,
+            "comment": comment,
+            "content_type": content_type,
+            "published": published,
+        }
+        if idempotency_key is not None:
+            payload["idempotency_key"] = idempotency_key
+        return self.client.post(
+            reverse("android-photo-confirm"), payload, format="json"
+        )
+
+    # --- presign ---
+
+    def test_presign_requires_auth(self):
+        self.client.credentials()
+        r = self._presign()
+        self.assertEqual(r.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    @mock.patch(f"{STORAGE}.presign_put", return_value="https://put.example/x")
+    def test_presign_returns_url_and_user_key(self, _put):
+        r = self._presign()
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        self.assertEqual(r.data["upload_url"], "https://put.example/x")
+        self.assertTrue(r.data["key"].startswith(f"photos/{self.user.pk}/"))
+
+    def test_presign_bad_content_type(self):
+        r = self._presign(content_type="image/gif")
+        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_presign_missing_content_type(self):
+        r = self.client.post(reverse("android-photo-presign"), {}, format="json")
+        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+
+    # --- confirm ---
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_confirm_creates_photo_without_story(self, _exists):
+        key = f"photos/{self.user.pk}/abc.jpg"
+        r = self._confirm(key, comment="")
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        self.assertTrue(r.data["ok"])
+        photo = PhotoAdded.objects.get(pk=r.data["photo_id"])
+        self.assertEqual(photo.original_key, key)
+        self.assertEqual(StoryEvent.objects.filter(event=photo).count(), 0)
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_confirm_idempotency_key_dedupes(self, _exists):
+        key = f"photos/{self.user.pk}/abc.jpg"
+        first = self._confirm(key, idempotency_key="ph-123")
+        second = self._confirm(key, idempotency_key="ph-123")
+        self.assertEqual(first.status_code, status.HTTP_200_OK)
+        self.assertEqual(second.status_code, status.HTTP_200_OK)
+        self.assertEqual(first.data["photo_id"], second.data["photo_id"])
+        self.assertEqual(PhotoAdded.objects.filter(idempotency_key="ph-123").count(), 1)
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=False)
+    def test_confirm_missing_object_409(self, _exists):
+        key = f"photos/{self.user.pk}/abc.jpg"
+        r = self._confirm(key)
+        self.assertEqual(r.status_code, status.HTTP_409_CONFLICT)
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_confirm_foreign_key_409(self, _exists):
+        key = f"photos/{self.other.pk}/abc.jpg"
+        r = self._confirm(key)
+        self.assertEqual(r.status_code, status.HTTP_409_CONFLICT)
+
+    def test_confirm_missing_published_400(self):
+        key = f"photos/{self.user.pk}/abc.jpg"
+        r = self.client.post(
+            reverse("android-photo-confirm"),
+            {"key": key, "content_type": "image/jpeg", "comment": ""},
+            format="json",
+        )
+        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
+
+    # --- original ---
+
+    @mock.patch(f"{STORAGE}.presign_get", return_value="https://get.example/orig")
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_original_returns_presigned_url(self, _exists, _get):
+        key = f"photos/{self.user.pk}/abc.jpg"
+        photo_id = self._confirm(key).data["photo_id"]
+        r = self.client.get(reverse("android-photo-original", args=[photo_id]))
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        self.assertEqual(r.data["url"], "https://get.example/orig")
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_original_other_user_404(self, _exists):
+        key = f"photos/{self.user.pk}/abc.jpg"
+        photo_id = self._confirm(key).data["photo_id"]
+        self._auth(self.other_token)
+        r = self.client.get(reverse("android-photo-original", args=[photo_id]))
+        self.assertEqual(r.status_code, status.HTTP_404_NOT_FOUND)

--- a/tasks/apps/tree/tests/test_standalone_photo_service.py
+++ b/tasks/apps/tree/tests/test_standalone_photo_service.py
@@ -1,0 +1,195 @@
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils import timezone
+
+from ..models import HabitTracked, JournalAdded, PhotoAdded, Profile, StoryEvent, Thread
+from ..services.photos import (
+    PhotoObjectMissingError,
+    add_standalone_photo,
+    photo_key,
+    photo_key_belongs_to,
+    presign_standalone_photo,
+)
+from ..services.trips import StoryNotFoundError, presign_photo_original
+
+STORAGE = "tasks.apps.tree.services.photos.storage"
+
+
+class PhotoKeyTestCase(TestCase):
+    def test_photo_key_lives_under_user_prefix(self):
+        key = photo_key(7, "image/jpeg")
+        self.assertTrue(key.startswith("photos/7/"))
+        self.assertTrue(key.endswith(".jpg"))
+
+    def test_photo_key_rejects_unsupported_content_type(self):
+        with self.assertRaises(ValueError):
+            photo_key(7, "image/gif")
+
+    def test_photo_key_belongs_to_accepts_own_prefix(self):
+        self.assertTrue(photo_key_belongs_to("photos/7/abc.jpg", 7))
+
+    def test_photo_key_belongs_to_rejects_other_user(self):
+        self.assertFalse(photo_key_belongs_to("photos/8/abc.jpg", 7))
+
+    def test_photo_key_belongs_to_rejects_trip_prefix(self):
+        self.assertFalse(photo_key_belongs_to("trips/7/3/abc.jpg", 7))
+
+
+class StandalonePhotoServiceTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        User = get_user_model()
+        cls.alice = User.objects.create_user(username="alice", password="x")
+        cls.bob = User.objects.create_user(username="bob", password="x")
+        cls.daily, _ = Thread.objects.get_or_create(name="Daily")
+        Profile.objects.create(user=cls.alice, default_board_thread=cls.daily)
+        Profile.objects.create(user=cls.bob, default_board_thread=cls.daily)
+
+    def setUp(self):
+        # Confirm reads the uploaded original's EXIF for the capture time; keep
+        # that download hermetic by default (empty bytes -> no EXIF -> the
+        # provided ``published`` is used unchanged).
+        patcher = mock.patch(f"{STORAGE}.download_bytes", return_value=b"")
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    # --- presign ---
+
+    @mock.patch(f"{STORAGE}.presign_put", return_value="https://put.example/x")
+    def test_presign_allocates_key_under_user_prefix(self, _put):
+        result = presign_standalone_photo(self.alice, content_type="image/jpeg")
+        self.assertTrue(result["key"].startswith(f"photos/{self.alice.pk}/"))
+        self.assertTrue(result["key"].endswith(".jpg"))
+        self.assertEqual(result["upload_url"], "https://put.example/x")
+        self.assertIn("expires_at", result)
+
+    def test_presign_rejects_unsupported_content_type(self):
+        with self.assertRaises(ValueError):
+            presign_standalone_photo(self.alice, content_type="image/gif")
+
+    # --- confirm ---
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_add_standalone_photo_creates_event_without_story_link(self, _exists):
+        key = f"photos/{self.alice.pk}/abc.jpg"
+        photo = add_standalone_photo(
+            self.alice,
+            key=key,
+            comment="sunset",
+            content_type="image/jpeg",
+            published=timezone.now(),
+        )
+        self.assertIsInstance(photo, PhotoAdded)
+        self.assertEqual(photo.original_key, key)
+        self.assertIsNone(photo.thumbnail_key)
+        self.assertEqual(photo.thread, self.daily)
+        # The defining property of a standalone photo: no StoryEvent link.
+        self.assertEqual(StoryEvent.objects.filter(event=photo).count(), 0)
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_add_standalone_photo_idempotency_returns_same_photo(self, _exists):
+        key = f"photos/{self.alice.pk}/abc.jpg"
+        first = add_standalone_photo(
+            self.alice,
+            key=key,
+            comment="sunset",
+            content_type="image/jpeg",
+            published=timezone.now(),
+            idempotency_key="ph-1",
+        )
+        second = add_standalone_photo(
+            self.alice,
+            key=key,
+            comment="sunset",
+            content_type="image/jpeg",
+            published=timezone.now(),
+            idempotency_key="ph-1",
+        )
+        self.assertEqual(first.pk, second.pk)
+        self.assertEqual(PhotoAdded.objects.filter(idempotency_key="ph-1").count(), 1)
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_add_standalone_photo_with_poi_creates_unlinked_habittracked(self, _exists):
+        comment = "#poi lat=40.7128 lng=-74.0060\nat the pier"
+        photo = add_standalone_photo(
+            self.alice,
+            key=f"photos/{self.alice.pk}/abc.jpg",
+            comment=comment,
+            content_type="image/jpeg",
+            published=timezone.now(),
+        )
+        habit = HabitTracked.objects.filter(habit__slug="poi").first()
+        self.assertIsNotNone(habit)
+        # Neither the photo nor its extracted habit is linked to any story.
+        self.assertEqual(StoryEvent.objects.filter(event=photo).count(), 0)
+        self.assertEqual(StoryEvent.objects.filter(event=habit).count(), 0)
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=False)
+    def test_add_standalone_photo_missing_object_raises(self, _exists):
+        with self.assertRaises(PhotoObjectMissingError):
+            add_standalone_photo(
+                self.alice,
+                key=f"photos/{self.alice.pk}/abc.jpg",
+                comment="x",
+                content_type="image/jpeg",
+                published=timezone.now(),
+            )
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_add_standalone_photo_foreign_key_prefix_raises(self, _exists):
+        with self.assertRaises(PhotoObjectMissingError):
+            add_standalone_photo(
+                self.alice,
+                key=f"photos/{self.bob.pk}/abc.jpg",
+                comment="x",
+                content_type="image/jpeg",
+                published=timezone.now(),
+            )
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_add_standalone_photo_trip_key_prefix_raises(self, _exists):
+        # A trips/ key must not be confirmable through the storyless path.
+        with self.assertRaises(PhotoObjectMissingError):
+            add_standalone_photo(
+                self.alice,
+                key=f"trips/{self.alice.pk}/9/abc.jpg",
+                comment="x",
+                content_type="image/jpeg",
+                published=timezone.now(),
+            )
+
+    # --- generalized original (ownership by key prefix) ---
+
+    @mock.patch(f"{STORAGE}.presign_get", return_value="https://get.example/orig")
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_presign_original_resolves_standalone_photo_for_owner(self, _exists, _get):
+        photo = add_standalone_photo(
+            self.alice,
+            key=f"photos/{self.alice.pk}/abc.jpg",
+            comment="",
+            content_type="image/jpeg",
+            published=timezone.now(),
+        )
+        result = presign_photo_original(self.alice, photo.pk)
+        self.assertEqual(result["url"], "https://get.example/orig")
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_presign_original_rejects_standalone_photo_for_other_user(self, _exists):
+        photo = add_standalone_photo(
+            self.alice,
+            key=f"photos/{self.alice.pk}/abc.jpg",
+            comment="",
+            content_type="image/jpeg",
+            published=timezone.now(),
+        )
+        with self.assertRaises(StoryNotFoundError):
+            presign_photo_original(self.bob, photo.pk)
+
+    def test_presign_original_404_for_non_photo_event(self):
+        journal = JournalAdded.objects.create(
+            thread=self.daily, comment="not a photo", published=timezone.now()
+        )
+        with self.assertRaises(StoryNotFoundError):
+            presign_photo_original(self.alice, journal.pk)

--- a/tasks/apps/tree/tests/test_standalone_photo_service.py
+++ b/tasks/apps/tree/tests/test_standalone_photo_service.py
@@ -1,8 +1,11 @@
+import io
 from unittest import mock
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.utils import timezone
+
+from PIL import Image
 
 from ..models import HabitTracked, JournalAdded, PhotoAdded, Profile, StoryEvent, Thread
 from ..services.photos import (
@@ -87,6 +90,32 @@ class StandalonePhotoServiceTestCase(TestCase):
         self.assertEqual(photo.thread, self.daily)
         # The defining property of a standalone photo: no StoryEvent link.
         self.assertEqual(StoryEvent.objects.filter(event=photo).count(), 0)
+
+    @staticmethod
+    def _jpeg_with_exif_datetime(dt_str):
+        """A tiny JPEG carrying ``dt_str`` as its EXIF DateTime."""
+        img = Image.new("RGB", (4, 4), "red")
+        exif = img.getexif()
+        exif[0x0132] = dt_str  # DateTime
+        buf = io.BytesIO()
+        img.save(buf, "JPEG", exif=exif)
+        return buf.getvalue()
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_add_standalone_photo_ignores_exif_capture_time(self, _exists):
+        # Unlike a trip photo, a standalone photo keeps the added-at time even
+        # when the original carries an EXIF capture time.
+        added_at = timezone.now()
+        jpeg = self._jpeg_with_exif_datetime("2021:07:15 09:30:00")
+        with mock.patch(f"{STORAGE}.download_bytes", return_value=jpeg):
+            photo = add_standalone_photo(
+                self.alice,
+                key=f"photos/{self.alice.pk}/abc.jpg",
+                comment="sunset",
+                content_type="image/jpeg",
+                published=added_at,
+            )
+        self.assertEqual(photo.published, added_at)
 
     @mock.patch(f"{STORAGE}.object_exists", return_value=True)
     def test_add_standalone_photo_idempotency_returns_same_photo(self, _exists):

--- a/tasks/apps/tree/urls.py
+++ b/tasks/apps/tree/urls.py
@@ -5,6 +5,7 @@ from rest_framework import routers
 from . import (
     views,
     views_android_api,
+    views_android_photo,
     views_android_trip,
     views_board_tasks,
     views_breakthrough,
@@ -139,6 +140,21 @@ urlpatterns = [
         "api/v1/android/trip/<int:story_id>/",
         views_android_trip.AndroidTripDetailView.as_view(),
         name="android-trip-detail",
+    ),
+    path(
+        "api/v1/android/photo/presign/",
+        views_android_photo.AndroidPhotoPresignView.as_view(),
+        name="android-photo-presign",
+    ),
+    path(
+        "api/v1/android/photo/",
+        views_android_photo.AndroidPhotoConfirmView.as_view(),
+        name="android-photo-confirm",
+    ),
+    path(
+        "api/v1/android/photo/<int:event_id>/original/",
+        views_android_trip.AndroidTripPhotoOriginalView.as_view(),
+        name="android-photo-original",
     ),
     path(
         "habit/keywords/mine/", views_habit.my_habit_keywords, name="my-habit-keywords"

--- a/tasks/apps/tree/views_android_photo.py
+++ b/tasks/apps/tree/views_android_photo.py
@@ -1,0 +1,86 @@
+"""Android endpoints for standalone (storyless) photos.
+
+The capture flow mirrors the trip-photo one — presign an S3 key, the device
+PUTs the bytes directly, then confirms — but there is no Story: a confirm
+creates a ``PhotoAdded`` on the Daily thread linked to no trip. The original
+endpoint is shared with trips via the generalized ``presign_photo_original``.
+"""
+
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+
+from rest_framework import status
+from rest_framework.authentication import TokenAuthentication
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .services.photos import (
+    PhotoObjectMissingError,
+    add_standalone_photo,
+    presign_standalone_photo,
+)
+from .views_android_trip import _bad_request, _conflict, _parse_datetime
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class AndroidPhotoPresignView(APIView):
+    """Allocate an S3 key and return a presigned PUT URL for a storyless photo.
+
+    The device uploads the original bytes directly to S3 with the returned
+    ``upload_url`` (an unauthenticated PUT), then calls the confirm endpoint.
+    """
+
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        content_type = request.data.get("content_type")
+        if not isinstance(content_type, str) or not content_type.strip():
+            return _bad_request("content_type is required")
+        try:
+            result = presign_standalone_photo(request.user, content_type=content_type)
+        except ValueError as e:
+            return _bad_request(str(e))
+        return Response(result, status=status.HTTP_200_OK)
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class AndroidPhotoConfirmView(APIView):
+    """Confirm an uploaded storyless photo and create the PhotoAdded event.
+
+    Like the trip-photo confirm, ``comment`` runs through
+    ``process_journal_entry`` so a ``#poi`` line still creates a HabitTracked.
+    """
+
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        key = request.data.get("key")
+        if not isinstance(key, str) or not key.strip():
+            return _bad_request("key is required")
+        content_type = request.data.get("content_type")
+        if not isinstance(content_type, str) or not content_type.strip():
+            return _bad_request("content_type is required")
+        comment = request.data.get("comment")
+        if not isinstance(comment, str):
+            return _bad_request("comment is required")
+        published = _parse_datetime(request.data.get("published"))
+        if published is None:
+            return _bad_request("published is required (full ISO 8601 timestamp)")
+        idempotency_key = request.data.get("idempotency_key")
+        if idempotency_key is not None and not isinstance(idempotency_key, str):
+            return _bad_request("idempotency_key must be a string")
+        try:
+            photo = add_standalone_photo(
+                request.user,
+                key=key,
+                comment=comment,
+                content_type=content_type,
+                published=published,
+                idempotency_key=idempotency_key,
+            )
+        except PhotoObjectMissingError:
+            return _conflict("uploaded photo not found; re-upload and retry")
+        return Response({"ok": True, "photo_id": photo.pk}, status=status.HTTP_200_OK)


### PR DESCRIPTION
## What

Adds an **Add Photo** action to the main-screen (Today) FAB. The single FAB becomes an expanding **speed-dial** revealing two actions plus a tap-to-dismiss scrim:

- **Add Task** — unchanged (opens the board picker for the selected day).
- **Add Photo** — pick an image, optionally add a note, optionally attach a **live** GPS fix, and queue it as a storyless photo — **no Trip/Story attached**.

Previously every photo had to belong to a Trip; this makes the photo pipeline work with an optional story end-to-end.

## Backend (Django)

Rather than duplicate the photo pipeline, `story_id` is made optional throughout and the existing thumbnail/journalling machinery is reused:

- `services/photos/keys.py`: new `photo_key()` → `photos/{user}/{uuid}.{ext}` and `photo_key_belongs_to()`.
- `services/photos/events.py` (new): hoisted the shared `PhotoObjectMissingError`, `daily_thread()`, `existing_event()`, `capture_datetime_from_storage()` out of `trips/operations.py` so the `photos` package no longer imports `trips` (avoids a circular import).
- `services/photos/standalone.py` (new): `presign_standalone_photo()` / `add_standalone_photo()` — same flow as the trip photo minus the story; lands a `PhotoAdded` on the **Daily** thread via `process_journal_entry(story=None)` (so a `#poi` line still creates a `HabitTracked`), enqueues the WebP thumbnail task. No new model, **no migration**.
- `presign_photo_original` is generalized to resolve ownership via `StoryEvent` **or** the `photos/{user}/` key prefix, so a standalone photo's full original still serves.
- New endpoints: `api/v1/android/photo/presign/`, `api/v1/android/photo/`, and `api/v1/android/photo/<id>/original/`.

## Android

- `OutboxItem.storyId` is now nullable; `OutboxDrainer` routes null-story photos through the new storyless endpoints, sharing the resume (presign → S3 PUT → confirm) logic.
- `GpsState`/`GpsSource` and `composeComment` hoisted to the `location` package; capture-time helpers extracted to `ui/photo/PhotoCaptureTime.kt`.
- `AddPhotoDialog` decoupled from `TripDetailViewModel` into a reusable params-based composable, reused by a new `AddPhotoViewModel` that resolves a **live** fix (there's no trip track to resolve against).

## Tests

- **Backend: 240/240 tree tests pass**, including new `test_standalone_photo_service.py` + `test_standalone_photo_api.py` (no StoryEvent, Daily thread, `#poi` habit, idempotency, key-prefix guards, generalized original path, endpoints).
- **Android**: added `OutboxTest` (null-story round-trip), `OutboxDrainerTest` (storyless branch), and `PoiCommentTest`.

> ⚠️ The Android JVM suite (`./gradlew :app:test`) was **not** run in the dev sandbox — it lacks Gradle 9.4.1 (AGP 9.2.1) and the wrapper jar isn't committed. The Android changes were statically audited (imports, signatures, call sites). Please run `./gradlew :app:test` in Android Studio and sanity-check the on-device flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)