### PR TITLE
fix(cli): accept PhotoAdded events and null reflection fields

### DIFF
--- a/cli/src/tasks_collector_tools/models.py
+++ b/cli/src/tasks_collector_tools/models.py
@@ -38,6 +38,10 @@ class JournalAdded(BaseEvent):
     tags: List[str]
 
 
+class PhotoAdded(JournalAdded):
+    resourcetype: Literal['PhotoAdded']
+
+
 class HabitTracked(BaseEvent):
     resourcetype: Literal['HabitTracked']
     note: str
@@ -190,8 +194,8 @@ class Plan(BaseModel):
 class Reflection(BaseModel):
     id: int
     good: str
-    better: str
-    best: str
+    better: Optional[str]
+    best: Optional[str]
     pub_date: date
 
     def empty(self):
@@ -208,8 +212,9 @@ class Reflection(BaseModel):
 
 
 Event = Union[
-    JournalAdded, 
-    HabitTracked, 
+    PhotoAdded,
+    JournalAdded,
+    HabitTracked,
     ObservationMade, 
     ObservationUpdated, 
     ObservationRecontextualized, 


### PR DESCRIPTION
## Summary
- Add `PhotoAdded` pydantic model (subclass of `JournalAdded` with its own `resourcetype` literal) so `reflectiondump` parses daily feeds that include the new event introduced by the trips/photos backend work.
- Relax `Reflection.better` and `Reflection.best` to `Optional[str]` — the API now returns `null` for these when unset. `good` stays required since the API isn't returning `null` for it.
- Place `PhotoAdded` before `JournalAdded` in the `Event` union so the more-specific literal is tried first. The existing `match case JournalAdded()` presenter dispatch already covers `PhotoAdded` via subclass, matching the web feed's "render as journal entry" behavior.

## Test plan
- [x] `Result.model_validate(...)` succeeds for a payload containing a `PhotoAdded` event and is dispatched to `JournalAddedPresenter`.
- [x] `Reflection` parses cleanly with `better=None`/`best=None`; `has_better()`, `has_best()`, and `ReflectionPresenter.better_list/best_list` return falsy/empty without raising.
- [ ] Run `reflectiondump` against a real day containing a `PhotoAdded` event and a reflection with empty better/best to confirm end-to-end output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)