### PR TITLE
feat(android): quick-add to board backlog from picker

### DIFF
--- a/android/app/src/main/java/org/polybrain/tasks/health/data/TasksApi.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/data/TasksApi.kt
@@ -114,6 +114,20 @@ data class BoardItemsResponse(
     @SerialName("items") val items: List<BoardItem> = emptyList(),
 )
 
+// Append a free-typed task to the caller's current board. `thread-name` is
+// intentionally omitted: the server defaults it to the user's board thread
+// (the same board /board/items/ returns), so the client never names the board.
+@Serializable
+data class BoardAppendRequest(
+    @SerialName("text") val text: String,
+)
+
+// boards/append/ echoes the full updated board (BoardSerializer). The client
+// only needs to know the call succeeded, so this field-less type discards the
+// body (the lenient Json drops all unknown keys).
+@Serializable
+class BoardAppendResponse
+
 @Serializable
 data class PlanItem(
     @SerialName("id") val id: Long,
@@ -312,6 +326,13 @@ interface TasksApi {
     // "add from board" picker. Date-independent.
     @GET("api/v1/android/board/items/")
     suspend fun listBoardItems(): BoardItemsResponse
+
+    // Non-API web endpoint (no /api/v1/ prefix; token auth via DRF defaults,
+    // like plans/ and habit/track/). Appends a task to the caller's current
+    // board's backlog — for capturing something to do later, not scheduling it
+    // on a day. The server resolves which board from the profile default.
+    @POST("boards/append/")
+    suspend fun appendBoardTask(@Body body: BoardAppendRequest): BoardAppendResponse
 
     @POST("api/v1/android/task/add/")
     suspend fun addTodayTask(@Body body: TaskTextRequest): OkResponse

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/BoardPickerScreen.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/BoardPickerScreen.kt
@@ -21,12 +21,16 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -97,6 +101,11 @@ fun BoardPickerScreen(
 
         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
 
+        // Append a new task straight onto this board's backlog — for capturing
+        // something to do later, distinct from the checkbox selection below
+        // (which schedules existing board items onto the chosen day).
+        AddTaskRow(onAdd = vm::addTask, enabled = configured)
+
         Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
             when {
                 !configured -> CenteredMessage(stringResource(R.string.today_not_configured))
@@ -140,6 +149,37 @@ fun BoardPickerScreen(
             ) {
                 Text(stringResource(R.string.board_picker_cancel))
             }
+        }
+    }
+}
+
+// Quick-add row mirroring TodayScreen's AddTaskRow: a text field plus an Add
+// button. The draft is cleared as soon as Add is tapped (the ViewModel reloads
+// the board on success, or surfaces an error banner on failure).
+@Composable
+private fun AddTaskRow(onAdd: (String) -> Unit, enabled: Boolean) {
+    var draft by remember { mutableStateOf("") }
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(bottom = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        OutlinedTextField(
+            value = draft,
+            onValueChange = { draft = it },
+            placeholder = { Text(stringResource(R.string.today_add_hint)) },
+            singleLine = true,
+            enabled = enabled,
+            modifier = Modifier.weight(1f),
+        )
+        Button(
+            onClick = {
+                onAdd(draft)
+                draft = ""
+            },
+            enabled = enabled && draft.isNotBlank(),
+        ) {
+            Text(stringResource(R.string.today_add_button))
         }
     }
 }

--- a/android/app/src/main/java/org/polybrain/tasks/health/ui/BoardPickerViewModel.kt
+++ b/android/app/src/main/java/org/polybrain/tasks/health/ui/BoardPickerViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import org.polybrain.tasks.health.data.BoardAppendRequest
 import org.polybrain.tasks.health.data.BoardItem
 import org.polybrain.tasks.health.data.Settings
 import org.polybrain.tasks.health.data.SettingsSnapshot
@@ -126,6 +127,35 @@ class BoardPickerViewModel(application: Application) : AndroidViewModel(applicat
             } else {
                 _error.value = "Failed to add ${failures.size} of ${texts.size} item(s)."
                 _selected.value = failures.toSet()
+            }
+        }
+    }
+
+    /**
+     * Append a free-typed task to the board the picker is showing, via the
+     * shared /boards/append/ endpoint. Unlike [addSelected] (which schedules
+     * existing board items onto a given day's Plan), this only adds the line to
+     * the board's backlog — for capturing something to tackle later rather than
+     * pinning it to a day. The server resolves which board from the user's
+     * profile, so no thread or date is sent. On success the board list is
+     * reloaded so the new line appears; failures surface via [error].
+     */
+    fun addTask(text: String) {
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) return
+        viewModelScope.launch {
+            val snapshot = settings.snapshot()
+            _configured.value = snapshot.isConfigured
+            if (!snapshot.isConfigured) {
+                _error.value = "Configure server URL and API token first."
+                return@launch
+            }
+            try {
+                buildApi(snapshot).appendBoardTask(BoardAppendRequest(trimmed))
+                _error.value = null
+                reload()
+            } catch (t: Throwable) {
+                _error.value = t.message ?: t.javaClass.simpleName
             }
         }
     }

--- a/android/app/src/test/java/org/polybrain/tasks/health/sync/OutboxDrainerTest.kt
+++ b/android/app/src/test/java/org/polybrain/tasks/health/sync/OutboxDrainerTest.kt
@@ -11,6 +11,8 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.polybrain.tasks.health.data.BoardAppendRequest
+import org.polybrain.tasks.health.data.BoardAppendResponse
 import org.polybrain.tasks.health.data.BoardItemsResponse
 import org.polybrain.tasks.health.data.HabitKeyword
 import org.polybrain.tasks.health.data.HealthDataResponse
@@ -223,6 +225,7 @@ class OutboxDrainerTest {
         override suspend fun healthData(): HealthDataResponse = nope()
         override suspend fun listTodayTasks(date: String): TodayTasksResponse = nope()
         override suspend fun listBoardItems(): BoardItemsResponse = nope()
+        override suspend fun appendBoardTask(body: BoardAppendRequest): BoardAppendResponse = nope()
         override suspend fun addTodayTask(body: TaskTextRequest): OkResponse = nope()
         override suspend fun completeTodayTask(body: TaskCompleteRequest): OkResponse = nope()
         override suspend fun deleteTodayTask(body: TaskTextRequest): OkResponse = nope()

--- a/tasks/apps/tree/board_operations.py
+++ b/tasks/apps/tree/board_operations.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.shortcuts import get_object_or_404
 
-from .models import Board, Thread
+from .models import Board, Profile, Thread
 
 
 def create_task_item(text):
@@ -38,3 +38,25 @@ def add_task_to_board(text, thread_name):
         board.save()
         return board
     return None
+
+
+def board_thread_for(user):
+    """The thread whose latest board acts as the user's 'current board':
+    ``Profile.default_board_thread`` when set, otherwise the Daily thread as a
+    fallback so callers never silently no-op on users without a configured
+    default.
+    """
+    profile = (
+        Profile.objects.select_related("default_board_thread").filter(user=user).first()
+    )
+    if profile and profile.default_board_thread is not None:
+        return profile.default_board_thread
+    return Thread.objects.get(name="Daily")
+
+
+def current_board_thread_name(user):
+    """Name of the user's current board thread (see :func:`board_thread_for`).
+    Lets callers name that board when appending a task to it via
+    ``boards/append/``, which is keyed by thread name.
+    """
+    return board_thread_for(user).name

--- a/tasks/apps/tree/services/today/operations.py
+++ b/tasks/apps/tree/services/today/operations.py
@@ -12,16 +12,8 @@ from typing import Optional
 from django.db import transaction
 from django.utils import timezone
 
-from ...models import (
-    Board,
-    JournalAdded,
-    Plan,
-    Profile,
-    Reflection,
-    Story,
-    StoryEvent,
-    Thread,
-)
+from ...board_operations import board_thread_for
+from ...models import Board, JournalAdded, Plan, Reflection, Story, StoryEvent, Thread
 from ..trips.operations import StoryNotFoundError, StoryStoppedError
 from . import board_tree, text_lines
 from .progress import parse_progress, render_progress
@@ -103,24 +95,8 @@ def _daily_thread():
     return Thread.objects.get(name="Daily")
 
 
-def _board_thread_for(user):
-    """The thread whose latest board acts as the user's 'current board'.
-
-    Uses Profile.default_board_thread when set; otherwise falls back to the
-    Daily thread so the operation never silently no-ops on users without a
-    configured default.
-    """
-    try:
-        profile = Profile.objects.select_related("default_board_thread").get(user=user)
-    except Profile.DoesNotExist:
-        return _daily_thread()
-    if profile.default_board_thread is not None:
-        return profile.default_board_thread
-    return _daily_thread()
-
-
 def _current_board(user):
-    thread = _board_thread_for(user)
+    thread = board_thread_for(user)
     board = Board.objects.filter(thread=thread).order_by("-date_started").first()
     if board is None:
         raise NoBoardError(

--- a/tasks/apps/tree/tests/test_board_append.py
+++ b/tasks/apps/tree/tests/test_board_append.py
@@ -1,0 +1,78 @@
+from django.contrib.auth import get_user_model
+
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APITestCase
+
+from ..models import Board, Profile, Thread
+
+APPEND_URL = "/boards/append/"
+
+
+def _texts(board):
+    """Root-level task texts on a board, in order."""
+    return [node.get("text") for node in board.state]
+
+
+class BoardAppendTestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        User = get_user_model()
+        cls.user = User.objects.create_user(username="phone", password="x")
+        cls.token = Token.objects.create(user=cls.user)
+        cls.daily = Thread.objects.create(name="Daily")
+        cls.weekly = Thread.objects.create(name="Weekly")
+        Profile.objects.create(user=cls.user, default_board_thread=cls.daily)
+        cls.daily_board = Board.objects.create(thread=cls.daily, state=[])
+        cls.weekly_board = Board.objects.create(thread=cls.weekly, state=[])
+
+    def setUp(self):
+        for board in (self.daily_board, self.weekly_board):
+            board.refresh_from_db()
+            board.state = []
+            board.save()
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+
+    def _append(self, payload):
+        return self.client.post(APPEND_URL, payload, format="json")
+
+    def test_no_thread_name_defaults_to_profile_board_thread(self):
+        response = self._append({"text": "buy milk"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.daily_board.refresh_from_db()
+        self.assertEqual(_texts(self.daily_board), ["buy milk"])
+        self.weekly_board.refresh_from_db()
+        self.assertEqual(_texts(self.weekly_board), [])
+
+    def test_default_follows_profile_default_board_thread(self):
+        Profile.objects.filter(user=self.user).update(default_board_thread=self.weekly)
+
+        response = self._append({"text": "quarterly review"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.weekly_board.refresh_from_db()
+        self.assertEqual(_texts(self.weekly_board), ["quarterly review"])
+        self.daily_board.refresh_from_db()
+        self.assertEqual(_texts(self.daily_board), [])
+
+    def test_explicit_thread_name_still_honored(self):
+        response = self._append({"text": "plan week", "thread-name": "Weekly"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.weekly_board.refresh_from_db()
+        self.assertEqual(_texts(self.weekly_board), ["plan week"])
+        self.daily_board.refresh_from_db()
+        self.assertEqual(_texts(self.daily_board), [])
+
+    def test_missing_text_is_rejected(self):
+        response = self._append({"thread-name": "Daily"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_no_board_for_thread_returns_conflict(self):
+        self.daily_board.delete()
+
+        response = self._append({"text": "orphan"})
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)

--- a/tasks/apps/tree/views_board_tasks.py
+++ b/tasks/apps/tree/views_board_tasks.py
@@ -8,7 +8,7 @@ from rest_framework import status, viewsets
 from rest_framework.decorators import api_view
 from rest_framework.response import Response as RestResponse
 
-from .board_operations import add_task_to_board
+from .board_operations import add_task_to_board, current_board_thread_name
 from .commit import calculate_changes_per_board, merge
 from .models import Board, BoardCommitted, Thread, default_state
 from .serializers import BoardSerializer, BoardSummary
@@ -86,13 +86,22 @@ def commit_board(request, id=None):
 def add_task(request):
     item = request.data
 
-    # XXX hackish
-    if "text" not in item or "thread-name" not in item:
-        return RestResponse(
-            {"errors": "no thread-name and text"}, status=status.HTTP_400_BAD_REQUEST
-        )
+    text = item.get("text")
+    if not text:
+        return RestResponse({"errors": "no text"}, status=status.HTTP_400_BAD_REQUEST)
 
-    board = add_task_to_board(item["text"], item["thread-name"])
+    # thread-name is optional: when omitted, append to the caller's current
+    # board — Profile.default_board_thread, or Daily as a fallback — which is
+    # the same board the Android picker shows. Explicit callers (e.g. the CLI's
+    # "text > Thread" syntax) keep naming the thread directly.
+    thread_name = item.get("thread-name") or current_board_thread_name(request.user)
+
+    board = add_task_to_board(text, thread_name)
+    if board is None:
+        return RestResponse(
+            {"errors": f"no board for thread {thread_name!r}"},
+            status=status.HTTP_409_CONFLICT,
+        )
     return RestResponse(BoardSerializer(board).data)
 
 


### PR DESCRIPTION
## What

Adds a quick-add row to the Android board picker (between the filter chips and the item list) that **appends a free-typed task to the board's backlog** via `boards/append/`. It captures something to do *later* — distinct from the checkbox multi-select below it, which schedules *existing* board items onto a chosen day.

The row mirrors `TodayScreen`'s `AddTaskRow` (text field + Add button, clears on tap); on success the picker reloads so the new line appears.

## How the board is chosen

The client never names the board. `boards/append/` now makes `thread-name` **optional** and defaults it server-side to the caller's current board — `Profile.default_board_thread`, or `Daily` as a fallback — which is exactly the board the picker (`board/items/`) already shows. Explicit callers (the CLI's `text > Thread` syntax) keep naming the thread directly and are unchanged.

Also hardens the endpoint: a `text`-required `400`, and a `409` when the resolved thread has no board.

## Refactor

The board-thread resolver moves into board services where it belongs:
- `board_operations.py` gains `board_thread_for(user)` and `current_board_thread_name(user)`.
- `today/operations.py` imports `board_thread_for` instead of keeping its own private `_board_thread_for` copy.

## Testing

- New `tests/test_board_append.py` — 5 cases: default → profile board thread, follows profile default, explicit `thread-name` honored, missing text → 400, no board → 409.
- Full tree suite: **328 passed** (`manage.py test tasks.apps.tree`).
- `manage.py check` clean (no circular import on the new `views_board_tasks → board_operations` / `today/operations → board_operations` edges).

⚠️ **Note:** `android/` has no gradle wrapper in this environment, so the Kotlin changes (`TasksApi`/`BoardPickerViewModel`/`BoardPickerScreen`) were verified by manual review, not compiled. Worth a local build before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)