### PR TITLE
feat(android): track an arbitrary habit from the Today screen

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/data/TasksApi.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/TasksApi.kt
@@ -37,6 +37,23 @@ data class OkResponse(
     @SerialName("ok") val ok: Boolean = false,
 )
 
+// One option in the "track a habit" picker. Mirrors the `habit/keywords/mine/`
+// payload — a HabitKeyword row with its parent Habit nested. The lenient JSON
+// config ignores the extra habit fields the server also sends (slug,
+// description, today_tracked).
+@Serializable
+data class HabitKeyword(
+    @SerialName("id") val id: Long,
+    @SerialName("keyword") val keyword: String,
+    @SerialName("habit") val habit: HabitRef? = null,
+)
+
+@Serializable
+data class HabitRef(
+    @SerialName("id") val id: Long = 0,
+    @SerialName("name") val name: String = "",
+)
+
 // Server-derived health data for the Health screen. Currently just the most
 // recently recorded body weight and when it was recorded; both null when
 // nothing has been recorded yet.
@@ -273,6 +290,13 @@ interface TasksApi {
     // collapse multiple events into one.
     @POST("habit/track/")
     suspend fun trackHabitText(@Body body: TrackHabitTextRequest): OkResponse
+
+    // The current user's available habit keywords for the "track a habit"
+    // picker. Scoped to the profile's selection (the server falls back to all
+    // keywords when none are chosen) and, because it filters by `date`,
+    // excludes habits already tracked that day. Returns a bare JSON array.
+    @GET("habit/keywords/mine/")
+    suspend fun listHabitKeywords(@Query("date") date: String): List<HabitKeyword>
 
     // Server-derived health data (currently the last recorded body weight).
     @GET("api/v1/android/health/data/")

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayScreen.kt
@@ -30,11 +30,14 @@ import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Surface
@@ -60,6 +63,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import org.polybrain.tasks.health.R
+import org.polybrain.tasks.health.data.HabitKeyword
 import org.polybrain.tasks.health.data.TodayTask
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -159,8 +163,26 @@ fun TodayScreen(
                 onExpandedChange = { fabExpanded = it },
                 onAddTask = { onAddFromBoard(selectedDate) },
                 onAddPhoto = onAddPhoto,
+                onTrackHabit = vm::openHabitDialog,
             )
         }
+    }
+
+    val habitDialogOpen by vm.habitDialogOpen.collectAsState()
+    if (habitDialogOpen) {
+        val keywords by vm.habitKeywords.collectAsState()
+        val keywordsLoading by vm.habitKeywordsLoading.collectAsState()
+        val habitSaving by vm.habitSaving.collectAsState()
+        val habitError by vm.habitError.collectAsState()
+        TrackHabitDialog(
+            keywords = keywords,
+            loading = keywordsLoading,
+            saving = habitSaving,
+            error = habitError,
+            onConfirm = vm::trackHabit,
+            onRetry = { vm.loadHabitKeywords(force = true) },
+            onDismiss = vm::closeHabitDialog,
+        )
     }
 
     pendingComplete?.let { pending ->
@@ -277,6 +299,141 @@ private fun CompletedTaskDialog(
             }
         },
     )
+}
+
+/**
+ * Track an arbitrary habit for the selected day: search the user's available
+ * keywords (fetched and cached by the ViewModel) in an autocomplete field and
+ * optionally attach a note. The Track button stays disabled until the field
+ * text exactly names an available keyword. When the keyword list is empty
+ * after loading (no habits, or a load error), the confirm slot offers Retry.
+ */
+@Composable
+private fun TrackHabitDialog(
+    keywords: List<HabitKeyword>,
+    loading: Boolean,
+    saving: Boolean,
+    error: String?,
+    onConfirm: (keyword: String, note: String) -> Unit,
+    onRetry: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var query by remember { mutableStateOf("") }
+    var note by remember { mutableStateOf("") }
+    // The chosen keyword is the field text once it exactly names an available
+    // keyword — set either by typing it in full or by picking from the dropdown.
+    val selected = remember(keywords, query) {
+        keywords.firstOrNull { it.keyword.equals(query.trim(), ignoreCase = true) }?.keyword
+    }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.today_habit_dialog_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                when {
+                    loading && keywords.isEmpty() ->
+                        Text(stringResource(R.string.today_habit_loading))
+                    keywords.isEmpty() ->
+                        Text(stringResource(R.string.today_habit_empty))
+                    else -> HabitKeywordPicker(
+                        keywords = keywords,
+                        query = query,
+                        onQueryChange = { query = it },
+                    )
+                }
+                if (keywords.isNotEmpty()) {
+                    OutlinedTextField(
+                        value = note,
+                        onValueChange = { note = it },
+                        placeholder = { Text(stringResource(R.string.today_habit_note_hint)) },
+                        singleLine = false,
+                        minLines = 2,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+                error?.let {
+                    Text(
+                        text = it,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            // Nothing to track until the list loads; offer Retry in its place.
+            if (keywords.isEmpty() && !loading) {
+                TextButton(onClick = onRetry) {
+                    Text(stringResource(R.string.today_habit_retry))
+                }
+            } else {
+                TextButton(
+                    onClick = { selected?.let { onConfirm(it, note) } },
+                    enabled = !saving && selected != null,
+                ) {
+                    Text(stringResource(R.string.today_habit_track))
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss, enabled = !saving) {
+                Text(stringResource(R.string.today_habit_cancel))
+            }
+        },
+    )
+}
+
+/**
+ * Autocomplete keyword field: an editable text field anchoring a dropdown that
+ * narrows to the keywords containing the typed text (case-insensitive; all of
+ * them when the field is empty). Picking an item fills the field with that
+ * keyword. Scrolls, so it copes with long keyword lists.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun HabitKeywordPicker(
+    keywords: List<HabitKeyword>,
+    query: String,
+    onQueryChange: (String) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val filtered = remember(keywords, query) {
+        val q = query.trim()
+        if (q.isEmpty()) keywords
+        else keywords.filter { it.keyword.contains(q, ignoreCase = true) }
+    }
+    ExposedDropdownMenuBox(
+        expanded = expanded && filtered.isNotEmpty(),
+        onExpandedChange = { expanded = it },
+    ) {
+        OutlinedTextField(
+            value = query,
+            onValueChange = {
+                onQueryChange(it)
+                expanded = true
+            },
+            label = { Text(stringResource(R.string.today_habit_keyword_hint)) },
+            singleLine = true,
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryEditable),
+        )
+        ExposedDropdownMenu(
+            expanded = expanded && filtered.isNotEmpty(),
+            onDismissRequest = { expanded = false },
+        ) {
+            filtered.forEach { kw ->
+                DropdownMenuItem(
+                    text = { Text("#${kw.keyword}") },
+                    onClick = {
+                        onQueryChange(kw.keyword)
+                        expanded = false
+                    },
+                )
+            }
+        }
+    }
 }
 
 // Date label like "Wed, May 28"; the year is omitted to keep the bar
@@ -471,6 +628,7 @@ private fun BoxScope.AddSpeedDial(
     onExpandedChange: (Boolean) -> Unit,
     onAddTask: () -> Unit,
     onAddPhoto: () -> Unit,
+    onTrackHabit: () -> Unit,
 ) {
     if (expanded) {
         // Full-screen scrim; tapping anywhere outside the actions collapses it.
@@ -510,6 +668,14 @@ private fun BoxScope.AddSpeedDial(
                     onClick = {
                         onExpandedChange(false)
                         onAddPhoto()
+                    },
+                )
+                SpeedDialItem(
+                    label = stringResource(R.string.today_fab_track_habit),
+                    icon = Icons.Filled.Add,
+                    onClick = {
+                        onExpandedChange(false)
+                        onTrackHabit()
                     },
                 )
             }

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import org.polybrain.tasks.health.data.HabitKeyword
 import org.polybrain.tasks.health.data.Settings
 import org.polybrain.tasks.health.data.SettingsSnapshot
 import org.polybrain.tasks.health.data.TaskCompleteRequest
@@ -18,6 +19,7 @@ import org.polybrain.tasks.health.data.TaskTextRequest
 import org.polybrain.tasks.health.data.TasksApi
 import org.polybrain.tasks.health.data.TasksClient
 import org.polybrain.tasks.health.data.TodayTask
+import org.polybrain.tasks.health.data.TrackHabitRequest
 import org.polybrain.tasks.health.data.TripSummary
 
 class TodayViewModel(application: Application) : AndroidViewModel(application) {
@@ -78,6 +80,30 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
      */
     private val _activeTrip = MutableStateFlow<TripSummary?>(null)
     val activeTrip: StateFlow<TripSummary?> = _activeTrip.asStateFlow()
+
+    /**
+     * Available habit keywords for the "track a habit" dialog, fetched once
+     * and cached for the ViewModel's lifetime — the user's keyword set rarely
+     * changes. Empty until [loadHabitKeywords] first succeeds.
+     */
+    private val _habitKeywords = MutableStateFlow<List<HabitKeyword>>(emptyList())
+    val habitKeywords: StateFlow<List<HabitKeyword>> = _habitKeywords.asStateFlow()
+
+    /** Whether the track-a-habit dialog is open. */
+    private val _habitDialogOpen = MutableStateFlow(false)
+    val habitDialogOpen: StateFlow<Boolean> = _habitDialogOpen.asStateFlow()
+
+    /** True while the keyword list is being fetched (drives the dialog spinner). */
+    private val _habitKeywordsLoading = MutableStateFlow(false)
+    val habitKeywordsLoading: StateFlow<Boolean> = _habitKeywordsLoading.asStateFlow()
+
+    /** True while a habit is being posted; gates the dialog's Track button. */
+    private val _habitSaving = MutableStateFlow(false)
+    val habitSaving: StateFlow<Boolean> = _habitSaving.asStateFlow()
+
+    /** Last habit-dialog error (load or post), shown inline; null = none. */
+    private val _habitError = MutableStateFlow<String?>(null)
+    val habitError: StateFlow<String?> = _habitError.asStateFlow()
 
     fun refresh() {
         viewModelScope.launch { reload() }
@@ -240,6 +266,75 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
 
     fun clearError() {
         _error.value = null
+    }
+
+    /**
+     * Open the track-a-habit dialog and make sure the keyword list is loaded.
+     * The list is cached across opens, so this only hits the network the first
+     * time (or after a previous failure left it empty).
+     */
+    fun openHabitDialog() {
+        _habitError.value = null
+        _habitDialogOpen.value = true
+        if (_habitKeywords.value.isEmpty()) loadHabitKeywords()
+    }
+
+    fun closeHabitDialog() {
+        if (_habitSaving.value) return
+        _habitDialogOpen.value = false
+    }
+
+    /**
+     * Fetch the user's available habit keywords. No-op while a fetch is already
+     * in flight or, unless [force] is set, when the cache is already populated.
+     */
+    fun loadHabitKeywords(force: Boolean = false) {
+        if (_habitKeywordsLoading.value) return
+        if (!force && _habitKeywords.value.isNotEmpty()) return
+        viewModelScope.launch {
+            val snapshot = settings.snapshot()
+            if (!snapshot.isConfigured) {
+                _habitError.value = "Configure server URL and API token first."
+                return@launch
+            }
+            _habitKeywordsLoading.value = true
+            try {
+                _habitKeywords.value = buildApi(snapshot).listHabitKeywords(today())
+                _habitError.value = null
+            } catch (t: Throwable) {
+                _habitError.value = t.message ?: t.javaClass.simpleName
+            } finally {
+                _habitKeywordsLoading.value = false
+            }
+        }
+    }
+
+    /**
+     * Record a habit for the selected day via the idempotent keyword endpoint
+     * (upsert on habit+date). Closes the dialog on success. The keyword cache
+     * is left intact — re-tracking just updates that day's note server-side.
+     */
+    fun trackHabit(keyword: String, note: String) {
+        if (_habitSaving.value) return
+        viewModelScope.launch {
+            val snapshot = settings.snapshot()
+            if (!snapshot.isConfigured) {
+                _habitError.value = "Configure server URL and API token first."
+                return@launch
+            }
+            _habitSaving.value = true
+            _habitError.value = null
+            try {
+                buildApi(snapshot).trackHabit(
+                    TrackHabitRequest(keyword = keyword, date = today(), note = note.trim())
+                )
+                _habitDialogOpen.value = false
+            } catch (t: Throwable) {
+                _habitError.value = t.message ?: t.javaClass.simpleName
+            } finally {
+                _habitSaving.value = false
+            }
+        }
     }
 
     private suspend fun reload() {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -94,6 +94,16 @@
     <string name="today_fab_close">Close</string>
     <string name="today_fab_add_task">Add Task</string>
     <string name="today_fab_add_photo">Add Photo</string>
+    <string name="today_fab_track_habit">Track Habit</string>
+
+    <string name="today_habit_dialog_title">Track a habit</string>
+    <string name="today_habit_loading">Loading habits…</string>
+    <string name="today_habit_empty">No habits available.</string>
+    <string name="today_habit_keyword_hint">Habit</string>
+    <string name="today_habit_note_hint">Add a note (optional)</string>
+    <string name="today_habit_track">Track</string>
+    <string name="today_habit_retry">Retry</string>
+    <string name="today_habit_cancel">Cancel</string>
     <plurals name="photo_uploaded">
         <item quantity="one">Photo uploaded</item>
         <item quantity="other">%d photos uploaded</item>

--- a/android/app/src/test/java/org/polybrain/tasks/health/sync/OutboxDrainerTest.kt
+++ b/android/app/src/test/java/org/polybrain/tasks/health/sync/OutboxDrainerTest.kt
@@ -12,6 +12,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.polybrain.tasks.health.data.BoardItemsResponse
+import org.polybrain.tasks.health.data.HabitKeyword
 import org.polybrain.tasks.health.data.HealthDataResponse
 import org.polybrain.tasks.health.data.Outbox
 import org.polybrain.tasks.health.data.OkResponse
@@ -218,6 +219,7 @@ class OutboxDrainerTest {
         // --- unused endpoints ---
         override suspend fun trackHabit(body: TrackHabitRequest): TrackHabitResponse = nope()
         override suspend fun trackHabitText(body: TrackHabitTextRequest): OkResponse = nope()
+        override suspend fun listHabitKeywords(date: String): List<HabitKeyword> = nope()
         override suspend fun healthData(): HealthDataResponse = nope()
         override suspend fun listTodayTasks(date: String): TodayTasksResponse = nope()
         override suspend fun listBoardItems(): BoardItemsResponse = nope()


### PR DESCRIPTION
## Summary

Adds a **Track Habit** dialog to the Android Today screen so any habit can be recorded for the selected day — not just the hardcoded activity types on the Health screen.

- New **Track Habit** entry on the Today speed-dial FAB opens the dialog.
- Available keywords come from the existing `habit/keywords/mine/` endpoint (profile-scoped; the server also excludes habits already tracked that day) and are **cached in the ViewModel** for its lifetime, so the list is fetched once.
- Keywords are offered through an **autocomplete field** (editable `OutlinedTextField` + filterable `ExposedDropdownMenu`) rather than chips, since there can be many of them. Track is enabled only when the field text exactly names an available keyword (typed in full or picked from the dropdown), so a non-existent keyword can't be posted.
- A free-form note can be attached. The entry is posted via the **idempotent** `api/v1/habit/track/` endpoint (upsert on habit+date) using the screen's selected date.
- Loading / empty / error states are handled inline, with a Retry affordance when the keyword list fails to load.

## Files

- `data/TasksApi.kt` — `HabitKeyword`/`HabitRef` models + `GET habit/keywords/mine/` (`listHabitKeywords`).
- `ui/TodayViewModel.kt` — dialog state, cached keyword load (`loadHabitKeywords`), and `trackHabit`.
- `ui/TodayScreen.kt` — speed-dial entry, `TrackHabitDialog`, and the `HabitKeywordPicker` autocomplete.
- `res/values/strings.xml` — new dialog strings.
- `test/.../OutboxDrainerTest.kt` — added the new method to the `TasksApi` fake.

## Notes

- The keyword cache reflects the day it was first loaded, so the server-side "already tracked today" exclusion won't re-filter when navigating to other days. Re-tracking is harmless (the endpoint upserts). Easy to switch to per-day loading if preferred.
- Not built locally (the `android/` project has no Gradle wrapper) — please build in Android Studio. Worth confirming the `ExposedDropdownMenu` popup nests cleanly inside the `AlertDialog` on the target API level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)