### PR TITLE
fix(board): prevent stale tree model from erasing board state

### DIFF
--- a/tasks/apps/tree/tests/test_board_update_guard.py
+++ b/tasks/apps/tree/tests/test_board_update_guard.py
@@ -1,0 +1,62 @@
+from django.contrib.auth import get_user_model
+
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APITestCase
+
+from ..board_operations import create_task_item
+from ..models import Board, Thread
+
+
+class BoardUpdateEmptyStateGuardTestCase(APITestCase):
+    """PUT /boards/<id>/ must refuse to erase a board that still has more
+    than one item — an empty ``state`` from a client is almost always a
+    stale/broken tree serialization, not an intentional clear (which goes
+    through the commit endpoint).
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        User = get_user_model()
+        cls.user = User.objects.create_user(username="web", password="x")
+        cls.token = Token.objects.create(user=cls.user)
+        cls.daily = Thread.objects.create(name="Daily")
+
+    def setUp(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+
+    def _make_board(self, texts):
+        return Board.objects.create(
+            thread=self.daily, state=[create_task_item(t) for t in texts]
+        )
+
+    def _put_state(self, board, state):
+        return self.client.put(f"/boards/{board.id}/", {"state": state}, format="json")
+
+    def test_emptying_a_multi_item_board_is_rejected(self):
+        board = self._make_board(["water plants", "call bank"])
+
+        response = self._put_state(board, [])
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        board.refresh_from_db()
+        self.assertEqual(len(board.state), 2)
+
+    def test_emptying_a_single_item_board_is_allowed(self):
+        board = self._make_board(["water plants"])
+
+        response = self._put_state(board, [])
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        board.refresh_from_db()
+        self.assertEqual(board.state, [])
+
+    def test_non_empty_update_passes_through(self):
+        board = self._make_board(["water plants", "call bank"])
+        new_state = [create_task_item("only task left")]
+
+        response = self._put_state(board, new_state)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        board.refresh_from_db()
+        self.assertEqual([n["text"] for n in board.state], ["only task left"])

--- a/tasks/apps/tree/views_board_tasks.py
+++ b/tasks/apps/tree/views_board_tasks.py
@@ -30,6 +30,26 @@ class BoardViewSet(viewsets.ModelViewSet):
 
     serializer_class = BoardSerializer
 
+    def update(self, request, *args, **kwargs):
+        # A stale or broken client (e.g. a tree view that serialized an empty
+        # model) can PUT `state: []` and silently erase the whole board. An
+        # empty state is only plausible when the board is already down to its
+        # last item — reject the rest as wipes. Clearing a board on purpose
+        # goes through /boards/<id>/commit/, which bypasses this endpoint.
+        new_state = request.data.get("state")
+        current_state = self.get_object().state or []
+
+        if new_state == [] and len(current_state) > 1:
+            return RestResponse(
+                {
+                    "errors": "refusing to erase a non-empty board; "
+                    "use the commit endpoint to clear it"
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        return super().update(request, *args, **kwargs)
+
 
 def make_board(thread_name):
     thread = Thread.objects.get(name=thread_name)

--- a/tasks/assets/store.js
+++ b/tasks/assets/store.js
@@ -204,10 +204,20 @@ export const useBoardStore = defineStore('board', {
 
             this.updateBoardInListResponse(newBoard)
 
-            const board = await apiRequest(`/boards/${newBoard.id}/`, {
-                method: 'PUT',
-                body: JSON.stringify(newBoard)
-            })
+            let board
+
+            try {
+                board = await apiRequest(`/boards/${newBoard.id}/`, {
+                    method: 'PUT',
+                    body: JSON.stringify(newBoard)
+                })
+            } catch (error) {
+                // The optimistic update above is now a lie (e.g. the server
+                // refused a board-erasing state) — resync from the server so
+                // the view snaps back to what is actually stored.
+                await this.reloadBoards()
+                throw error
+            }
 
             this.updateBoardInListResponse(board)
         },

--- a/tasks/assets/tasktree/lib/Tree.js
+++ b/tasks/assets/tasktree/lib/Tree.js
@@ -53,49 +53,58 @@ export default class Tree {
   }
 
   setModel (data) {
-    // The tree and the component must share one identity for the model: nodes
-    // are already reactive proxies (see objectToNode), and the array is made
-    // reactive here so splices done through the tree re-render the component.
-    this.model = reactive(this.parse(data))
+    // Rebuilding from the store must never write back to the store:
+    // refreshIndeterminateState below can flip a parent's checked state and
+    // $emit, and an emit here would dispatch a save while `vm.model` still
+    // holds the PREVIOUS model — persisting a stale (possibly empty) board.
+    this.__silence = true
 
-    /* eslint-disable */
-    requestAnimationFrame(_ => {
+    try {
+      // The tree and the component must share one identity for the model: nodes
+      // are already reactive proxies (see objectToNode), and the array is made
+      // reactive here so splices done through the tree re-render the component.
+      this.model = reactive(this.parse(data))
+
+      // Assigned synchronously: toJSON() serializes vm.model, so any deferral
+      // (this used to wait for a requestAnimationFrame) opens a window where a
+      // dispatched save writes the previous model over the current board.
       this.vm.model = this.model
-    })
-    /* eslint-enable */
 
-    this.selectedNodes = new List()
-    this.checkedNodes = new List()
+      this.selectedNodes = new List()
+      this.checkedNodes = new List()
 
-    recurseDown(this.model, node => {
-      node.tree = this
+      recurseDown(this.model, node => {
+        node.tree = this
 
-      // Store-driven rebuilds replace every Node instance; carry an
-      // in-progress edit over to the node's replacement, matched by id.
-      if (this._editingNode && node.id === this._editingNode.id) {
-        node.isEditing = true
-        this._editingNode = node
-        this.activeElement = node
-      }
-
-      if (node.selected()) {
-        this.selectedNodes.add(node)
-      }
-
-      if (node.checked()) {
-        this.checkedNodes.add(node)
-
-        if (node.parent) {
-          node.parent.refreshIndeterminateState()
+        // Store-driven rebuilds replace every Node instance; carry an
+        // in-progress edit over to the node's replacement, matched by id.
+        if (this._editingNode && node.id === this._editingNode.id) {
+          node.isEditing = true
+          this._editingNode = node
+          this.activeElement = node
         }
-      }
 
-      if (node.disabled()) {
-        node.recurseDown(child => {
-          child.state('disabled', true)
-        })
-      }
-    })
+        if (node.selected()) {
+          this.selectedNodes.add(node)
+        }
+
+        if (node.checked()) {
+          this.checkedNodes.add(node)
+
+          if (node.parent) {
+            node.parent.refreshIndeterminateState()
+          }
+        }
+
+        if (node.disabled()) {
+          node.recurseDown(child => {
+            child.state('disabled', true)
+          })
+        }
+      })
+    } finally {
+      this.__silence = false
+    }
   }
 
   recurseDown (node, fn) {


### PR DESCRIPTION
## Incident

On 2026-07-08 at 21:40:31, loading the board page erased `Board.state` to `[]` within the same second as the page's boot requests — before first paint. Access logs show the SPA boot sequence (`GET /todo/` → `/threads/` → `/boards/`) immediately followed by a `PUT /boards/69/` carrying an empty state.

## Root cause

Three defects lined up:

1. **The tree emits during store-driven rebuilds.** Android-side task crossings set `state.checked` on individual board nodes, leaving parents inconsistent with their children. On the next web load, `Tree.setModel` runs `refreshIndeterminateState()`, which flips the parent and `$emit`s — and every tree emit calls `syncStore()`, scheduling a full-board save on `nextTick`.
2. **The serialized model lags one rebuild behind.** `vm.model` (read by `toJSON()` and rendering) was only assigned inside `requestAnimationFrame`, while the save fires on `nextTick` — a microtask that always beats the next frame. On first load, the stale model was the empty array from mount.
3. **The server accepts any full-state PUT**, so `state: []` over a populated board wiped it with no audit trail (unlike commits, which record `BoardCommitted` events).

## Fixes

- **`Tree.js`**: the whole `setModel` rebuild now runs with `__silence = true` (in `try/finally`), so normalization can fix checkbox states but can never dispatch a save mid-rebuild.
- **`Tree.js`**: `vm.model` is assigned synchronously — `toJSON()` can no longer serialize a one-rebuild-stale model (this also fixes a silent partial-loss variant mid-session).
- **`views_board_tasks.py`**: `PUT /boards/<id>/` returns **409** when the payload would empty a board that still has more than one root item. Deleting the genuinely last item still works; intentional clears go through `/boards/<id>/commit/`.
- **`store.js`**: a failed save PUT now resyncs boards from the server, so a rejected optimistic update snaps back instead of lingering on screen.

## Testing

- New `test_board_update_guard.py`: empty-PUT on multi-item board → 409, state untouched; empty-PUT on single-item board → 200; normal update → 200.
- Full `tasks.apps.tree` suite: 331 tests pass.
- `npm run build` completes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)