### PR TITLE
feat(trips): photo content-hash dedup, multi-pick, pausable tracking

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/data/Outbox.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/Outbox.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.security.MessageDigest
 import java.util.UUID
 import kotlinx.serialization.json.Json
 
@@ -45,13 +46,25 @@ class Outbox(private val dir: File) {
         return item
     }
 
+    /**
+     * Queue a photo. Returns null (and writes nothing) when the same image is
+     * already queued for this scope — the content hash dedups a rapid
+     * double-pick or an overlapping bulk selection *before* any S3 upload. A
+     * copy that already failed permanently is ignored for this check, so
+     * re-picking it gives a fresh attempt.
+     */
     fun enqueuePhoto(
         storyId: Long?,
         comment: String,
         published: String,
         contentType: String,
         bytes: ByteArray,
-    ): OutboxItem {
+    ): OutboxItem? {
+        val contentHash = sha256Hex(bytes)
+        val scope = if (storyId != null) forStory(storyId) else standalone()
+        if (scope.any { it.isPhoto && !it.failedPermanently && it.contentHash == contentHash }) {
+            return null
+        }
         val id = UUID.randomUUID().toString()
         val createdAt = System.currentTimeMillis()
         val photoName = baseName(createdAt, id) + "." + extFor(contentType)
@@ -65,6 +78,7 @@ class Outbox(private val dir: File) {
             createdAt = createdAt,
             contentType = contentType,
             photoFile = photoName,
+            contentHash = contentHash,
         )
         write(item)
         return item
@@ -114,6 +128,11 @@ class Outbox(private val dir: File) {
     private fun jsonName(item: OutboxItem) = baseName(item.createdAt, item.id) + ".json"
 
     private companion object {
+        fun sha256Hex(bytes: ByteArray): String =
+            MessageDigest.getInstance("SHA-256")
+                .digest(bytes)
+                .joinToString("") { "%02x".format(it) }
+
         fun baseName(createdAt: Long, id: String) =
             "%016d-%s".format(createdAt, id.take(8))
 

--- a/android/app/src/main/java/org/polybrain/tasks/health/data/OutboxItem.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/OutboxItem.kt
@@ -30,6 +30,10 @@ data class OutboxItem(
     // Photos only:
     val contentType: String? = null,
     val photoFile: String? = null,
+    // Hex SHA-256 of the photo bytes. Sent to the trip confirm endpoint as
+    // `content_hash` so the server dedups the same image within a trip, and
+    // used locally to skip enqueuing a photo already queued (see Outbox).
+    val contentHash: String? = null,
     // Photo resume guards: set together only after a successful S3 PUT, so a
     // confirm-failure retry skips straight to confirm and never re-uploads.
     val presignedKey: String? = null,

--- a/android/app/src/main/java/org/polybrain/tasks/health/data/Settings.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/Settings.kt
@@ -3,6 +3,7 @@ package org.polybrain.tasks.health.data
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -106,6 +107,22 @@ class Settings(private val context: Context) {
         }
     }
 
+    /**
+     * Whether location tracking is paused. Global (a single [TripLocationService]
+     * records one shared trail), decoupled from a trip being active: pausing
+     * stops sampling without dropping the trail; only finishing the last trip
+     * clears it. Reset to false when the last trip finishes.
+     */
+    suspend fun trackingPaused(): Boolean =
+        context.dataStore.data.first()[TRACKING_PAUSED] ?: false
+
+    suspend fun setTrackingPaused(paused: Boolean) {
+        context.dataStore.edit { prefs -> prefs[TRACKING_PAUSED] = paused }
+    }
+
+    val trackingPausedFlow: Flow<Boolean> =
+        context.dataStore.data.map { it[TRACKING_PAUSED] ?: false }
+
     private companion object {
         val SERVER_URL = stringPreferencesKey("server_url")
         val API_TOKEN = stringPreferencesKey("api_token")
@@ -113,5 +130,6 @@ class Settings(private val context: Context) {
         val LAST_SYNC_ERROR = stringPreferencesKey("last_sync_error")
         val SYNCED_BIKE_SESSION_IDS = stringSetPreferencesKey("synced_bike_session_ids")
         val TRACKED_STORY_IDS = stringSetPreferencesKey("tracked_story_ids")
+        val TRACKING_PAUSED = booleanPreferencesKey("tracking_paused")
     }
 }

--- a/android/app/src/main/java/org/polybrain/tasks/health/data/TasksApi.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/TasksApi.kt
@@ -228,6 +228,9 @@ data class PhotoConfirmRequest(
     @SerialName("published") val published: String,
     // Client-generated UUID for exactly-once delivery (see TripNoteRequest).
     @SerialName("idempotency_key") val idempotencyKey: String,
+    // Hex SHA-256 of the bytes; lets the server dedup the same image within a
+    // trip even across distinct idempotency keys (re-picks). Null if unknown.
+    @SerialName("content_hash") val contentHash: String? = null,
 )
 
 @Serializable

--- a/android/app/src/main/java/org/polybrain/tasks/health/location/TripTracker.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/location/TripTracker.kt
@@ -11,9 +11,13 @@ import org.polybrain.tasks.health.data.Settings
 /**
  * Drives [TripLocationService]'s lifecycle off the set of locally-tracked
  * trips ([Settings.trackedStoryIds]) — the analogue of `SyncScheduler` for the
- * outbox. The service runs whenever that set is non-empty; when it empties
- * (the last active trip stopped) the service is stopped and the breadcrumb log
- * is cleared.
+ * outbox. The service runs whenever that set is non-empty *and* tracking isn't
+ * paused ([Settings.trackingPaused]); when the set empties (the last active
+ * trip stopped) the service is stopped and the breadcrumb log is cleared.
+ *
+ * Pause/resume is decoupled from the trip lifecycle: pausing stops sampling but
+ * keeps the trail, so resuming continues the same log. The trail is dropped
+ * *only* on finish (the set going empty), never on pause.
  *
  * All entry points are `suspend` because they touch DataStore; call them from
  * a coroutine (the trip ViewModels already do).
@@ -31,6 +35,20 @@ object TripTracker {
     suspend fun stop(context: Context, storyId: Long) {
         val settings = Settings(context.applicationContext)
         settings.removeTrackedStoryId(storyId)
+        ensureService(context.applicationContext, settings)
+    }
+
+    /** Pause breadcrumb sampling without ending the trip or dropping the trail. */
+    suspend fun pause(context: Context) {
+        val settings = Settings(context.applicationContext)
+        settings.setTrackingPaused(true)
+        ensureService(context.applicationContext, settings)
+    }
+
+    /** Resume breadcrumb sampling, continuing the existing trail. */
+    suspend fun resume(context: Context) {
+        val settings = Settings(context.applicationContext)
+        settings.setTrackingPaused(false)
         ensureService(context.applicationContext, settings)
     }
 
@@ -52,21 +70,32 @@ object TripTracker {
 
     private suspend fun ensureService(appContext: Context, settings: Settings) {
         val intent = Intent(appContext, TripLocationService::class.java)
-        if (settings.trackedStoryIds().isNotEmpty()) {
-            // Without the fine-location grant the service could never promote
-            // itself to a location-type FGS (Android 14+ throws), and bailing
-            // out inside onStartCommand still trips the startForeground
-            // deadline (ForegroundServiceDidNotStartInTimeException) — so the
-            // service must not be started at all. The tracked ids are kept:
-            // the next ensureService call after the user grants location
-            // brings the service up.
-            if (!hasFineLocation(appContext)) return
-            ContextCompat.startForegroundService(appContext, intent)
-        } else {
+        if (settings.trackedStoryIds().isEmpty()) {
+            // No active trip owns the trail anymore — stop and drop it. Clearing
+            // the trail happens ONLY here (finish), never on pause. Reset the
+            // pause flag so the next trip starts sampling unpaused.
             appContext.stopService(intent)
-            // No active trip owns the trail anymore — drop it.
             BreadcrumbStore(appContext).clear()
+            if (settings.trackingPaused()) settings.setTrackingPaused(false)
+            return
         }
+        if (settings.trackingPaused()) {
+            // Trip still active, but the user paused sampling: stop the service
+            // (the notification clears; stopService cancels the START_STICKY
+            // restart) but keep the trail so resume continues it.
+            appContext.stopService(intent)
+            return
+        }
+        // Without the fine-location grant the service could never promote
+        // itself to a location-type FGS (Android 14+ throws), and bailing out
+        // inside onStartCommand still trips the startForeground deadline
+        // (ForegroundServiceDidNotStartInTimeException) — so the service must
+        // not be started at all. The tracked ids are kept: the next
+        // ensureService call after the user grants location brings it up. Note
+        // we don't stop a possibly-running service here — a permission-read
+        // race shouldn't tear down active tracking.
+        if (!hasFineLocation(appContext)) return
+        ContextCompat.startForegroundService(appContext, intent)
     }
 
     private fun hasFineLocation(context: Context): Boolean =

--- a/android/app/src/main/java/org/polybrain/tasks/health/sync/OutboxDrainer.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/sync/OutboxDrainer.kt
@@ -130,6 +130,7 @@ object OutboxDrainer {
                     contentType = contentType,
                     published = current.published,
                     idempotencyKey = current.id,
+                    contentHash = current.contentHash,
                 )
             )
         } else {

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/photo/AddPhotoViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/photo/AddPhotoViewModel.kt
@@ -180,8 +180,13 @@ class AddPhotoViewModel(application: Application) : AndroidViewModel(application
                     // storyId = null -> delivered through the storyless endpoints.
                     outbox.enqueuePhoto(null, comment, published, contentType, bytes)
                 }
-                watched = watched + item.id
-                SyncScheduler.drainOutbox(getApplication())
+                // Null means an identical image is already queued (deduped by
+                // content hash) — the existing copy is already watched, so
+                // there's nothing new to deliver.
+                if (item != null) {
+                    watched = watched + item.id
+                    SyncScheduler.drainOutbox(getApplication())
+                }
             } catch (e: CancellationException) {
                 throw e
             } catch (t: Throwable) {

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripDetailScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripDetailScreen.kt
@@ -85,11 +85,21 @@ fun TripDetailScreen(
     val shareOpen by vm.shareDialogOpen.collectAsState()
     val shareBusy by vm.shareBusy.collectAsState()
 
+    val trackingPaused by vm.trackingPaused.collectAsState()
+
     LaunchedEffect(storyId) { vm.load(storyId) }
 
+    // Multi-select: one photo opens the note dialog (unchanged); two or more
+    // upload directly with no dialog, each getting its location from the track.
     val photoPicker = rememberLauncherForActivityResult(
-        ActivityResultContracts.PickVisualMedia(),
-    ) { uri -> if (uri != null) vm.openAddPhoto(uri) }
+        ActivityResultContracts.PickMultipleVisualMedia(),
+    ) { uris ->
+        when {
+            uris.isEmpty() -> Unit
+            uris.size == 1 -> vm.openAddPhoto(uris.first())
+            else -> vm.sendPhotosDirect(uris)
+        }
+    }
 
     val s = story
     // Pick "HH:mm" vs "yyyy-MM-dd HH:mm" once for this render, based on
@@ -109,8 +119,12 @@ fun TripDetailScreen(
                     title = s.title,
                     startedIso = s.started,
                     stoppedIso = s.stopped,
+                    trackingPaused = trackingPaused,
                     onRename = vm::openRename,
                     onShare = vm::openShare,
+                    onTogglePause = {
+                        if (trackingPaused) vm.resumeTracking() else vm.pauseTracking()
+                    },
                     onStop = vm::stop,
                 )
             }
@@ -321,8 +335,10 @@ private fun TripHeader(
     title: String,
     startedIso: String,
     stoppedIso: String?,
+    trackingPaused: Boolean,
     onRename: () -> Unit,
     onShare: () -> Unit,
+    onTogglePause: () -> Unit,
     onStop: () -> Unit,
 ) {
     var menuOpen by remember { mutableStateOf(false) }
@@ -362,6 +378,20 @@ private fun TripHeader(
                         },
                     )
                     if (stoppedIso == null) {
+                        DropdownMenuItem(
+                            text = {
+                                Text(
+                                    stringResource(
+                                        if (trackingPaused) R.string.trip_detail_resume_tracking
+                                        else R.string.trip_detail_pause_tracking
+                                    )
+                                )
+                            },
+                            onClick = {
+                                menuOpen = false
+                                onTogglePause()
+                            },
+                        )
                         DropdownMenuItem(
                             text = { Text(stringResource(R.string.trip_detail_stop)) },
                             onClick = {

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripDetailViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/trip/TripDetailViewModel.kt
@@ -115,6 +115,15 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
     private val _shareBusy = MutableStateFlow(false)
     val shareBusy: StateFlow<Boolean> = _shareBusy.asStateFlow()
 
+    /**
+     * Whether location tracking is paused (global — see [Settings.trackingPaused]).
+     * The header toggle reads this to show "Pause"/"Resume".
+     */
+    val trackingPaused: StateFlow<Boolean> =
+        settings.trackingPausedFlow.stateIn(
+            viewModelScope, SharingStarted.WhileSubscribed(5_000), false
+        )
+
     private var storyId: Long = -1
 
     init {
@@ -275,6 +284,56 @@ class TripDetailViewModel(application: Application) : AndroidViewModel(applicati
                 _error.value = t.message ?: t.javaClass.simpleName
             }
         }
+    }
+
+    /**
+     * Enqueue several picked photos at once with no dialog (the multi-pick
+     * path). Each photo's location is resolved from the trip's recorded track
+     * at its capture time — the same source as the single-photo "Save with
+     * location" — and attached when a trusted fix exists, otherwise the photo
+     * is sent without a `#poi` line.
+     */
+    fun sendPhotosDirect(uris: List<Uri>) {
+        val story = _story.value ?: return
+        if (story.stopped != null) return
+        viewModelScope.launch {
+            val resolver = getApplication<Application>().contentResolver
+            // Read the trail once — all() re-parses the whole NDJSON file per call.
+            val crumbs = withContext(Dispatchers.IO) { breadcrumbStore.all() }
+            // Sequential on purpose: Outbox's content-hash skip dedups a batch
+            // only if each item is written before the next is checked, and a
+            // serial loop avoids holding every image in memory at once.
+            for (uri in uris) {
+                try {
+                    val contentType = resolver.getType(uri) ?: "image/jpeg"
+                    val bytes = withContext(Dispatchers.IO) {
+                        resolver.openInputStream(uri)?.use { it.readBytes() }
+                    } ?: continue
+                    val captureMs = withContext(Dispatchers.IO) {
+                        captureMillisFor(resolver, uri) ?: System.currentTimeMillis()
+                    }
+                    val fix = PhotoLocationResolver.resolve(crumbs, captureMs)
+                    val comment = composeComment(fix, "")
+                    val published = withContext(Dispatchers.IO) { captureTimeFor(resolver, uri) }
+                    withContext(Dispatchers.IO) {
+                        outbox.enqueuePhoto(story.id, comment, published, contentType, bytes)
+                    }
+                } catch (t: Throwable) {
+                    _error.value = t.message ?: t.javaClass.simpleName
+                }
+            }
+            refreshPending()
+            SyncScheduler.drainOutbox(getApplication())
+        }
+    }
+
+    /** Pause/resume the global breadcrumb tracking (independent of the trip). */
+    fun pauseTracking() {
+        viewModelScope.launch { TripTracker.pause(getApplication()) }
+    }
+
+    fun resumeTracking() {
+        viewModelScope.launch { TripTracker.resume(getApplication()) }
     }
 
     /** Re-queue a permanently-failed item for another delivery attempt. */

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -19,6 +19,8 @@
     <string name="trip_detail_add_note">Add note</string>
     <string name="trip_detail_add_photo">Add photo</string>
     <string name="trip_detail_stop">Stop trip</string>
+    <string name="trip_detail_pause_tracking">Pause location tracking</string>
+    <string name="trip_detail_resume_tracking">Resume location tracking</string>
     <string name="trip_detail_empty">No notes yet — tap Add note to record one.</string>
     <string name="trip_detail_rename">Rename</string>
     <string name="trip_detail_rename_title">Rename trip</string>

--- a/android/app/src/test/java/org/polybrain/tasks/health/data/OutboxTest.kt
+++ b/android/app/src/test/java/org/polybrain/tasks/health/data/OutboxTest.kt
@@ -40,7 +40,7 @@ class OutboxTest {
     @Test
     fun `enqueuePhoto writes the photo bytes alongside the item`() {
         val bytes = byteArrayOf(1, 2, 3, 4, 5)
-        val item = outbox.enqueuePhoto(3L, "caption", "2026-06-06T10:00:00Z", "image/jpeg", bytes)
+        val item = outbox.enqueuePhoto(3L, "caption", "2026-06-06T10:00:00Z", "image/jpeg", bytes)!!
         assertTrue(item.isPhoto)
         assertEquals("image/jpeg", item.contentType)
         assertTrue(outbox.photoFile(item)!!.name.endsWith(".jpg"))
@@ -68,7 +68,7 @@ class OutboxTest {
     @Test
     fun `enqueuePhoto with null story is a standalone photo`() {
         val bytes = byteArrayOf(4, 2)
-        val item = outbox.enqueuePhoto(null, "cap", "2026-06-06T10:00:00Z", "image/jpeg", bytes)
+        val item = outbox.enqueuePhoto(null, "cap", "2026-06-06T10:00:00Z", "image/jpeg", bytes)!!
         assertNull(item.storyId)
         val reloaded = outbox.all().single()
         assertNull(reloaded.storyId)
@@ -82,7 +82,7 @@ class OutboxTest {
     fun `standalone returns only storyless items`() {
         outbox.enqueueNote(1L, "trip note", "t")
         outbox.enqueuePhoto(1L, "trip photo", "t", "image/jpeg", byteArrayOf(1))
-        val solo = outbox.enqueuePhoto(null, "standalone", "t", "image/jpeg", byteArrayOf(2))
+        val solo = outbox.enqueuePhoto(null, "standalone", "t", "image/jpeg", byteArrayOf(2))!!
         assertEquals(listOf(solo.id), outbox.standalone().map { it.id })
     }
 
@@ -99,7 +99,7 @@ class OutboxTest {
 
     @Test
     fun `remove deletes the json and the photo file`() {
-        val item = outbox.enqueuePhoto(1L, "c", "t", "image/png", byteArrayOf(9))
+        val item = outbox.enqueuePhoto(1L, "c", "t", "image/png", byteArrayOf(9))!!
         val photo = outbox.photoFile(item)!!
         assertTrue(photo.exists())
         outbox.remove(item)
@@ -111,5 +111,36 @@ class OutboxTest {
     fun `photoBytes is null for a note`() {
         val item = outbox.enqueueNote(1L, "x", "t")
         assertNull(outbox.photoBytes(item))
+    }
+
+    @Test
+    fun `enqueuePhoto skips an identical image already queued for the story`() {
+        val bytes = byteArrayOf(1, 2, 3)
+        val first = outbox.enqueuePhoto(1L, "a", "t1", "image/jpeg", bytes)
+        // Same bytes -> same content hash -> deduped (returns null, writes nothing).
+        val second = outbox.enqueuePhoto(1L, "b", "t2", "image/jpeg", bytes)
+        assertTrue(first != null)
+        assertNull(second)
+        assertEquals(1, outbox.forStory(1L).size)
+    }
+
+    @Test
+    fun `enqueuePhoto dedups per scope, not across stories`() {
+        val bytes = byteArrayOf(7, 8, 9)
+        assertTrue(outbox.enqueuePhoto(1L, "a", "t", "image/jpeg", bytes) != null)
+        // Same image, different trip -> allowed.
+        assertTrue(outbox.enqueuePhoto(2L, "a", "t", "image/jpeg", bytes) != null)
+        assertEquals(1, outbox.forStory(1L).size)
+        assertEquals(1, outbox.forStory(2L).size)
+    }
+
+    @Test
+    fun `enqueuePhoto re-enqueues an image whose prior copy failed permanently`() {
+        val bytes = byteArrayOf(5, 5, 5)
+        val first = outbox.enqueuePhoto(1L, "a", "t", "image/jpeg", bytes)!!
+        outbox.update(first.copy(failedPermanently = true))
+        // A permanently-failed copy must not block a fresh attempt.
+        val retry = outbox.enqueuePhoto(1L, "a", "t", "image/jpeg", bytes)
+        assertTrue(retry != null)
     }
 }

--- a/android/app/src/test/java/org/polybrain/tasks/health/sync/OutboxDrainerTest.kt
+++ b/android/app/src/test/java/org/polybrain/tasks/health/sync/OutboxDrainerTest.kt
@@ -77,7 +77,7 @@ class OutboxDrainerTest {
 
     @Test
     fun `photo first send presigns puts confirms and marks uploaded`() = runTest {
-        val item = outbox.enqueuePhoto(2L, "cap", "t", "image/jpeg", byteArrayOf(1, 2, 3))
+        val item = outbox.enqueuePhoto(2L, "cap", "t", "image/jpeg", byteArrayOf(1, 2, 3))!!
         val api = FakeApi(presignKey = "trips/2/k.jpg", presignUrl = "https://put/x")
         var putCalls = 0
         val put = OutboxDrainer.PhotoPutter { url, _, _ ->
@@ -97,7 +97,7 @@ class OutboxDrainerTest {
 
     @Test
     fun `photo retry skips re-upload when already uploaded`() = runTest {
-        val base = outbox.enqueuePhoto(2L, "cap", "t", "image/jpeg", byteArrayOf(1, 2, 3))
+        val base = outbox.enqueuePhoto(2L, "cap", "t", "image/jpeg", byteArrayOf(1, 2, 3))!!
         // Simulate a previous run that uploaded but failed at confirm.
         val resumed = base.copy(uploaded = true, presignedKey = "trips/2/already.jpg")
         outbox.update(resumed)
@@ -114,7 +114,7 @@ class OutboxDrainerTest {
     @Test
     fun `standalone photo presigns and confirms via storyless endpoints`() = runTest {
         // storyId = null marks a standalone photo (a PhotoTaken with no trip).
-        val item = outbox.enqueuePhoto(null, "cap", "t", "image/jpeg", byteArrayOf(9))
+        val item = outbox.enqueuePhoto(null, "cap", "t", "image/jpeg", byteArrayOf(9))!!
         val api = FakeApi(presignKey = "photos/7/k.jpg", presignUrl = "https://put/s")
         var putCalls = 0
         val put = OutboxDrainer.PhotoPutter { url, _, _ ->
@@ -159,7 +159,7 @@ class OutboxDrainerTest {
 
     @Test
     fun `missing photo bytes is permanent not an endless retry`() = runTest {
-        val item = outbox.enqueuePhoto(1L, "c", "t", "image/jpeg", byteArrayOf(7))
+        val item = outbox.enqueuePhoto(1L, "c", "t", "image/jpeg", byteArrayOf(7))!!
         // Delete the bytes file but keep the item (simulates corruption).
         outbox.photoFile(item)!!.delete()
         val api = FakeApi()

--- a/tasks/apps/tree/migrations/0075_photoadded_content_hash.py
+++ b/tasks/apps/tree/migrations/0075_photoadded_content_hash.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("tree", "0074_weight_habit"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="photoadded",
+            name="content_hash",
+            field=models.CharField(blank=True, db_index=True, max_length=64, null=True),
+        ),
+    ]

--- a/tasks/apps/tree/models.py
+++ b/tasks/apps/tree/models.py
@@ -599,6 +599,13 @@ class PhotoAdded(JournalAdded):
     width = models.PositiveIntegerField(null=True, blank=True)
     height = models.PositiveIntegerField(null=True, blank=True)
 
+    # Hex SHA-256 of the original bytes, supplied by the client. Drives
+    # per-trip dedup (see services.trips.add_trip_photo) so re-picking the same
+    # image doesn't create a second photo. Plain (non-unique) index on purpose:
+    # dedup is scoped to a Story, so the same image may legitimately appear in
+    # more than one trip. Null on legacy rows and standalone photos.
+    content_hash = models.CharField(max_length=64, null=True, blank=True, db_index=True)
+
     template = "tree/events/journal_added.html"
 
     is_photo = True

--- a/tasks/apps/tree/services/trips/operations.py
+++ b/tasks/apps/tree/services/trips/operations.py
@@ -182,7 +182,14 @@ def presign_photo_upload(user, story_id, content_type, web=False):
 
 @transaction.atomic
 def add_trip_photo(
-    user, story_id, key, comment, content_type, published=None, idempotency_key=None
+    user,
+    story_id,
+    key,
+    comment,
+    content_type,
+    published=None,
+    idempotency_key=None,
+    content_hash=None,
 ):
     """Confirm an uploaded photo: create a PhotoAdded linked to ``story`` and
     run it through the journalling pipeline (so a ``#poi`` line in ``comment``
@@ -195,12 +202,27 @@ def add_trip_photo(
     that already produced a photo returns that same photo (checked before the
     stopped/object existence guards, so a re-delivered confirm succeeds even
     after the trip stopped or the S3 object was swept).
+
+    ``content_hash`` (hex SHA-256 of the original bytes) dedups by *content*
+    within this trip: re-picking the same image — a fresh ``idempotency_key``
+    each time — returns the photo already in the story instead of creating a
+    duplicate. Scoped to the story (never global) so the same image can still
+    be added to a different trip, and so it can't match another user's photo.
+    Checked before the stopped/object guards for the same reason as the
+    idempotency lookup, which also short-circuits the EXIF download + S3 HEAD.
     """
     story = _get_owned_story(user, story_id)
 
     existing = existing_event(PhotoAdded, idempotency_key)
     if existing is not None:
         return existing
+
+    if content_hash:
+        dup = PhotoAdded.objects.filter(
+            story_entry__story=story, content_hash=content_hash
+        ).first()
+        if dup is not None:
+            return dup
 
     if story.stopped is not None:
         raise StoryStoppedError(f"Story #{story_id} is stopped; cannot add photos.")
@@ -226,6 +248,7 @@ def add_trip_photo(
                 content_type=content_type,
                 published=captured or published or timezone.now(),
                 idempotency_key=idempotency_key,
+                content_hash=content_hash,
             )
             process_journal_entry(photo, story=story)
     except IntegrityError:

--- a/tasks/apps/tree/tests/test_photo_api.py
+++ b/tasks/apps/tree/tests/test_photo_api.py
@@ -49,6 +49,7 @@ class PhotoAPITestCase(APITestCase):
         content_type="image/jpeg",
         published=PUB_AT,
         idempotency_key=None,
+        content_hash=None,
     ):
         payload = {
             "story_id": story_id,
@@ -59,6 +60,8 @@ class PhotoAPITestCase(APITestCase):
         }
         if idempotency_key is not None:
             payload["idempotency_key"] = idempotency_key
+        if content_hash is not None:
+            payload["content_hash"] = content_hash
         return self.client.post(
             reverse("android-trip-photo-confirm"), payload, format="json"
         )
@@ -129,6 +132,34 @@ class PhotoAPITestCase(APITestCase):
         self.assertEqual(first.data["photo_id"], second.data["photo_id"])
         self.assertEqual(PhotoAdded.objects.filter(idempotency_key="ph-123").count(), 1)
         self.assertEqual(StoryEvent.objects.filter(story=self.story).count(), 1)
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_confirm_content_hash_dedupes_within_trip(self, _exists):
+        # Re-picking the same image (same content_hash) with a fresh key and
+        # idempotency_key returns the existing photo — one PhotoAdded + link.
+        first = self._confirm(
+            self.story.pk,
+            f"trips/{self.user.pk}/{self.story.pk}/one.jpg",
+            idempotency_key="k1",
+            content_hash="deadbeef",
+        )
+        second = self._confirm(
+            self.story.pk,
+            f"trips/{self.user.pk}/{self.story.pk}/two.jpg",
+            idempotency_key="k2",
+            content_hash="deadbeef",
+        )
+        self.assertEqual(first.data["photo_id"], second.data["photo_id"])
+        self.assertEqual(PhotoAdded.objects.filter(content_hash="deadbeef").count(), 1)
+        self.assertEqual(StoryEvent.objects.filter(story=self.story).count(), 1)
+
+    def test_confirm_rejects_non_string_content_hash(self):
+        r = self._confirm(
+            self.story.pk,
+            f"trips/{self.user.pk}/{self.story.pk}/abc.jpg",
+            content_hash=123,
+        )
+        self.assertEqual(r.status_code, status.HTTP_400_BAD_REQUEST)
 
     @mock.patch(f"{STORAGE}.object_exists", return_value=False)
     def test_confirm_missing_object_409(self, _exists):

--- a/tasks/apps/tree/tests/test_trip_service.py
+++ b/tasks/apps/tree/tests/test_trip_service.py
@@ -409,6 +409,88 @@ class TripPhotoServiceTestCase(TestCase):
         self.assertEqual(StoryEvent.objects.filter(story=story, event=first).count(), 1)
 
     @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_add_trip_photo_content_hash_dedups_within_trip(self, _exists):
+        # Re-picking the same image (same content_hash) — a fresh key and
+        # idempotency_key each time — returns the photo already in the trip
+        # instead of creating a second one.
+        story = start_trip(self.alice)
+        first = add_trip_photo(
+            self.alice,
+            story.pk,
+            key=f"trips/{self.alice.pk}/{story.pk}/one.jpg",
+            comment="sunset",
+            content_type="image/jpeg",
+            published=timezone.now(),
+            idempotency_key="key-1",
+            content_hash="abc123",
+        )
+        second = add_trip_photo(
+            self.alice,
+            story.pk,
+            key=f"trips/{self.alice.pk}/{story.pk}/two.jpg",
+            comment="sunset again",
+            content_type="image/jpeg",
+            published=timezone.now(),
+            idempotency_key="key-2",
+            content_hash="abc123",
+        )
+        self.assertEqual(first.pk, second.pk)
+        self.assertEqual(PhotoAdded.objects.filter(content_hash="abc123").count(), 1)
+        self.assertEqual(StoryEvent.objects.filter(story=story, event=first).count(), 1)
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_add_trip_photo_same_content_hash_different_trip_creates_distinct(
+        self, _exists
+    ):
+        # Dedup is scoped to a trip: the same image in a *different* trip is a
+        # new photo (and can't match another user's row either).
+        story_a = start_trip(self.alice)
+        story_b = start_trip(self.alice)
+        first = add_trip_photo(
+            self.alice,
+            story_a.pk,
+            key=f"trips/{self.alice.pk}/{story_a.pk}/a.jpg",
+            comment="x",
+            content_type="image/jpeg",
+            published=timezone.now(),
+            content_hash="dup",
+        )
+        second = add_trip_photo(
+            self.alice,
+            story_b.pk,
+            key=f"trips/{self.alice.pk}/{story_b.pk}/b.jpg",
+            comment="x",
+            content_type="image/jpeg",
+            published=timezone.now(),
+            content_hash="dup",
+        )
+        self.assertNotEqual(first.pk, second.pk)
+        self.assertEqual(PhotoAdded.objects.filter(content_hash="dup").count(), 2)
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
+    def test_add_trip_photo_without_content_hash_allows_duplicates(self, _exists):
+        # A null content_hash must never collapse distinct photos (the filter
+        # would otherwise match every legacy null-hash row).
+        story = start_trip(self.alice)
+        first = add_trip_photo(
+            self.alice,
+            story.pk,
+            key=f"trips/{self.alice.pk}/{story.pk}/one.jpg",
+            comment="x",
+            content_type="image/jpeg",
+            published=timezone.now(),
+        )
+        second = add_trip_photo(
+            self.alice,
+            story.pk,
+            key=f"trips/{self.alice.pk}/{story.pk}/two.jpg",
+            comment="y",
+            content_type="image/jpeg",
+            published=timezone.now(),
+        )
+        self.assertNotEqual(first.pk, second.pk)
+
+    @mock.patch(f"{STORAGE}.object_exists", return_value=True)
     def test_add_trip_photo_with_poi_creates_habittracked(self, _exists):
         story = start_trip(self.alice)
         key = f"trips/{self.alice.pk}/{story.pk}/abc.jpg"

--- a/tasks/apps/tree/views_android_trip.py
+++ b/tasks/apps/tree/views_android_trip.py
@@ -353,6 +353,9 @@ class AndroidTripPhotoConfirmView(APIView):
         idempotency_key = request.data.get("idempotency_key")
         if idempotency_key is not None and not isinstance(idempotency_key, str):
             return _bad_request("idempotency_key must be a string")
+        content_hash = request.data.get("content_hash")
+        if content_hash is not None and not isinstance(content_hash, str):
+            return _bad_request("content_hash must be a string")
         try:
             photo = add_trip_photo(
                 request.user,
@@ -362,6 +365,7 @@ class AndroidTripPhotoConfirmView(APIView):
                 content_type=content_type,
                 published=published,
                 idempotency_key=idempotency_key,
+                content_hash=content_hash,
             )
         except StoryNotFoundError:
             return _not_found()


### PR DESCRIPTION
Three improvements to the Android Trips feature and its Django API.

## 1. Photo dedup by content hash
Re-picking the same image no longer creates a second photo. The client sends a hex SHA-256 of the image bytes as `content_hash`; `add_trip_photo` returns the existing photo when one with the same hash is already in the story.

- Scoped **per-trip** (`story_entry__story=story`) — cross-user / cross-trip safe, and it deliberately does **not** reuse the global `idempotency_key` unique column (which would collide across users). The check is guarded by `if content_hash:` so a null hash never collapses legacy rows.
- New nullable, non-unique indexed column `PhotoAdded.content_hash` + migration `0075_photoadded_content_hash`.
- Client also **skips enqueuing** an image already queued for the same scope (excluding permanently-failed copies), avoiding a wasted S3 upload. `Outbox.enqueuePhoto` now returns a nullable item.
- Standalone photos get the client-side skip only (no server change).

## 2. Multiple photos without notes
The picker is now `PickMultipleVisualMedia`:
- 1 photo → the existing note dialog (unchanged).
- 2+ photos → `sendPhotosDirect(uris)` uploads them straight to the outbox with no dialog, each resolving its location from the recorded trip track at capture time (breadcrumbs read once; sequential loop so the batch dedup and memory stay sane).

## 3. Pause/resume location tracking, decoupled from the trip
- New global, persisted `Settings.trackingPaused`; `TripTracker.pause/resume`.
- `ensureService` rewritten: the trail is cleared **only on finish** (tracked set empty, which also resets the pause flag); pausing stops the foreground service but **keeps** the trail so resume continues it.
- Exposed as a "Pause/Resume location tracking" item in the trip header menu for active trips.
- Auto-start-on-start and drop-on-finish are unchanged.

## Design notes (defaults, easy to flip)
Dedup is **per-trip**; bulk photos **attach location when available**; pause is **global** (single shared breadcrumb service).

## Tests
- Backend (ran in Docker): `python manage.py test tasks.apps.tree` → **323 passed**, including new per-trip dedup, cross-trip-distinct, null-allows-duplicates (service) and dedup + validation (API) cases.
- Android: `OutboxTest` skip/scope/failed-retry cases added; `OutboxTest`/`OutboxDrainerTest` updated for the now-nullable `enqueuePhoto`. Not run here — Android can't be built from the CLI (no gradle wrapper); verify on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)