### PR TITLE
feat(android): record body weight from the Health screen

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/data/TasksApi.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/TasksApi.kt
@@ -37,6 +37,15 @@ data class OkResponse(
     @SerialName("ok") val ok: Boolean = false,
 )
 
+// Server-derived health data for the Health screen. Currently just the most
+// recently recorded body weight and when it was recorded; both null when
+// nothing has been recorded yet.
+@Serializable
+data class HealthDataResponse(
+    @SerialName("weight_kg") val weightKg: Double? = null,
+    @SerialName("recorded_at") val recordedAt: String? = null,
+)
+
 @Serializable
 data class TaskTextRequest(
     @SerialName("text") val text: String,
@@ -264,6 +273,10 @@ interface TasksApi {
     // collapse multiple events into one.
     @POST("habit/track/")
     suspend fun trackHabitText(@Body body: TrackHabitTextRequest): OkResponse
+
+    // Server-derived health data (currently the last recorded body weight).
+    @GET("api/v1/android/health/data/")
+    suspend fun healthData(): HealthDataResponse
 
     @GET("api/v1/android/task/today/")
     suspend fun listTodayTasks(@Query("date") date: String): TodayTasksResponse

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/HealthScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/HealthScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -32,11 +33,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.PermissionController
 import org.polybrain.tasks.health.R
 import java.time.Instant
+import java.time.OffsetDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.launch
@@ -46,6 +49,7 @@ fun HealthScreen(vm: MainViewModel) {
     val state by vm.settingsState.collectAsState()
     val permissionsGranted by vm.permissionsGranted.collectAsState()
     val todayMetrics by vm.todayMetrics.collectAsState()
+    val healthData by vm.healthData.collectAsState()
     val activityDialogOpen by vm.activityDialogOpen.collectAsState()
     val scope = rememberCoroutineScope()
 
@@ -98,6 +102,19 @@ fun HealthScreen(vm: MainViewModel) {
                 },
             )
 
+            // Last recorded weight comes from the server (independent of Health
+            // Connect permissions), so it shows regardless of the grant state.
+            HorizontalDivider()
+            val weightKg = healthData?.weightKg
+            if (weightKg != null) {
+                Text(
+                    stringResource(R.string.metric_weight_format)
+                        .format(weightKg, formatWeightDate(healthData?.recordedAt))
+                )
+            } else {
+                Text(stringResource(R.string.metric_weight_none))
+            }
+
             if (permissionsGranted) {
                 HorizontalDivider()
                 Text(
@@ -144,6 +161,11 @@ private fun TrackActivityDialog(vm: MainViewModel) {
 
     var selectedType by remember { mutableStateOf(ActivityType.Gym) }
     var note by remember { mutableStateOf("") }
+    var weightText by remember { mutableStateOf("") }
+
+    val isWeight = selectedType == ActivityType.Weight
+    val weightKg = weightText.trim().toDoubleOrNull()
+    val canConfirm = if (isWeight) weightKg != null && weightKg > 0 else true
 
     AlertDialog(
         onDismissRequest = { vm.closeActivityDialog() },
@@ -159,14 +181,25 @@ private fun TrackActivityDialog(vm: MainViewModel) {
                         )
                     }
                 }
-                OutlinedTextField(
-                    value = note,
-                    onValueChange = { note = it },
-                    placeholder = { Text(stringResource(R.string.activity_note_hint)) },
-                    singleLine = false,
-                    minLines = 3,
-                    modifier = Modifier.fillMaxWidth(),
-                )
+                if (isWeight) {
+                    OutlinedTextField(
+                        value = weightText,
+                        onValueChange = { weightText = it },
+                        placeholder = { Text(stringResource(R.string.weight_kg_hint)) },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                } else {
+                    OutlinedTextField(
+                        value = note,
+                        onValueChange = { note = it },
+                        placeholder = { Text(stringResource(R.string.activity_note_hint)) },
+                        singleLine = false,
+                        minLines = 3,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
                 error?.let {
                     Text(
                         text = it,
@@ -178,8 +211,14 @@ private fun TrackActivityDialog(vm: MainViewModel) {
         },
         confirmButton = {
             TextButton(
-                onClick = { vm.trackActivity(selectedType, note) },
-                enabled = !saving,
+                onClick = {
+                    if (isWeight) {
+                        weightKg?.let { vm.trackWeight(it) }
+                    } else {
+                        vm.trackActivity(selectedType, note)
+                    }
+                },
+                enabled = !saving && canConfirm,
             ) {
                 Text(stringResource(R.string.activity_send))
             }
@@ -198,7 +237,20 @@ private fun TrackActivityDialog(vm: MainViewModel) {
 private val displayFormatter: DateTimeFormatter =
     DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
 
+private val dateFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy-MM-dd")
+
 private fun formatInstant(epochMs: Long): String =
     Instant.ofEpochMilli(epochMs)
         .atZone(ZoneId.systemDefault())
         .format(displayFormatter)
+
+/** Formats the server's ISO 8601 `recorded_at` as a local date, or "" if absent/unparseable. */
+private fun formatWeightDate(iso: String?): String {
+    if (iso == null) return ""
+    return runCatching {
+        OffsetDateTime.parse(iso)
+            .atZoneSameInstant(ZoneId.systemDefault())
+            .format(dateFormatter)
+    }.getOrDefault("")
+}

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/MainViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/MainViewModel.kt
@@ -5,6 +5,7 @@ import androidx.health.connect.client.HealthConnectClient
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import org.polybrain.tasks.health.data.DailyMetrics
+import org.polybrain.tasks.health.data.HealthDataResponse
 import org.polybrain.tasks.health.data.HealthRepository
 import org.polybrain.tasks.health.data.Settings
 import org.polybrain.tasks.health.data.SettingsSnapshot
@@ -15,6 +16,7 @@ import org.polybrain.tasks.health.sync.SyncScheduler
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneId
+import java.util.Locale
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -26,10 +28,14 @@ import kotlinx.coroutines.launch
  * The activities the FAB on the Health screen can register, each mapped to the
  * hashtag the backend parses into a [HabitTracked]. [Gym] is the default
  * subtype. The keyword is sent verbatim (Unicode is fine) prefixed with '#'.
+ *
+ * [Weight] is special: instead of a free-text note it carries a numeric
+ * kilogram value, posted as `#weight weight=<x.x>kg` (see [MainViewModel.trackWeight]).
  */
 enum class ActivityType(val keyword: String) {
     Gym("siłka"),
     Workout("workout"),
+    Weight("weight"),
 }
 
 class MainViewModel(application: Application) : AndroidViewModel(application) {
@@ -48,6 +54,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     private val _todayMetrics = MutableStateFlow<DailyMetrics?>(null)
     val todayMetrics: StateFlow<DailyMetrics?> = _todayMetrics.asStateFlow()
+
+    /** Server-derived health data (last recorded weight); null until loaded. */
+    private val _healthData = MutableStateFlow<HealthDataResponse?>(null)
+    val healthData: StateFlow<HealthDataResponse?> = _healthData.asStateFlow()
 
     /** Open/closed state for the "register activity" dialog opened from the FAB. */
     private val _activityDialogOpen = MutableStateFlow(false)
@@ -74,6 +84,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             TripTracker.resumeIfNeeded(getApplication())
             refreshPermissionState()
             if (_permissionsGranted.value) refreshMetrics()
+            refreshHealthData()
         }
     }
 
@@ -95,6 +106,19 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         _todayMetrics.value = runCatching { health.aggregateDay(today) }.getOrNull()
     }
 
+    fun refreshHealthDataAsync() {
+        viewModelScope.launch { refreshHealthData() }
+    }
+
+    private suspend fun refreshHealthData() {
+        val snapshot = settings.snapshot()
+        if (!snapshot.isConfigured) return
+        val data = runCatching {
+            TasksClient.build(snapshot.serverUrl, snapshot.apiToken).healthData()
+        }.getOrNull()
+        if (data != null) _healthData.value = data
+    }
+
     fun save(serverUrl: String, apiToken: String) {
         viewModelScope.launch {
             settings.saveServerConfig(serverUrl, apiToken)
@@ -105,6 +129,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     fun syncNow() {
         SyncScheduler.runOnce(getApplication())
         refreshMetricsAsync()
+        refreshHealthDataAsync()
     }
 
     fun openActivityDialog() {
@@ -124,9 +149,30 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
      * Multiple posts on the same day are intentional (e.g. two gym visits).
      */
     fun trackActivity(type: ActivityType, note: String) {
-        if (_activitySaving.value) return
         val trimmed = note.trim()
         val text = if (trimmed.isEmpty()) "#${type.keyword}" else "#${type.keyword} $trimmed"
+        postHabitLine(text)
+    }
+
+    /**
+     * Records body weight as `#weight weight=<x.x>kg` through the same
+     * non-idempotent text endpoint. Weight uses its own habit (separate from
+     * the sync's `health-metrics`), so each entry is preserved. Refreshes the
+     * last-weight display on success.
+     */
+    fun trackWeight(kg: Double) {
+        val text = "#${ActivityType.Weight.keyword} weight=${"%.1f".format(Locale.US, kg)}kg"
+        postHabitLine(text) { refreshHealthDataAsync() }
+    }
+
+    /**
+     * Shared post path for the activity dialog: sends a habit line, gating the
+     * dialog buttons via [activitySaving] and surfacing failures in
+     * [activityError]. Closes the dialog and runs [onSuccess] when the post
+     * succeeds.
+     */
+    private fun postHabitLine(text: String, onSuccess: () -> Unit = {}) {
+        if (_activitySaving.value) return
         // Wall-clock moment of the tap, so the entry lands on today.
         val published = OffsetDateTime.now().toString()
         _activitySaving.value = true
@@ -142,6 +188,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 val api = TasksClient.build(snapshot.serverUrl, snapshot.apiToken)
                 api.trackHabitText(TrackHabitTextRequest(text = text, published = published))
                 _activityDialogOpen.value = false
+                onSuccess()
             } catch (t: Throwable) {
                 _activityError.value = t.message ?: t.javaClass.simpleName
             } finally {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -127,6 +127,7 @@
     <string name="activity_note_hint">Add a note (optional)</string>
     <string name="activity_send">Track</string>
     <string name="activity_cancel">Cancel</string>
+    <string name="weight_kg_hint">Weight (kg)</string>
 
     <string name="today_metrics_heading">Today</string>
     <string name="metric_steps_format">Steps: %1$d</string>
@@ -134,4 +135,6 @@
     <string name="metric_active_format">Active: %1$d min</string>
     <string name="metric_kcal_format">Calories: %1$.0f kcal</string>
     <string name="metric_loading">Reading from Health Connect…</string>
+    <string name="metric_weight_format">Last weight: %1$.1f kg (%2$s)</string>
+    <string name="metric_weight_none">No weight recorded yet</string>
 </resources>

--- a/android/app/src/test/java/org/polybrain/tasks/health/sync/OutboxDrainerTest.kt
+++ b/android/app/src/test/java/org/polybrain/tasks/health/sync/OutboxDrainerTest.kt
@@ -12,6 +12,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.polybrain.tasks.health.data.BoardItemsResponse
+import org.polybrain.tasks.health.data.HealthDataResponse
 import org.polybrain.tasks.health.data.Outbox
 import org.polybrain.tasks.health.data.OkResponse
 import org.polybrain.tasks.health.data.PhotoConfirmRequest
@@ -217,6 +218,7 @@ class OutboxDrainerTest {
         // --- unused endpoints ---
         override suspend fun trackHabit(body: TrackHabitRequest): TrackHabitResponse = nope()
         override suspend fun trackHabitText(body: TrackHabitTextRequest): OkResponse = nope()
+        override suspend fun healthData(): HealthDataResponse = nope()
         override suspend fun listTodayTasks(date: String): TodayTasksResponse = nope()
         override suspend fun listBoardItems(): BoardItemsResponse = nope()
         override suspend fun addTodayTask(body: TaskTextRequest): OkResponse = nope()

--- a/tasks/apps/tree/migrations/0074_weight_habit.py
+++ b/tasks/apps/tree/migrations/0074_weight_habit.py
@@ -1,0 +1,46 @@
+from django.db import migrations
+
+
+WEIGHT_SLUG = "weight"
+WEIGHT_NAME = "Weight"
+WEIGHT_DESCRIPTION = (
+    "Body weight recorded from the Health screen. "
+    "Tracked via the #weight hashtag; the note carries weight=<float>kg."
+)
+WEIGHT_KEYWORDS = ("weight",)
+
+
+def create_weight_habit(apps, schema_editor):
+    Habit = apps.get_model("tree", "Habit")
+    HabitKeyword = apps.get_model("tree", "HabitKeyword")
+    db_alias = schema_editor.connection.alias
+
+    habit, _ = Habit.objects.using(db_alias).get_or_create(
+        slug=WEIGHT_SLUG,
+        defaults={"name": WEIGHT_NAME, "description": WEIGHT_DESCRIPTION},
+    )
+
+    for keyword in WEIGHT_KEYWORDS:
+        HabitKeyword.objects.using(db_alias).get_or_create(
+            keyword=keyword, defaults={"habit": habit}
+        )
+
+
+def remove_weight_habit(apps, schema_editor):
+    Habit = apps.get_model("tree", "Habit")
+    HabitKeyword = apps.get_model("tree", "HabitKeyword")
+    db_alias = schema_editor.connection.alias
+
+    HabitKeyword.objects.using(db_alias).filter(keyword__in=WEIGHT_KEYWORDS).delete()
+    Habit.objects.using(db_alias).filter(slug=WEIGHT_SLUG).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("tree", "0073_sharedstory"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_weight_habit, remove_weight_habit),
+    ]

--- a/tasks/apps/tree/services/health/__init__.py
+++ b/tasks/apps/tree/services/health/__init__.py
@@ -1,0 +1,55 @@
+"""
+Health data helpers for the Android Health screen.
+
+Body weight is recorded as a HabitTracked under a dedicated ``weight`` Habit
+(see migration 0074). It is intentionally a separate Habit from
+``health-metrics`` so the hourly background sync — which upserts on
+(habit, date) — never clobbers a manually recorded weight.
+"""
+
+import datetime
+import re
+from dataclasses import dataclass
+
+from ...models import HabitTracked
+
+WEIGHT_SLUG = "weight"
+
+# Matches the ``weight=<float>kg`` token the Android client writes (whitespace
+# before ``kg`` is tolerated). The number is captured for parsing.
+_WEIGHT_RE = re.compile(r"weight=([0-9]+(?:\.[0-9]+)?)\s*kg")
+
+
+@dataclass
+class WeightRecord:
+    value_kg: float
+    recorded_at: datetime.datetime
+
+
+def parse_weight_kg(note):
+    """Extract the kilogram value from a habit note, or None if absent."""
+    if not note:
+        return None
+    match = _WEIGHT_RE.search(note)
+    if match is None:
+        return None
+    return float(match.group(1))
+
+
+def latest_weight():
+    """Return the most recently recorded weight, or None if none exists.
+
+    Walks weight events newest-first and returns the first whose note carries
+    a parseable ``weight=<float>kg`` token. Global (not user-scoped), matching
+    the rest of the habit-tracking endpoints.
+    """
+    events = HabitTracked.objects.filter(
+        habit__slug=WEIGHT_SLUG, occured=True
+    ).order_by("-published")
+
+    for event in events:
+        value = parse_weight_kg(event.note)
+        if value is not None:
+            return WeightRecord(value_kg=value, recorded_at=event.published)
+
+    return None

--- a/tasks/apps/tree/tests/test_health_data_api.py
+++ b/tasks/apps/tree/tests/test_health_data_api.py
@@ -1,0 +1,127 @@
+import datetime
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APITestCase
+
+from ..models import Habit, HabitTracked, Thread
+from ..services.health import parse_weight_kg
+
+
+class ParseWeightKgTestCase(APITestCase):
+    def test_parses_decimal_value(self):
+        self.assertEqual(parse_weight_kg("weight=82.5kg"), 82.5)
+
+    def test_parses_integer_value(self):
+        self.assertEqual(parse_weight_kg("#weight weight=80kg"), 80.0)
+
+    def test_tolerates_space_before_unit(self):
+        self.assertEqual(parse_weight_kg("weight=75.0 kg"), 75.0)
+
+    def test_returns_none_when_absent(self):
+        self.assertIsNone(parse_weight_kg("steps=8500 distance=6.2km"))
+
+    def test_returns_none_for_empty(self):
+        self.assertIsNone(parse_weight_kg(""))
+        self.assertIsNone(parse_weight_kg(None))
+
+
+class AndroidHealthDataAPITestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        User = get_user_model()
+        cls.user = User.objects.create_user(username="phone", password="x")
+        cls.token = Token.objects.create(user=cls.user)
+        cls.daily_thread = Thread.objects.create(name="Daily")
+        # Created by migration 0074_weight_habit; fetching it also asserts the
+        # migration ran.
+        cls.weight_habit = Habit.objects.get(slug="weight")
+        cls.url = reverse("android-health-data")
+
+    def _auth(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+
+    def _record_weight(self, note, *, days_ago=0):
+        published = timezone.now() - datetime.timedelta(days=days_ago)
+        return HabitTracked.objects.create(
+            habit=self.weight_habit,
+            occured=True,
+            note=note,
+            thread=self.daily_thread,
+            published=published,
+        )
+
+    def test_returns_nulls_when_no_weight_recorded(self):
+        self._auth()
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"weight_kg": None, "recorded_at": None})
+
+    def test_returns_latest_weight_and_date(self):
+        event = self._record_weight("#weight weight=82.5kg")
+        self._auth()
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["weight_kg"], 82.5)
+        self.assertEqual(body["recorded_at"], event.published.isoformat())
+
+    def test_picks_most_recent_by_published(self):
+        self._record_weight("#weight weight=80.0kg", days_ago=3)
+        self._record_weight("#weight weight=81.0kg", days_ago=1)
+        latest = self._record_weight("#weight weight=82.5kg", days_ago=0)
+        self._auth()
+        response = self.client.get(self.url)
+        self.assertEqual(response.json()["weight_kg"], 82.5)
+        self.assertEqual(response.json()["recorded_at"], latest.published.isoformat())
+
+    def test_ignores_records_under_other_habits(self):
+        other = Habit.objects.create(name="Health metrics", slug="health-metrics")
+        HabitTracked.objects.create(
+            habit=other,
+            occured=True,
+            note="weight=99.9kg",  # not the weight habit; must be ignored
+            thread=self.daily_thread,
+            published=timezone.now(),
+        )
+        self._auth()
+        response = self.client.get(self.url)
+        self.assertEqual(response.json(), {"weight_kg": None, "recorded_at": None})
+
+    def test_skips_weight_records_without_parseable_note(self):
+        # A newer weight event with no parseable value must fall through to the
+        # most recent one that does.
+        self._record_weight("#weight weight=70.0kg", days_ago=1)
+        self._record_weight("#weight forgot the number", days_ago=0)
+        self._auth()
+        response = self.client.get(self.url)
+        self.assertEqual(response.json()["weight_kg"], 70.0)
+
+    def test_requires_authentication(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_track_habit_text_then_read_back(self):
+        # End-to-end over the real endpoints the Android client uses: post a
+        # weight line through the non-idempotent text endpoint, then read it
+        # back via the health-data endpoint.
+        self._auth()
+        post = self.client.post(
+            reverse("public-habit-track"),
+            {
+                "text": "#weight weight=82.5kg",
+                "published": timezone.now().isoformat(),
+            },
+            format="json",
+        )
+        self.assertEqual(post.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            HabitTracked.objects.filter(habit=self.weight_habit).count(), 1
+        )
+
+        response = self.client.get(self.url)
+        self.assertEqual(response.json()["weight_kg"], 82.5)

--- a/tasks/apps/tree/urls.py
+++ b/tasks/apps/tree/urls.py
@@ -97,6 +97,11 @@ urlpatterns = [
         name="android-board-items",
     ),
     path(
+        "api/v1/android/health/data/",
+        views_android_api.AndroidHealthDataView.as_view(),
+        name="android-health-data",
+    ),
+    path(
         "api/v1/android/trip/start/",
         views_android_trip.AndroidTripStartView.as_view(),
         name="android-trip-start",

--- a/tasks/apps/tree/views_android_api.py
+++ b/tasks/apps/tree/views_android_api.py
@@ -11,6 +11,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from .services.health import latest_weight
 from .services.today import (
     NoBoardError,
     add_task,
@@ -215,6 +216,34 @@ class AndroidTaskCompleteView(APIView):
                 status=status.HTTP_409_CONFLICT,
             )
         return Response({"ok": True}, status=status.HTTP_200_OK)
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class AndroidHealthDataView(APIView):
+    """Return server-side health data for the Health screen.
+
+    Currently just the most recently recorded body weight and when it was
+    recorded; both null when nothing has been recorded yet. Named generically
+    so other server-derived metrics can be added here later.
+    """
+
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        record = latest_weight()
+        if record is None:
+            return Response(
+                {"weight_kg": None, "recorded_at": None},
+                status=status.HTTP_200_OK,
+            )
+        return Response(
+            {
+                "weight_kg": record.value_kg,
+                "recorded_at": record.recorded_at.isoformat(),
+            },
+            status=status.HTTP_200_OK,
+        )
 
 
 @method_decorator(csrf_exempt, name="dispatch")


### PR DESCRIPTION
## Summary

Adds the ability to record **body weight** from the Android Health screen and shows the last recorded weight + date.

- Tapping the Health FAB now offers a **`#weight`** chip alongside `#siłka`/`#workout`. Selecting it swaps the note field for a numeric **kg** input and posts `#weight weight=<x.x>kg` through the non-idempotent text endpoint (`POST /habit/track/`), the same path bike rides use.
- The screen shows **"Last weight: 82.5 kg (date)"**, fetched from a new `GET /api/v1/android/health/data/` endpoint (server data, shown regardless of Health Connect permissions).

## Why a separate `#weight` habit (not `#health-metrics`)

The original idea was to record weight as `#health-metrics weight=xx.xkg`. But `#health-metrics` is owned by the hourly background sync (`HealthSyncWorker`), whose idempotent endpoint **upserts on `(habit, date)`** — and that dedup key is the **Habit row**, not the keyword. A weight stored under that habit (even via a different keyword) would be clobbered by the next sync. So weight gets its **own dedicated Habit** (`slug="weight"`, migration `0074`), which is the only design that survives the next sync intact.

## Changes

**Backend (`tasks/apps/tree`)**
- `migrations/0074_weight_habit.py` — creates `Habit(slug="weight")` + `HabitKeyword("weight")` (modeled on `0068_poi_habit.py`). No post-path code needed: the text endpoint's form matches against all habits.
- `services/health/__init__.py` — `parse_weight_kg()` + `latest_weight()`.
- `views_android_api.py` / `urls.py` — new `AndroidHealthDataView` → `{"weight_kg", "recorded_at"}` (nulls when none).
- `tests/test_health_data_api.py` — parsing, latest-by-date, ignores other habits, skips unparseable notes, auth, end-to-end through `/habit/track/`.

**Android (`android/.../health`)**
- `TasksApi.kt` — `HealthDataResponse` DTO + `healthData()`.
- `MainViewModel.kt` — `Weight` added to `ActivityType`; `healthData` flow refreshed on init/sync/after-save; `trackWeight(kg)` posting `weight=%.1fkg` (Locale.US); shared `postHabitLine` helper extracted so `trackActivity`/`trackWeight` don't duplicate the post boilerplate.
- `HealthScreen.kt` — last-weight display; dialog branches to a decimal kg field for Weight, confirm gated on a valid positive number.
- `strings.xml` — `weight_kg_hint`, `metric_weight_format`, `metric_weight_none`.
- `OutboxDrainerTest.kt` — `FakeApi` stubs `healthData()`.

## Test plan

- Backend: 12 new tests pass; existing `test_habit_api` (8) pass; `makemigrations --check` clean; migration applied to dev.
- Android: `:app:compileDebugKotlin` + `:app:testDebugUnitTest` → **BUILD SUCCESSFUL**.
- Live dev server: full authenticated round-trip confirmed (`null` → post → `82.5 kg` + timestamp).
- ⚠️ Not exercised: the Android UI tap-through (no emulator/device available) — verified only via compile + unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)