### PR TITLE
feat(android): tap weight to record, add running activity

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/HealthScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/HealthScreen.kt
@@ -1,9 +1,13 @@
 package org.polybrain.tasks.health.ui
 
+import android.widget.NumberPicker
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -35,6 +39,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.PermissionController
 import org.polybrain.tasks.health.R
@@ -104,15 +109,23 @@ fun HealthScreen(vm: MainViewModel) {
 
             // Last recorded weight comes from the server (independent of Health
             // Connect permissions), so it shows regardless of the grant state.
+            // Tapping the section opens the dialog ready to record a new weight.
             HorizontalDivider()
-            val weightKg = healthData?.weightKg
-            if (weightKg != null) {
-                Text(
-                    stringResource(R.string.metric_weight_format)
-                        .format(weightKg, formatWeightDate(healthData?.recordedAt))
-                )
-            } else {
-                Text(stringResource(R.string.metric_weight_none))
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { vm.openActivityDialog(ActivityType.Weight) }
+                    .padding(vertical = 4.dp),
+            ) {
+                val weightKg = healthData?.weightKg
+                if (weightKg != null) {
+                    Text(
+                        stringResource(R.string.metric_weight_format)
+                            .format(weightKg, formatWeightDate(healthData?.recordedAt))
+                    )
+                } else {
+                    Text(stringResource(R.string.metric_weight_none))
+                }
             }
 
             if (permissionsGranted) {
@@ -154,25 +167,35 @@ fun HealthScreen(vm: MainViewModel) {
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun TrackActivityDialog(vm: MainViewModel) {
     val saving by vm.activitySaving.collectAsState()
     val error by vm.activityError.collectAsState()
 
-    var selectedType by remember { mutableStateOf(ActivityType.Gym) }
+    var selectedType by remember { mutableStateOf(vm.activityInitialType.value) }
     var note by remember { mutableStateOf("") }
     var weightText by remember { mutableStateOf("") }
+    var distanceText by remember { mutableStateOf("") }
+    var minutes by remember { mutableStateOf(0) }
+    var seconds by remember { mutableStateOf(0) }
 
     val isWeight = selectedType == ActivityType.Weight
+    val isRunning = selectedType == ActivityType.Running
     val weightKg = weightText.trim().toDoubleOrNull()
-    val canConfirm = if (isWeight) weightKg != null && weightKg > 0 else true
+    val distanceKm = distanceText.trim().toDoubleOrNull()
+    val canConfirm = when {
+        isWeight -> weightKg != null && weightKg > 0
+        isRunning -> distanceKm != null && distanceKm > 0 && (minutes > 0 || seconds > 0)
+        else -> true
+    }
 
     AlertDialog(
         onDismissRequest = { vm.closeActivityDialog() },
         title = { Text(stringResource(R.string.activity_dialog_title)) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     ActivityType.entries.forEach { type ->
                         FilterChip(
                             selected = type == selectedType,
@@ -181,24 +204,54 @@ private fun TrackActivityDialog(vm: MainViewModel) {
                         )
                     }
                 }
-                if (isWeight) {
-                    OutlinedTextField(
-                        value = weightText,
-                        onValueChange = { weightText = it },
-                        placeholder = { Text(stringResource(R.string.weight_kg_hint)) },
-                        singleLine = true,
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                } else {
-                    OutlinedTextField(
-                        value = note,
-                        onValueChange = { note = it },
-                        placeholder = { Text(stringResource(R.string.activity_note_hint)) },
-                        singleLine = false,
-                        minLines = 3,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
+                when {
+                    isWeight -> {
+                        OutlinedTextField(
+                            value = weightText,
+                            onValueChange = { weightText = it },
+                            placeholder = { Text(stringResource(R.string.weight_kg_hint)) },
+                            singleLine = true,
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                    isRunning -> {
+                        OutlinedTextField(
+                            value = distanceText,
+                            onValueChange = { distanceText = it },
+                            placeholder = { Text(stringResource(R.string.running_distance_hint)) },
+                            singleLine = true,
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(16.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            DurationWheel(
+                                label = stringResource(R.string.running_minutes_label),
+                                value = minutes,
+                                range = 0..240,
+                                onValueChange = { minutes = it },
+                            )
+                            DurationWheel(
+                                label = stringResource(R.string.running_seconds_label),
+                                value = seconds,
+                                range = 0..59,
+                                onValueChange = { seconds = it },
+                            )
+                        }
+                    }
+                    else -> {
+                        OutlinedTextField(
+                            value = note,
+                            onValueChange = { note = it },
+                            placeholder = { Text(stringResource(R.string.activity_note_hint)) },
+                            singleLine = false,
+                            minLines = 3,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
                 }
                 error?.let {
                     Text(
@@ -212,10 +265,10 @@ private fun TrackActivityDialog(vm: MainViewModel) {
         confirmButton = {
             TextButton(
                 onClick = {
-                    if (isWeight) {
-                        weightKg?.let { vm.trackWeight(it) }
-                    } else {
-                        vm.trackActivity(selectedType, note)
+                    when {
+                        isWeight -> weightKg?.let { vm.trackWeight(it) }
+                        isRunning -> distanceKm?.let { vm.trackRunning(it, minutes, seconds) }
+                        else -> vm.trackActivity(selectedType, note)
                     }
                 },
                 enabled = !saving && canConfirm,
@@ -232,6 +285,38 @@ private fun TrackActivityDialog(vm: MainViewModel) {
             }
         },
     )
+}
+
+/**
+ * A labelled spinning "wheel" for one component of the run duration. Compose has
+ * no native wheel picker, so this wraps the platform [NumberPicker] View; the
+ * label sits above it and [onValueChange] mirrors each scroll back into state.
+ */
+@Composable
+private fun DurationWheel(
+    label: String,
+    value: Int,
+    range: IntRange,
+    onValueChange: (Int) -> Unit,
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(text = label, style = MaterialTheme.typography.bodySmall)
+        AndroidView(
+            factory = { context ->
+                NumberPicker(context).apply {
+                    minValue = range.first
+                    maxValue = range.last
+                    this.value = value
+                    setOnValueChangedListener { _, _, newValue -> onValueChange(newValue) }
+                }
+            },
+            update = { picker ->
+                picker.minValue = range.first
+                picker.maxValue = range.last
+                if (picker.value != value) picker.value = value
+            },
+        )
+    }
 }
 
 private val displayFormatter: DateTimeFormatter =

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/MainViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/MainViewModel.kt
@@ -31,10 +31,14 @@ import kotlinx.coroutines.launch
  *
  * [Weight] is special: instead of a free-text note it carries a numeric
  * kilogram value, posted as `#weight weight=<x.x>kg` (see [MainViewModel.trackWeight]).
+ *
+ * [Running] is likewise special: it carries a distance and a duration, posted
+ * as `#running distance=<x.x>km, time=<m>m<s>s` (see [MainViewModel.trackRunning]).
  */
 enum class ActivityType(val keyword: String) {
     Gym("siłka"),
     Workout("workout"),
+    Running("running"),
     Weight("weight"),
 }
 
@@ -62,6 +66,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     /** Open/closed state for the "register activity" dialog opened from the FAB. */
     private val _activityDialogOpen = MutableStateFlow(false)
     val activityDialogOpen: StateFlow<Boolean> = _activityDialogOpen.asStateFlow()
+
+    /** Activity type the dialog should preselect when it opens (e.g. Weight when
+     *  the dialog is opened by tapping the weight section). */
+    private val _activityInitialType = MutableStateFlow(ActivityType.Gym)
+    val activityInitialType: StateFlow<ActivityType> = _activityInitialType.asStateFlow()
 
     /** True while an activity is being posted; gates the dialog buttons. */
     private val _activitySaving = MutableStateFlow(false)
@@ -132,7 +141,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         refreshHealthDataAsync()
     }
 
-    fun openActivityDialog() {
+    fun openActivityDialog(initialType: ActivityType = ActivityType.Gym) {
+        _activityInitialType.value = initialType
         _activityError.value = null
         _activityDialogOpen.value = true
     }
@@ -163,6 +173,17 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     fun trackWeight(kg: Double) {
         val text = "#${ActivityType.Weight.keyword} weight=${"%.1f".format(Locale.US, kg)}kg"
         postHabitLine(text) { refreshHealthDataAsync() }
+    }
+
+    /**
+     * Records a run as `#running distance=<x.x>km, time=<m>m<s>s` through the
+     * same non-idempotent text endpoint. Distance is formatted with one decimal
+     * (US locale, so the separator is a dot the backend can parse).
+     */
+    fun trackRunning(distanceKm: Double, minutes: Int, seconds: Int) {
+        val distance = "%.1f".format(Locale.US, distanceKm)
+        val text = "#${ActivityType.Running.keyword} distance=${distance}km, time=${minutes}m${seconds}s"
+        postHabitLine(text)
     }
 
     /**

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -139,6 +139,9 @@
     <string name="activity_send">Track</string>
     <string name="activity_cancel">Cancel</string>
     <string name="weight_kg_hint">Weight (kg)</string>
+    <string name="running_distance_hint">Distance (km)</string>
+    <string name="running_minutes_label">Min</string>
+    <string name="running_seconds_label">Sec</string>
 
     <string name="today_metrics_heading">Today</string>
     <string name="metric_steps_format">Steps: %1$d</string>


### PR DESCRIPTION
## Summary

Two additions to the Android Health screen (`HealthScreen.kt`):

1. **Tap the Weight section to record weight.** The last-weight row is now tappable and opens the activity dialog pre-selected on Weight, ready to enter a new value.
2. **Record running.** A new `Running` activity type with a distance field and a compound duration entered via two `NumberPicker` wheels (minutes / seconds). It posts `#running distance=<x.x>km, time=<m>m<s>s` through the same non-idempotent habit-text endpoint that weight/gym/workout already use (distance formatted with US locale so the separator is a dot the backend can parse).

## Details

- `MainViewModel.kt`: added `Running("running")` to `ActivityType`; added `activityInitialType` state + an `openActivityDialog(initialType = Gym)` parameter so the dialog can open pre-selected; added `trackRunning(distanceKm, minutes, seconds)`.
- `HealthScreen.kt`: weight section wrapped in a `clickable` column; type chips moved from `Row` to `FlowRow` (the 4th chip now wraps instead of overflowing); dialog field area became a 3-way `when` (weight / running / note); new private `DurationWheel` composable wrapping the platform `NumberPicker` via `AndroidView` (Compose has no native wheel widget). `FlowRow` use is opted in via `@OptIn(ExperimentalLayoutApi::class)`.
- `strings.xml`: added `running_distance_hint`, `running_minutes_label`, `running_seconds_label`.

## Note on backend

The text endpoint resolves `#running` by prefix-matching against existing `HabitKeyword`s. For running entries to actually land, a `Habit` with a `running`-matching keyword must exist on the server (same as the existing `weight`/`siłka`/`workout` habits) — otherwise the POST returns `{"ok": true}` but records nothing.

## Verification

`android/` has no Gradle wrapper, so this was verified by manual review rather than compiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)