### PR TITLE
feat(android): copy a task to today from the Today screen

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayScreen.kt
@@ -142,11 +142,16 @@ fun TodayScreen(
                                 HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
                             }
                         }
+                        // "Copy to today" only makes sense while browsing some
+                        // other day — on today it would be a no-op duplicate.
+                        val onAnotherDay = selectedDate != LocalDate.now()
                         items(items = tasks, key = TodayTask::text) { task ->
                             TaskRow(
                                 task = task,
                                 onToggle = { done -> vm.requestSetDone(task.text, done) },
                                 onDelete = { vm.delete(task.text) },
+                                onCopyToToday =
+                                    if (onAnotherDay) ({ vm.copyToToday(task.text) }) else null,
                             )
                         }
                     }
@@ -515,6 +520,9 @@ private fun TaskRow(
     task: TodayTask,
     onToggle: (Boolean) -> Unit,
     onDelete: () -> Unit,
+    // Non-null only when the row belongs to a day other than today; drives the
+    // optional "Copy to today" menu item.
+    onCopyToToday: (() -> Unit)? = null,
 ) {
     var menuExpanded by remember { mutableStateOf(false) }
     Row(
@@ -546,6 +554,15 @@ private fun TaskRow(
                 expanded = menuExpanded,
                 onDismissRequest = { menuExpanded = false },
             ) {
+                onCopyToToday?.let { copy ->
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.today_copy_to_today_menu)) },
+                        onClick = {
+                            menuExpanded = false
+                            copy()
+                        },
+                    )
+                }
                 DropdownMenuItem(
                     text = { Text(stringResource(R.string.today_remove_menu)) },
                     onClick = {

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayViewModel.kt
@@ -151,6 +151,24 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     /**
+     * Copy a task onto the actual current day. Offered from a task's context
+     * menu only while browsing some other day. Reuses the same /add path as a
+     * typed task, but pins the date to the real today rather than the selected
+     * day, so the task lands on today's Daily plan while staying put on the day
+     * being viewed. `mutate`'s reload refreshes the day in view (unchanged when
+     * that isn't today); navigating to today then shows the copy.
+     */
+    fun copyToToday(text: String) {
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) return
+        viewModelScope.launch {
+            mutate { api ->
+                api.addTodayTask(TaskTextRequest(trimmed, LocalDate.now().toString()))
+            }
+        }
+    }
+
+    /**
      * Entry point for the checkbox tap.
      *
      * Branching:

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="today_empty">Nothing on today\'s plan yet.</string>
     <string name="today_add_hint">Add a task</string>
     <string name="today_add_button">Add</string>
+    <string name="today_copy_to_today_menu">Copy to today</string>
     <string name="today_remove_menu">Remove</string>
     <string name="today_not_configured">Configure server URL and API token in Settings first.</string>
     <string name="today_error_format">Error: %1$s</string>


### PR DESCRIPTION
## Summary

Adds a **"Copy to today"** action to a task's long-press context menu on the Today screen, alongside the existing "Remove" action. It's shown only when browsing a day other than today — on today it would be a no-op duplicate.

The action reuses the existing `addTodayTask` (`/api/v1/android/task/add/`) endpoint: it pins the date to the real `LocalDate.now()` rather than the selected day, so the task lands on today's Daily plan while staying put on the day being viewed.

## Changes

- **`TodayViewModel.kt`** — new `copyToToday(text)` method. Same `/add` path as `add`/`addPlanItemToToday` via `mutate`, but with the date pinned to today.
- **`TodayScreen.kt`** — `TaskRow` gained an optional `onCopyToToday: (() -> Unit)? = null`; when non-null it renders a "Copy to today" `DropdownMenuItem` above "Remove". The call site passes it only when `selectedDate != LocalDate.now()`.
- **`strings.xml`** — new `today_copy_to_today_menu` string.

## Testing

The Android module has no Gradle wrapper, so this was verified by manual review rather than a compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)