### PR TITLE
ci: skip backend tests for frontend asset-only changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,25 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - 'docker/**'
-      - '**.md'
-      - 'android/**'
-      - 'cli/**'
+    # Whitelist (paths) rather than blacklist (paths-ignore) so that frontend
+    # asset changes under tasks/assets/** never trigger a backend test run.
+    paths:
+      # Backend Python: apps, settings, templates, fixtures, migrations
+      - 'tasks/**'
+      # ...but not the frontend asset sources built by the "Build assets" step
+      - '!tasks/assets/**'
+      # Python dependencies and project config
+      - 'requirements/**'
+      - 'manage.py'
+      - 'manage.dist.py'
+      - 'pytest.ini'
+      - 'pyproject.toml'
+      # Frontend build inputs the test job's "Build assets" step depends on
+      - 'package.json'
+      - 'package-lock.json'
+      - 'rsbuild.config.ts'
+      # The workflow definition itself
+      - '.github/workflows/test.yml'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Frontend asset changes were triggering the full backend test workflow (Postgres + Django test suite). This switches `test.yml` from a `paths-ignore` **blacklist** to a `paths` **whitelist** scoped to backend files.

The key change is `tasks/**` followed by `!tasks/assets/**` — GitHub evaluates path patterns in order, so a change under `tasks/assets/` matches the positive `tasks/**` and is then negated out, skipping the run. Real backend changes still trigger it.

### Now triggers the test job
- `tasks/**` (apps, settings, templates, fixtures, migrations) — **except** `tasks/assets/**`
- `requirements/**`, `manage.py`, `manage.dist.py`, `pytest.ini`, `pyproject.toml`
- `package.json`, `package-lock.json`, `rsbuild.config.ts` — build inputs the test job's "Build assets" step depends on, so dependency/build-config breaks are still caught at PR time
- `.github/workflows/test.yml` itself

### No longer triggers the test job
- Frontend asset-only changes under `tasks/assets/**` (Vue/JS/SCSS/images)

### Left unchanged
- `android-test.yml` — already a proper `android/**` whitelist
- `deploy.yml` — intentionally still deploys on asset changes (assets must be rebuilt + collected + rsynced to prod)

## Notes
- **Whitelist trade-off**: a backend-relevant file at a *new* top-level path won't trigger tests unless added to the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)