### PR TITLE
fix(photos): unstick outbox drains, surface upload state, allow HEIC

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/MainActivity.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/MainActivity.kt
@@ -22,11 +22,14 @@ import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.NavigationDrawerItem
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -34,6 +37,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -89,6 +93,30 @@ private fun MainScaffold(vm: MainViewModel = viewModel()) {
         ActivityResultContracts.PickVisualMedia(),
     ) { uri -> if (uri != null) addPhotoVm.openAddPhoto(uri) }
 
+    // Standalone photos have no screen showing their outbox state, so delivery
+    // results (uploaded / failed / couldn't queue) surface here as snackbars.
+    val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+    LaunchedEffect(addPhotoVm) {
+        addPhotoVm.events.collect { event ->
+            val message = when (event) {
+                is AddPhotoViewModel.UploadEvent.Uploaded ->
+                    context.resources.getQuantityString(
+                        R.plurals.photo_uploaded, event.count, event.count,
+                    )
+                is AddPhotoViewModel.UploadEvent.Failed ->
+                    context.getString(
+                        if (event.willRetry) R.string.photo_upload_failed_retry
+                        else R.string.photo_upload_failed,
+                        event.error,
+                    )
+                is AddPhotoViewModel.UploadEvent.QueueFailed ->
+                    context.getString(R.string.photo_queue_failed, event.error)
+            }
+            snackbarHostState.showSnackbar(message)
+        }
+    }
+
     BackHandler(enabled = tripDetailId != null) {
         tripDetailId = null
     }
@@ -124,6 +152,7 @@ private fun MainScaffold(vm: MainViewModel = viewModel()) {
         },
     ) {
         Scaffold(
+            snackbarHost = { SnackbarHost(snackbarHostState) },
             topBar = {
                 TopAppBar(
                     // The Today screen's top bar carries the product name

--- a/android/app/src/main/java/org/polybrain/tasks/health/data/Outbox.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/Outbox.kt
@@ -78,6 +78,9 @@ class Outbox(private val dir: File) {
 
     fun forStory(storyId: Long): List<OutboxItem> = all().filter { it.storyId == storyId }
 
+    /** Standalone (storyless) items, oldest first. */
+    fun standalone(): List<OutboxItem> = all().filter { it.storyId == null }
+
     /** Persist a mutated item back to its file (same name — id/createdAt are immutable). */
     fun update(item: OutboxItem) = write(item)
 

--- a/android/app/src/main/java/org/polybrain/tasks/health/sync/SyncScheduler.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/sync/SyncScheduler.kt
@@ -1,6 +1,7 @@
 package org.polybrain.tasks.health.sync
 
 import android.content.Context
+import androidx.core.content.ContextCompat
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
@@ -8,6 +9,7 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import java.time.Duration
 import java.util.concurrent.TimeUnit
@@ -77,23 +79,37 @@ object SyncScheduler {
 
     /**
      * Kick the trip-outbox drain. Network-constrained so it waits for
-     * connectivity, with exponential backoff between retries. Enqueued as
-     * APPEND_OR_REPLACE so an item added while a drain is mid-flight still gets
-     * a fresh pass afterwards; the worker is idempotent (re-reads the queue,
-     * server dedupes on the idempotency key), so an extra pass is harmless.
+     * connectivity, with exponential backoff between retries.
+     *
+     * While a drain is actively RUNNING the kick is APPENDed so the mid-flight
+     * pass finishes and a fresh one follows. Otherwise the existing chain is
+     * REPLACEd: after a string of failures the chain sits in exponential
+     * backoff (hours, eventually), and APPEND would park this kick — and every
+     * later one — behind that wait; a user-initiated kick should retry *now*.
+     * Replacing is safe because the worker is idempotent: it re-reads the
+     * queue, a photo's upload resume flags are persisted, and the server
+     * dedupes on the idempotency key. The check-then-enqueue race (a worker
+     * starting in between and getting cancelled) is harmless for the same
+     * reason.
      *
      * Safe to call on app start to resume after a reboot/kill.
      */
     fun drainOutbox(context: Context) {
+        val wm = WorkManager.getInstance(context)
         val request = OneTimeWorkRequestBuilder<OutboxWorker>()
             .setConstraints(networkConstraints)
             .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
             .build()
-        WorkManager.getInstance(context).enqueueUniqueWork(
-            OUTBOX,
-            ExistingWorkPolicy.APPEND_OR_REPLACE,
-            request,
-        )
+        val infos = wm.getWorkInfosForUniqueWork(OUTBOX)
+        infos.addListener({
+            val running = runCatching { infos.get() }
+                .getOrDefault(emptyList())
+                .any { it.state == WorkInfo.State.RUNNING }
+            val policy =
+                if (running) ExistingWorkPolicy.APPEND_OR_REPLACE
+                else ExistingWorkPolicy.REPLACE
+            wm.enqueueUniqueWork(OUTBOX, policy, request)
+        }, ContextCompat.getMainExecutor(context))
     }
 
     fun cancelAll(context: Context) {

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/photo/AddPhotoViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/photo/AddPhotoViewModel.kt
@@ -2,13 +2,20 @@ package org.polybrain.tasks.health.ui.photo
 
 import android.app.Application
 import android.net.Uri
+import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
 import java.io.IOException
 import java.time.OffsetDateTime
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -27,11 +34,30 @@ import org.polybrain.tasks.health.sync.SyncScheduler
  *
  * The photo is enqueued with `storyId = null`; [org.polybrain.tasks.health.sync.OutboxDrainer]
  * then delivers it through the storyless `photo/…` endpoints.
+ *
+ * Unlike a trip photo (whose outbox state shows in the trip timeline), a
+ * standalone photo has no screen of its own, so delivery is reported through
+ * one-shot [events]: the drain worker is watched and each completed pass emits
+ * either [UploadEvent.Uploaded] or [UploadEvent.Failed] for the storyless
+ * items it was responsible for.
  */
 class AddPhotoViewModel(application: Application) : AndroidViewModel(application) {
 
+    /** One-shot delivery notifications, shown as snackbars by the main screen. */
+    sealed class UploadEvent {
+        /** All queued standalone photos were delivered. */
+        data class Uploaded(val count: Int) : UploadEvent()
+
+        /** A drain pass finished with standalone photos still queued. */
+        data class Failed(val error: String, val willRetry: Boolean) : UploadEvent()
+
+        /** The photo never made it into the queue (e.g. unreadable image). */
+        data class QueueFailed(val error: String) : UploadEvent()
+    }
+
     private val locationProvider = LocationProvider(application)
     private val outbox = Outbox(application)
+    private val workManager = WorkManager.getInstance(application)
 
     /** Open/closed state for the add-photo dialog and the picked image. */
     private val _dialogOpen = MutableStateFlow(false)
@@ -43,8 +69,50 @@ class AddPhotoViewModel(application: Application) : AndroidViewModel(application
     private val _gps = MutableStateFlow<GpsState>(GpsState.Idle)
     val gps: StateFlow<GpsState> = _gps.asStateFlow()
 
-    private val _error = MutableStateFlow<String?>(null)
-    val error: StateFlow<String?> = _error.asStateFlow()
+    private val _events = MutableSharedFlow<UploadEvent>(extraBufferCapacity = 8)
+    val events: SharedFlow<UploadEvent> = _events.asSharedFlow()
+
+    /**
+     * Ids of queued standalone photos whose delivery hasn't been reported yet.
+     * Only touched from [viewModelScope] (main thread), so no synchronization.
+     */
+    private var watched: Set<String> = emptySet()
+
+    init {
+        // Watch the drain worker and report what each completed pass did to
+        // the watched standalone photos: gone from the outbox means delivered,
+        // still present means failed (with the recorded error). Trip items are
+        // ignored — their state shows in the trip timeline.
+        viewModelScope.launch {
+            watched = withContext(Dispatchers.IO) {
+                outbox.standalone().map { it.id }.toSet()
+            }
+            var wasRunning = false
+            workManager.getWorkInfosForUniqueWorkFlow(SyncScheduler.OUTBOX).collect { infos ->
+                val running = infos.any { it.state == WorkInfo.State.RUNNING }
+                if (wasRunning && !running) reportDrainResult()
+                wasRunning = running
+            }
+        }
+    }
+
+    private suspend fun reportDrainResult() {
+        val remaining = withContext(Dispatchers.IO) { outbox.standalone() }
+        val remainingIds = remaining.map { it.id }.toSet()
+        val delivered = (watched - remainingIds).size
+        if (remaining.isEmpty()) {
+            if (delivered > 0) _events.emit(UploadEvent.Uploaded(delivered))
+        } else {
+            val failed = remaining.firstOrNull { it.lastError != null } ?: remaining.first()
+            _events.emit(
+                UploadEvent.Failed(
+                    error = failed.lastError ?: "unknown error",
+                    willRetry = remaining.none { it.failedPermanently },
+                )
+            )
+        }
+        watched = remainingIds
+    }
 
     /** Open the dialog for a picked image and start resolving a live GPS fix. */
     fun openAddPhoto(uri: Uri) {
@@ -108,18 +176,24 @@ class AddPhotoViewModel(application: Application) : AndroidViewModel(application
                 val bytes = withContext(Dispatchers.IO) {
                     resolver.openInputStream(uri)?.use { it.readBytes() }
                 } ?: throw IOException("could not read the selected photo")
-                withContext(Dispatchers.IO) {
+                val item = withContext(Dispatchers.IO) {
                     // storyId = null -> delivered through the storyless endpoints.
                     outbox.enqueuePhoto(null, comment, published, contentType, bytes)
                 }
+                watched = watched + item.id
                 SyncScheduler.drainOutbox(getApplication())
+            } catch (e: CancellationException) {
+                throw e
             } catch (t: Throwable) {
-                _error.value = t.message ?: t.javaClass.simpleName
+                Log.w(TAG, "could not queue standalone photo", t)
+                _events.tryEmit(
+                    UploadEvent.QueueFailed(t.message ?: t.javaClass.simpleName)
+                )
             }
         }
     }
 
-    fun clearError() {
-        _error.value = null
+    private companion object {
+        const val TAG = "AddPhotoViewModel"
     }
 }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -81,6 +81,13 @@
     <string name="today_fab_close">Close</string>
     <string name="today_fab_add_task">Add Task</string>
     <string name="today_fab_add_photo">Add Photo</string>
+    <plurals name="photo_uploaded">
+        <item quantity="one">Photo uploaded</item>
+        <item quantity="other">%d photos uploaded</item>
+    </plurals>
+    <string name="photo_upload_failed">Photo upload failed: %1$s</string>
+    <string name="photo_upload_failed_retry">Photo upload failed: %1$s — will retry</string>
+    <string name="photo_queue_failed">Could not save photo: %1$s</string>
     <string name="board_picker_add_button">Add %1$d</string>
     <string name="board_picker_cancel">Cancel</string>
     <string name="board_picker_empty">This board has no items.</string>

--- a/android/app/src/test/java/org/polybrain/tasks/health/data/OutboxTest.kt
+++ b/android/app/src/test/java/org/polybrain/tasks/health/data/OutboxTest.kt
@@ -79,6 +79,14 @@ class OutboxTest {
     }
 
     @Test
+    fun `standalone returns only storyless items`() {
+        outbox.enqueueNote(1L, "trip note", "t")
+        outbox.enqueuePhoto(1L, "trip photo", "t", "image/jpeg", byteArrayOf(1))
+        val solo = outbox.enqueuePhoto(null, "standalone", "t", "image/jpeg", byteArrayOf(2))
+        assertEquals(listOf(solo.id), outbox.standalone().map { it.id })
+    }
+
+    @Test
     fun `update rewrites the same file in place`() {
         val item = outbox.enqueueNote(1L, "x", "t")
         outbox.update(item.copy(attempts = 3, lastError = "boom"))

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,3 +15,4 @@ django-htmx==1.19.0
 django-rest-polymorphic==0.1.9
 boto3>=1.34
 Pillow>=10
+pillow-heif>=0.16

--- a/tasks/apps/tree/services/photos/keys.py
+++ b/tasks/apps/tree/services/photos/keys.py
@@ -3,10 +3,14 @@
 import uuid
 
 # Allowed upload content types -> file extension for the original object.
+# HEIC/HEIF is what real phones produce by default; thumbnailing decodes it
+# via the pillow-heif opener registered in tasks.py.
 CONTENT_TYPE_EXT = {
     "image/jpeg": "jpg",
     "image/png": "png",
     "image/webp": "webp",
+    "image/heic": "heic",
+    "image/heif": "heif",
 }
 
 

--- a/tasks/apps/tree/tasks.py
+++ b/tasks/apps/tree/tasks.py
@@ -4,6 +4,10 @@ from django.conf import settings
 
 from celery import shared_task
 from PIL import Image, ImageOps
+from pillow_heif import register_heif_opener
+
+# Teach Pillow to decode the HEIC/HEIF originals phones upload by default.
+register_heif_opener()
 
 
 @shared_task(bind=True, max_retries=3, default_retry_delay=10)

--- a/tasks/apps/tree/tests/test_standalone_photo_service.py
+++ b/tasks/apps/tree/tests/test_standalone_photo_service.py
@@ -30,6 +30,10 @@ class PhotoKeyTestCase(TestCase):
         with self.assertRaises(ValueError):
             photo_key(7, "image/gif")
 
+    def test_photo_key_accepts_heic(self):
+        self.assertTrue(photo_key(7, "image/heic").endswith(".heic"))
+        self.assertTrue(photo_key(7, "image/heif").endswith(".heif"))
+
     def test_photo_key_belongs_to_accepts_own_prefix(self):
         self.assertTrue(photo_key_belongs_to("photos/7/abc.jpg", 7))
 


### PR DESCRIPTION
## Why

Follow-up to #255. The first standalone photo sent from a real phone silently vanished: the S3 user policy only allowed `trips/*`, so every presigned PUT to the new `photos/{user}/…` prefix got 403. After 10 retries the outbox drain chain was hours deep in exponential backoff — and `APPEND_OR_REPLACE` parked every new kick (new photos, app-start drains) behind that wait — while the UI showed nothing: the error StateFlow was never collected and storyless items appear in no pending list.

The policy itself is fixed in AWS (resource extended to `photos/*`); this PR fixes everything that made the failure invisible and unrecoverable, plus the next phone-only failure waiting to happen (HEIC).

## What

**Drain recovery (Android)** — `SyncScheduler.drainOutbox` REPLACEs the unique chain unless a drain is actively RUNNING, so a user-initiated kick retries immediately instead of waiting out accumulated backoff. Safe: the worker re-reads the queue, photo upload resume flags are persisted, and the server dedupes on the idempotency key.

**Upload state surfacing (Android)** — `AddPhotoViewModel` watches the drain worker and emits one-shot events for storyless photos after each completed pass: uploaded (count), failed (with the recorded `lastError`, noting whether it will retry), or could-not-queue. `MainActivity` shows them as snackbars. Queue failures are now also logged, and `CancellationException` is rethrown instead of swallowed. Adds `Outbox.standalone()`.

**HEIC (backend)** — `CONTENT_TYPE_EXT` accepts `image/heic`/`image/heif` (the Android side already sends them; real phones shoot HEIC by default). `pillow-heif` added and its opener registered so the thumbnail task can decode HEIC originals to WebP.

## Testing

- `tasks.apps.tree` suite: 242 tests pass (includes new heic key test).
- HEIC→WebP thumbnail pipeline smoke-tested in the dev container.
- Android unit test added for `Outbox.standalone()`; **Kotlin not compiled here** (no Gradle wrapper in repo) — please build/run tests in Android Studio.

## Deploy notes

- `pip install -r requirements/base.txt` (new: `pillow-heif`) for both web and celery.
- The stuck phone photo should deliver on the next app open once the IAM policy change is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)