### PR TITLE
ci: bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/android-test.yml
+++ b/.github/workflows/android-test.yml
@@ -16,10 +16,10 @@ jobs:
         working-directory: android
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -28,7 +28,7 @@ jobs:
       # android/gradle/libs.versions.toml (compileSdk = 35). Without this,
       # AGP 9 fails on a fresh runner.
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
         with:
           packages: 'platforms;android-35 build-tools;35.0.0'
 
@@ -36,7 +36,7 @@ jobs:
       # the minimum compatible with AGP 9.2.x (see
       # android/gradle/libs.versions.toml — agp version).
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
         with:
           gradle-version: 9.4.1
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
@@ -54,7 +54,7 @@ jobs:
 
       - name: Upload debug APK
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: app-debug-${{ github.event.pull_request.number }}
           path: android/app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,18 +18,18 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Cache pip dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements/dist.txt', 'requirements/base.txt') }}
@@ -37,7 +37,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Cache node modules
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,16 +28,16 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Cache pip dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements/test.txt', 'requirements/base.txt', 'requirements/dist.txt') }}
@@ -45,7 +45,7 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Cache node modules
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}

--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -91,7 +91,7 @@ services:
         command: "/app/docker/development/scripts/run-development.sh"
         working_dir: /app
     tasks-frontend:
-        image: "node:22-alpine"
+        image: "node:24-alpine"
         volumes:
             - "../..:/app"
         command: "/app/docker/development/scripts/run-frontend.sh"


### PR DESCRIPTION
## What

GitHub is [deprecating the Node 20 runtime](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) for JavaScript actions, which was producing deprecation warnings on every CI run. This bumps all Node-based actions to majors that run on Node 24, and moves the build Node version to 24 as well.

## Action version bumps

| Action | From | To |
| --- | --- | --- |
| `actions/checkout` | v2 / v4 | **v5** |
| `actions/setup-python` | v4 | **v6** |
| `actions/setup-node` | v4 | **v5** |
| `actions/cache` | v3 | **v5** |
| `actions/setup-java` | v4 | **v5** |
| `actions/upload-artifact` | v4 | **v6** |
| `android-actions/setup-android` | v3 | **v4** |
| `gradle/actions/setup-gradle` | v4 | **v5** |

## Notes

- **`actions/cache@v3 → v5`** was overdue regardless of Node — the cache service backend v3 talked to has been retired, so v3 jobs would have started failing anyway.
- **`gradle/actions/setup-gradle`** stops at **v5** (the first Node 24 release) rather than the latest v6. v6 moved caching to a proprietary `gradle-actions-caching` component requiring acceptance of new Terms of Use; v5 keeps the existing open-source caching behavior while still fixing the deprecation.
- **Docker-based actions** (`burnett01/rsync-deployments`, `appleboy/ssh-action`) aren't Node actions, so they're unaffected and left as-is.
- These Node 24 majors require Actions Runner ≥ 2.327.1, which `ubuntu-latest` already satisfies.

## Build Node version

Also moves the **build** Node version from 22 → 24 (current active LTS), keeping CI and the dev container in sync:

- `node-version: 24` in `test.yml` and `deploy.yml`
- `node:24-alpine` in `docker/development/docker-compose.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)