### PR TITLE
fix(tree): normalize CRLF in plan/reflection task lines

### DIFF
--- a/tasks/apps/tree/services/today/text_lines.py
+++ b/tasks/apps/tree/services/today/text_lines.py
@@ -1,11 +1,20 @@
 """Helpers for the newline-joined text fields backing Plan.focus and
-Reflection.good. Exact-line equality, no trimming or case folding."""
+Reflection.good. Exact-line equality, no trimming or case folding.
+
+CRLF / CR endings are normalized to LF (some writers store ``\\r\\n`` — e.g.
+the CLI's ``sanitize_string``), so a line never carries a stray ``\\r`` and
+matching stays consistent across fields. Functions that rewrite a field
+return it normalized."""
+
+
+def _normalize(value):
+    return value.replace("\r\n", "\n").replace("\r", "\n")
 
 
 def split_lines(value):
     if not value:
         return []
-    return value.split("\n")
+    return _normalize(value).split("\n")
 
 
 def has_line(value, line):
@@ -13,24 +22,22 @@ def has_line(value, line):
 
 
 def add_unique_line(value, line):
-    if not value:
-        return line
-    if line in value.split("\n"):
-        return value
-    return value + "\n" + line
+    lines = split_lines(value)
+    if line in lines:
+        return "\n".join(lines)
+    return "\n".join(lines + [line])
 
 
 def remove_line(value, line):
-    if not value:
-        return ""
-    return "\n".join(l for l in value.split("\n") if l != line)
+    return "\n".join(l for l in split_lines(value) if l != line)
 
 
 def replace_line(value, old_line, new_line):
     """Replace exact-match occurrences of old_line with new_line, preserving
-    the position of other lines. Returns the original value unchanged if
+    the position of other lines. Returns the (normalized) value unchanged if
     old_line is not present.
     """
-    if not value or old_line not in value.split("\n"):
-        return value or ""
-    return "\n".join(new_line if l == old_line else l for l in value.split("\n"))
+    lines = split_lines(value)
+    if old_line not in lines:
+        return "\n".join(lines)
+    return "\n".join(new_line if l == old_line else l for l in lines)

--- a/tasks/apps/tree/tests/test_today_plans_api.py
+++ b/tasks/apps/tree/tests/test_today_plans_api.py
@@ -80,6 +80,21 @@ class TodayPlansAPITestCase(APITestCase):
             body["monthly"]["tasks"], [{"text": "month task", "done": True}]
         )
 
+    def test_crlf_stored_focus_returns_clean_task_text(self):
+        # Some writers store the focus with \r\n endings; task text must come
+        # back with no stray \r so the journal prints normal newlines.
+        Plan.objects.create(pub_date=TODAY, thread=self.daily, focus="alpha\r\nbravo")
+        Reflection.objects.create(pub_date=TODAY, thread=self.daily, good="bravo")
+
+        tasks = self._get().json()["daily"]["tasks"]
+        self.assertEqual(
+            tasks,
+            [
+                {"text": "alpha", "done": False},
+                {"text": "bravo", "done": True},
+            ],
+        )
+
     def test_empty_when_nothing_planned(self):
         body = self._get().json()
         self.assertEqual(body["daily"]["tasks"], [])

--- a/tasks/apps/tree/tests/test_today_tasks_service.py
+++ b/tasks/apps/tree/tests/test_today_tasks_service.py
@@ -55,6 +55,17 @@ class TodayServiceTestCase(TestCase):
         self.assertEqual(text_lines.remove_line("only", "only"), "")
         self.assertEqual(text_lines.remove_line(None, "x"), "")
 
+    def test_text_lines_normalizes_crlf(self):
+        # CRLF-stored fields (e.g. via the CLI's sanitize_string) split into
+        # clean lines with no stray \r, and matching ignores the line ending.
+        self.assertEqual(text_lines.split_lines("a\r\nb"), ["a", "b"])
+        self.assertEqual(text_lines.split_lines("a\rb"), ["a", "b"])
+        self.assertTrue(text_lines.has_line("a\r\nb", "a"))
+        self.assertEqual(text_lines.remove_line("a\r\nb", "a"), "b")
+        self.assertEqual(text_lines.replace_line("a\r\nb", "a", "A"), "A\nb")
+        # add_unique_line normalizes the existing field on write.
+        self.assertEqual(text_lines.add_unique_line("a\r\nb", "c"), "a\nb\nc")
+
     # --- board_tree DFS -----------------------------------------------------
 
     def test_find_task_by_text_walks_children(self):


### PR DESCRIPTION
## What

The CLI journal printed the **Weekly plan** with `\r\n` line endings.

## Why

`Plan.focus` / `Reflection.good` can be stored with `\r\n` endings (the CLI's `sanitize_string` writes CRLF). The today service's `text_lines.split_lines` only split on `\n`, so each task line kept a trailing `\r`. That `\r` was carried in the `/api/v1/plans/today/` task text, and the CLI appended its own newline when rendering → `\r\n` in the output.

## Fix

Made the line-parsing module (`services/today/text_lines.py`) CRLF-tolerant: `split_lines` normalizes `\r\n` / `\r` → `\n` before splitting, and the rewrite helpers (`add_unique_line` / `remove_line` / `replace_line`) return normalized values. Effects:

- Clean task text everywhere it's consumed — the CLI journal **and** the Android Today tab both go through this module.
- Crossed-off matching stays consistent when `focus` and `good` were stored with different endings (previously `"alpha\r"` wouldn't match `"alpha"` in `good`, so a done task could render unchecked).
- Stored fields self-heal to LF on the next write.

No CLI change needed — it just renders the backend-provided text. No model changes → no migrations.

## Tests

- `test_text_lines_normalizes_crlf` — unit coverage for split/has/remove/replace/add under CRLF (and confirms prior LF behavior is unchanged).
- `test_crlf_stored_focus_returns_clean_task_text` — the endpoint returns clean task text from a `\r\n`-stored plan.

⚠️ Could not run the Django suite locally (no Docker daemon / no local Django). Verified `text_lines` behavior in isolation (all prior expectations hold + new CRLF cases pass). Please run:

```
docker compose -f docker/development/docker-compose.yml exec tasks-backend \
  python manage.py test tasks.apps.tree.tests.test_today_tasks_service tasks.apps.tree.tests.test_today_progress tasks.apps.tree.tests.test_today_plans_api tasks.apps.tree.tests.test_android_task_api
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)