### PR TITLE
feat(android): move task to tomorrow and add focus mode

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/HealthScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/HealthScreen.kt
@@ -1,9 +1,13 @@
 package org.polybrain.tasks.health.ui
 
+import android.widget.NumberPicker
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -35,6 +39,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.PermissionController
 import org.polybrain.tasks.health.R
@@ -104,15 +109,23 @@ fun HealthScreen(vm: MainViewModel) {
 
             // Last recorded weight comes from the server (independent of Health
             // Connect permissions), so it shows regardless of the grant state.
+            // Tapping the section opens the dialog ready to record a new weight.
             HorizontalDivider()
-            val weightKg = healthData?.weightKg
-            if (weightKg != null) {
-                Text(
-                    stringResource(R.string.metric_weight_format)
-                        .format(weightKg, formatWeightDate(healthData?.recordedAt))
-                )
-            } else {
-                Text(stringResource(R.string.metric_weight_none))
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { vm.openActivityDialog(ActivityType.Weight) }
+                    .padding(vertical = 4.dp),
+            ) {
+                val weightKg = healthData?.weightKg
+                if (weightKg != null) {
+                    Text(
+                        stringResource(R.string.metric_weight_format)
+                            .format(weightKg, formatWeightDate(healthData?.recordedAt))
+                    )
+                } else {
+                    Text(stringResource(R.string.metric_weight_none))
+                }
             }
 
             if (permissionsGranted) {
@@ -154,25 +167,35 @@ fun HealthScreen(vm: MainViewModel) {
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun TrackActivityDialog(vm: MainViewModel) {
     val saving by vm.activitySaving.collectAsState()
     val error by vm.activityError.collectAsState()
 
-    var selectedType by remember { mutableStateOf(ActivityType.Gym) }
+    var selectedType by remember { mutableStateOf(vm.activityInitialType.value) }
     var note by remember { mutableStateOf("") }
     var weightText by remember { mutableStateOf("") }
+    var distanceText by remember { mutableStateOf("") }
+    var minutes by remember { mutableStateOf(0) }
+    var seconds by remember { mutableStateOf(0) }
 
     val isWeight = selectedType == ActivityType.Weight
+    val isRunning = selectedType == ActivityType.Running
     val weightKg = weightText.trim().toDoubleOrNull()
-    val canConfirm = if (isWeight) weightKg != null && weightKg > 0 else true
+    val distanceKm = distanceText.trim().toDoubleOrNull()
+    val canConfirm = when {
+        isWeight -> weightKg != null && weightKg > 0
+        isRunning -> distanceKm != null && distanceKm > 0 && (minutes > 0 || seconds > 0)
+        else -> true
+    }
 
     AlertDialog(
         onDismissRequest = { vm.closeActivityDialog() },
         title = { Text(stringResource(R.string.activity_dialog_title)) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     ActivityType.entries.forEach { type ->
                         FilterChip(
                             selected = type == selectedType,
@@ -181,24 +204,54 @@ private fun TrackActivityDialog(vm: MainViewModel) {
                         )
                     }
                 }
-                if (isWeight) {
-                    OutlinedTextField(
-                        value = weightText,
-                        onValueChange = { weightText = it },
-                        placeholder = { Text(stringResource(R.string.weight_kg_hint)) },
-                        singleLine = true,
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                } else {
-                    OutlinedTextField(
-                        value = note,
-                        onValueChange = { note = it },
-                        placeholder = { Text(stringResource(R.string.activity_note_hint)) },
-                        singleLine = false,
-                        minLines = 3,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
+                when {
+                    isWeight -> {
+                        OutlinedTextField(
+                            value = weightText,
+                            onValueChange = { weightText = it },
+                            placeholder = { Text(stringResource(R.string.weight_kg_hint)) },
+                            singleLine = true,
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                    isRunning -> {
+                        OutlinedTextField(
+                            value = distanceText,
+                            onValueChange = { distanceText = it },
+                            placeholder = { Text(stringResource(R.string.running_distance_hint)) },
+                            singleLine = true,
+                            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(16.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            DurationWheel(
+                                label = stringResource(R.string.running_minutes_label),
+                                value = minutes,
+                                range = 0..240,
+                                onValueChange = { minutes = it },
+                            )
+                            DurationWheel(
+                                label = stringResource(R.string.running_seconds_label),
+                                value = seconds,
+                                range = 0..59,
+                                onValueChange = { seconds = it },
+                            )
+                        }
+                    }
+                    else -> {
+                        OutlinedTextField(
+                            value = note,
+                            onValueChange = { note = it },
+                            placeholder = { Text(stringResource(R.string.activity_note_hint)) },
+                            singleLine = false,
+                            minLines = 3,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
                 }
                 error?.let {
                     Text(
@@ -212,10 +265,10 @@ private fun TrackActivityDialog(vm: MainViewModel) {
         confirmButton = {
             TextButton(
                 onClick = {
-                    if (isWeight) {
-                        weightKg?.let { vm.trackWeight(it) }
-                    } else {
-                        vm.trackActivity(selectedType, note)
+                    when {
+                        isWeight -> weightKg?.let { vm.trackWeight(it) }
+                        isRunning -> distanceKm?.let { vm.trackRunning(it, minutes, seconds) }
+                        else -> vm.trackActivity(selectedType, note)
                     }
                 },
                 enabled = !saving && canConfirm,
@@ -232,6 +285,38 @@ private fun TrackActivityDialog(vm: MainViewModel) {
             }
         },
     )
+}
+
+/**
+ * A labelled spinning "wheel" for one component of the run duration. Compose has
+ * no native wheel picker, so this wraps the platform [NumberPicker] View; the
+ * label sits above it and [onValueChange] mirrors each scroll back into state.
+ */
+@Composable
+private fun DurationWheel(
+    label: String,
+    value: Int,
+    range: IntRange,
+    onValueChange: (Int) -> Unit,
+) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(text = label, style = MaterialTheme.typography.bodySmall)
+        AndroidView(
+            factory = { context ->
+                NumberPicker(context).apply {
+                    minValue = range.first
+                    maxValue = range.last
+                    this.value = value
+                    setOnValueChangedListener { _, _, newValue -> onValueChange(newValue) }
+                }
+            },
+            update = { picker ->
+                picker.minValue = range.first
+                picker.maxValue = range.last
+                if (picker.value != value) picker.value = value
+            },
+        )
+    }
 }
 
 private val displayFormatter: DateTimeFormatter =

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/MainViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/MainViewModel.kt
@@ -31,10 +31,14 @@ import kotlinx.coroutines.launch
  *
  * [Weight] is special: instead of a free-text note it carries a numeric
  * kilogram value, posted as `#weight weight=<x.x>kg` (see [MainViewModel.trackWeight]).
+ *
+ * [Running] is likewise special: it carries a distance and a duration, posted
+ * as `#running distance=<x.x>km, time=<m>m<s>s` (see [MainViewModel.trackRunning]).
  */
 enum class ActivityType(val keyword: String) {
     Gym("siłka"),
     Workout("workout"),
+    Running("running"),
     Weight("weight"),
 }
 
@@ -62,6 +66,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     /** Open/closed state for the "register activity" dialog opened from the FAB. */
     private val _activityDialogOpen = MutableStateFlow(false)
     val activityDialogOpen: StateFlow<Boolean> = _activityDialogOpen.asStateFlow()
+
+    /** Activity type the dialog should preselect when it opens (e.g. Weight when
+     *  the dialog is opened by tapping the weight section). */
+    private val _activityInitialType = MutableStateFlow(ActivityType.Gym)
+    val activityInitialType: StateFlow<ActivityType> = _activityInitialType.asStateFlow()
 
     /** True while an activity is being posted; gates the dialog buttons. */
     private val _activitySaving = MutableStateFlow(false)
@@ -132,7 +141,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         refreshHealthDataAsync()
     }
 
-    fun openActivityDialog() {
+    fun openActivityDialog(initialType: ActivityType = ActivityType.Gym) {
+        _activityInitialType.value = initialType
         _activityError.value = null
         _activityDialogOpen.value = true
     }
@@ -163,6 +173,17 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     fun trackWeight(kg: Double) {
         val text = "#${ActivityType.Weight.keyword} weight=${"%.1f".format(Locale.US, kg)}kg"
         postHabitLine(text) { refreshHealthDataAsync() }
+    }
+
+    /**
+     * Records a run as `#running distance=<x.x>km, time=<m>m<s>s` through the
+     * same non-idempotent text endpoint. Distance is formatted with one decimal
+     * (US locale, so the separator is a dot the backend can parse).
+     */
+    fun trackRunning(distanceKm: Double, minutes: Int, seconds: Int) {
+        val distance = "%.1f".format(Locale.US, distanceKm)
+        val text = "#${ActivityType.Running.keyword} distance=${distance}km, time=${minutes}m${seconds}s"
+        postHabitLine(text)
     }
 
     /**

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -53,6 +54,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
@@ -80,6 +82,7 @@ fun TodayScreen(
     val configured by vm.configured.collectAsState()
     val pendingComplete by vm.pendingComplete.collectAsState()
     val selectedDate by vm.selectedDate.collectAsState()
+    val focusedTask by vm.focusedTask.collectAsState()
 
     var fabExpanded by remember { mutableStateOf(false) }
 
@@ -106,10 +109,18 @@ fun TodayScreen(
                 onRefresh = vm::refresh,
                 modifier = Modifier.fillMaxSize(),
             ) {
+                // Focus mode hides everything but the focused task and the
+                // already-finished ones, so the single thing left to do stands
+                // alone (with the done list kept for motivation). The weekly
+                // plan section is hidden too — it's "other tasks".
+                val focusMode = focusedTask != null
                 // This week's plan items that aren't already on today's list.
                 // Adding one copies it onto today, after which it drops out here.
                 val todayTexts = tasks.map { it.text }.toSet()
-                val pendingWeekPlan = weekPlan.filterNot { it in todayTexts }
+                val pendingWeekPlan =
+                    if (focusMode) emptyList() else weekPlan.filterNot { it in todayTexts }
+                val displayedTasks =
+                    if (focusMode) tasks.filter { it.text == focusedTask || it.done } else tasks
                 when {
                     !configured -> EmptyState(stringResource(R.string.today_not_configured))
                     tasks.isEmpty() && pendingWeekPlan.isEmpty() ->
@@ -143,15 +154,20 @@ fun TodayScreen(
                             }
                         }
                         // "Copy to today" only makes sense while browsing some
-                        // other day — on today it would be a no-op duplicate.
+                        // other day; "Move to tomorrow" only on today — the two
+                        // are mutually exclusive on the same row.
                         val onAnotherDay = selectedDate != LocalDate.now()
-                        items(items = tasks, key = TodayTask::text) { task ->
+                        items(items = displayedTasks, key = TodayTask::text) { task ->
                             TaskRow(
                                 task = task,
                                 onToggle = { done -> vm.requestSetDone(task.text, done) },
                                 onDelete = { vm.delete(task.text) },
                                 onCopyToToday =
                                     if (onAnotherDay) ({ vm.copyToToday(task.text) }) else null,
+                                onMoveToTomorrow =
+                                    if (!onAnotherDay) ({ vm.moveToTomorrow(task.text) }) else null,
+                                focused = task.text == focusedTask,
+                                onToggleFocus = { vm.toggleFocus(task.text) },
                             )
                         }
                     }
@@ -445,6 +461,12 @@ private fun HabitKeywordPicker(
 // compact since most navigation stays within the current year.
 private val DATE_NAV_FORMAT = DateTimeFormatter.ofPattern("EEE, MMM d")
 
+// Translucent blue (Material Blue 500 at ~12% alpha) behind the focused task.
+// A tint rather than an opaque swatch so it sits well over the surface and
+// doesn't fight the row's text colour. The app uses the default violet
+// MaterialTheme, so this is an explicit blue rather than a theme token.
+private val FOCUS_HIGHLIGHT = Color(0x1F2196F3)
+
 @Composable
 private fun DateNavBar(
     selectedDate: LocalDate,
@@ -523,10 +545,28 @@ private fun TaskRow(
     // Non-null only when the row belongs to a day other than today; drives the
     // optional "Copy to today" menu item.
     onCopyToToday: (() -> Unit)? = null,
+    // Non-null only when the row belongs to today; drives the optional
+    // "Move to tomorrow" menu item, which copies the task onto tomorrow and
+    // removes it from today.
+    onMoveToTomorrow: (() -> Unit)? = null,
+    // Whether this row is the one currently being focused on, which flips the
+    // focus menu item between "Enter" and "Exit focus mode".
+    focused: Boolean = false,
+    onToggleFocus: () -> Unit = {},
 ) {
     var menuExpanded by remember { mutableStateOf(false) }
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        // A faint blue wash marks the focused row so focus mode is obvious
+        // at a glance; rounded so it reads as a deliberate highlight band.
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(
+                if (focused) {
+                    Modifier.clip(RoundedCornerShape(8.dp)).background(FOCUS_HIGHLIGHT)
+                } else {
+                    Modifier
+                },
+            ),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Checkbox(checked = task.done, onCheckedChange = onToggle)
@@ -563,6 +603,29 @@ private fun TaskRow(
                         },
                     )
                 }
+                onMoveToTomorrow?.let { move ->
+                    DropdownMenuItem(
+                        text = { Text(stringResource(R.string.today_move_to_tomorrow_menu)) },
+                        onClick = {
+                            menuExpanded = false
+                            move()
+                        },
+                    )
+                }
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            stringResource(
+                                if (focused) R.string.today_focus_exit_menu
+                                else R.string.today_focus_enter_menu,
+                            )
+                        )
+                    },
+                    onClick = {
+                        menuExpanded = false
+                        onToggleFocus()
+                    },
+                )
                 DropdownMenuItem(
                     text = { Text(stringResource(R.string.today_remove_menu)) },
                     onClick = {

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/TodayViewModel.kt
@@ -74,6 +74,16 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
     val pendingComplete: StateFlow<PendingComplete?> = _pendingComplete.asStateFlow()
 
     /**
+     * Text of the task the user is currently focusing on, or null when focus
+     * mode is off. In focus mode the screen hides everything except this task
+     * and already-finished ones, so only the one thing left to do is in view.
+     * Cleared on day change and when the focused task disappears from a reload
+     * (so its "exit focus" menu item can never become unreachable).
+     */
+    private val _focusedTask = MutableStateFlow<String?>(null)
+    val focusedTask: StateFlow<String?> = _focusedTask.asStateFlow()
+
+    /**
      * The most recently started active trip, refreshed alongside the task
      * list. Drives the "Save to trip" button on the add-note dialog; null
      * when no trip is active.
@@ -123,7 +133,18 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
         _selectedDate.value = date
         // Any pending dialog refers to a task on the previous day's list.
         _pendingComplete.value = null
+        // Focus is scoped to the day it was started on.
+        _focusedTask.value = null
         viewModelScope.launch { reload() }
+    }
+
+    /**
+     * Context-menu toggle: focus this task (entering focus mode), or exit focus
+     * mode if this task is already the focused one. Pure view state — nothing is
+     * sent to the server.
+     */
+    fun toggleFocus(text: String) {
+        _focusedTask.value = if (_focusedTask.value == text) null else text
     }
 
     fun add(text: String) {
@@ -164,6 +185,24 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch {
             mutate { api ->
                 api.addTodayTask(TaskTextRequest(trimmed, LocalDate.now().toString()))
+            }
+        }
+    }
+
+    /**
+     * Move a task to tomorrow: copy it onto tomorrow's Daily plan, then drop it
+     * from today's. Offered from a task's context menu only while viewing today.
+     * Both calls share one [mutate] block so a single reload reflects the result
+     * — the row leaves today and reappears when you step to tomorrow. Reuses the
+     * existing /add and /delete paths, so no new endpoint is needed.
+     */
+    fun moveToTomorrow(text: String) {
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) return
+        viewModelScope.launch {
+            mutate { api ->
+                api.addTodayTask(TaskTextRequest(trimmed, LocalDate.now().plusDays(1).toString()))
+                api.deleteTodayTask(TaskTextRequest(trimmed, today()))
             }
         }
     }
@@ -219,6 +258,9 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
     private fun completePending(note: String, storyId: Long?) {
         val pending = _pendingComplete.value as? PendingComplete.AddNote ?: return
         _pendingComplete.value = null
+        // Crossing off the focused task ends focus mode — its one job is done,
+        // so fall back to the full list (the completed task included).
+        if (_focusedTask.value == pending.text) _focusedTask.value = null
         viewModelScope.launch {
             _tasks.value = _tasks.value.map { t ->
                 if (t.text == pending.text) t.copy(done = true) else t
@@ -368,6 +410,11 @@ class TodayViewModel(application: Application) : AndroidViewModel(application) {
         try {
             val api = buildApi(snapshot)
             _tasks.value = api.listTodayTasks(today()).items
+            // Drop focus if its task is gone (deleted, or its text changed),
+            // otherwise the "exit focus mode" item would vanish with the row.
+            if (_focusedTask.value != null && _tasks.value.none { it.text == _focusedTask.value }) {
+                _focusedTask.value = null
+            }
             _weekPlan.value = api.listPlans("Weekly", endOfWeek()).results
                 .firstOrNull()
                 ?.focus

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -69,6 +69,9 @@
     <string name="today_add_hint">Add a task</string>
     <string name="today_add_button">Add</string>
     <string name="today_copy_to_today_menu">Copy to today</string>
+    <string name="today_move_to_tomorrow_menu">Move to tomorrow</string>
+    <string name="today_focus_enter_menu">Enter focus mode</string>
+    <string name="today_focus_exit_menu">Exit focus mode</string>
     <string name="today_remove_menu">Remove</string>
     <string name="today_not_configured">Configure server URL and API token in Settings first.</string>
     <string name="today_error_format">Error: %1$s</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -139,6 +139,9 @@
     <string name="activity_send">Track</string>
     <string name="activity_cancel">Cancel</string>
     <string name="weight_kg_hint">Weight (kg)</string>
+    <string name="running_distance_hint">Distance (km)</string>
+    <string name="running_minutes_label">Min</string>
+    <string name="running_seconds_label">Sec</string>
 
     <string name="today_metrics_heading">Today</string>
     <string name="metric_steps_format">Steps: %1$d</string>


### PR DESCRIPTION
## Summary

Two PRs' worth of Android Today-screen work, bundled. Builds on the still-unmerged weight-tap/running commit (`674d851`), which is included here.

### Move to tomorrow & focus mode (this branch)
Two new actions on a today task's long-press context menu:

- **Move to tomorrow** (shown only while viewing today): copies the task onto tomorrow's Daily plan and removes it from today, reusing the existing `/add` and `/delete` endpoints — no new backend route. Add runs before delete, so a failed add leaves the task on today rather than losing it.
- **Enter / Exit focus mode**: hides every task except the focused one and the already-finished ones (and the weekly-plan section), so the single thing left to do stands alone with the done list kept for motivation. Pure view-only state — cleared on day change and when the focused task disappears from a reload, so its "exit" menu item can never become unreachable.

### Tap weight to record, add running activity (`674d851`)
Included because it isn't yet on `main`.

## Testing
Manual review only — `android/` has no Gradle wrapper, so the module can't be compiled from the CLI in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)