### PR TITLE
feat(observations): Folder/Type/Sort controls in lower pane

### DIFF
--- a/tasks/apps/tree/templatetags/observation_menu.py
+++ b/tasks/apps/tree/templatetags/observation_menu.py
@@ -1,8 +1,12 @@
 from django import template
 
-from ..models import InsightRefined, Observation, ObservationClosed
+from ..models import InsightRefined, Observation, ObservationClosed, ObservationType
 
 register = template.Library()
+
+# Keep in sync with ObservationListFilterMixin in views_observation.py.
+SORT_CHOICES = ("added", "modified")
+DEFAULT_SORT = "added"
 
 
 @register.inclusion_tag("tree/_observation_menu.html", takes_context=True)
@@ -11,6 +15,10 @@ def observation_menu(context, attach_mode=False):
 
     active = getattr(request.resolver_match, "url_name", None)
 
+    current_sort = request.GET.get("sort")
+    if current_sort not in SORT_CHOICES:
+        current_sort = DEFAULT_SORT
+
     return {
         "mine_count": Observation.objects.filter(user=request.user).count(),
         "open_count": Observation.objects.count(),
@@ -18,6 +26,9 @@ def observation_menu(context, attach_mode=False):
         "insights_count": (
             InsightRefined.objects.values("event_stream_id").distinct().count()
         ),
+        "observation_types": ObservationType.objects.order_by("name"),
+        "current_type": request.GET.get("type") or "",
+        "current_sort": current_sort,
         "attach_mode": attach_mode,
         "active": active,
     }

--- a/tasks/apps/tree/views_observation.py
+++ b/tasks/apps/tree/views_observation.py
@@ -144,15 +144,67 @@ class ObservationEventViewSet(viewsets.ModelViewSet):
         return Event.objects.instance_of(*observation_event_types)
 
 
-class ObservationListView(LoginRequiredMixin, ListView):
-    model = Observation
-    queryset = (
-        Observation.objects.with_attached_count()
-        .select_related("thread", "type")
-        .prefetch_related("observationupdated_set")
-    )
+# Keep in sync with SORT_CHOICES in templatetags/observation_menu.py.
+SORT_ADDED = "added"
+SORT_MODIFIED = "modified"
+DEFAULT_SORT = SORT_ADDED
 
+
+class ObservationListFilterMixin:
+    """Shared lower-pane filtering for the observation folder list views.
+
+    Reads two query-string controls rendered by ``_observation_menu.html``:
+
+    - ``?type=<slug>`` — ephemeral filter by :class:`ObservationType`. Every
+      folder model (Observation / ObservationClosed / InsightRefined) exposes a
+      ``type`` FK, so the same ``type__slug`` filter works across all of them.
+    - ``?sort=added|modified`` — ordering, persisted client-side to localStorage.
+      ``added`` sorts by primary key (creation order); ``modified`` sorts by the
+      most recent activity. Subclasses map each choice to an ORDER BY tuple via
+      ``sort_orderings`` and opt into the last-event annotation as needed.
+    """
+
+    # "modified" defaults to the row's own timestamp; the Observation views
+    # override it with the last-event annotation (see below).
+    sort_orderings = {
+        SORT_ADDED: ("-pk",),
+        SORT_MODIFIED: ("-published", "-pk"),
+    }
+    annotate_last_event = False
+
+    def get_current_sort(self):
+        sort = self.request.GET.get("sort")
+        return sort if sort in self.sort_orderings else DEFAULT_SORT
+
+    def apply_observation_filters(self, queryset):
+        type_slug = self.request.GET.get("type")
+        if type_slug:
+            queryset = queryset.filter(type__slug=type_slug)
+
+        sort = self.get_current_sort()
+        if self.annotate_last_event and sort == SORT_MODIFIED:
+            queryset = queryset.with_last_event_published()
+
+        return queryset.order_by(*self.sort_orderings[sort])
+
+
+class ObservationListView(ObservationListFilterMixin, LoginRequiredMixin, ListView):
+    model = Observation
     paginate_by = 200
+
+    sort_orderings = {
+        SORT_ADDED: ("-pk",),
+        SORT_MODIFIED: ("-last_event_published", "-pk"),
+    }
+    annotate_last_event = True
+
+    def get_queryset(self):
+        queryset = (
+            Observation.objects.with_attached_count()
+            .select_related("thread", "type")
+            .prefetch_related("observationupdated_set")
+        )
+        return self.apply_observation_filters(queryset)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -163,28 +215,36 @@ class ObservationListView(LoginRequiredMixin, ListView):
         return context
 
 
-class ObservationClosedListView(LoginRequiredMixin, ListView):
+class ObservationClosedListView(
+    ObservationListFilterMixin, LoginRequiredMixin, ListView
+):
     model = ObservationClosed
-    queryset = ObservationClosed.objects.select_related("thread", "type").order_by(
-        "-published"
-    )
-
     paginate_by = 100
 
+    def get_queryset(self):
+        queryset = ObservationClosed.objects.select_related("thread", "type")
+        return self.apply_observation_filters(queryset)
 
-class ObservationMineListView(LoginRequiredMixin, ListView):
+
+class ObservationMineListView(ObservationListFilterMixin, LoginRequiredMixin, ListView):
     model = Observation
     template_name = "tree/observation_list.html"
     paginate_by = 200
 
+    sort_orderings = {
+        SORT_ADDED: ("-pk",),
+        SORT_MODIFIED: ("-last_event_published", "-pk"),
+    }
+    annotate_last_event = True
+
     def get_queryset(self):
-        return (
+        queryset = (
             Observation.objects.with_attached_count()
             .filter(user=self.request.user)
             .select_related("thread", "type")
             .prefetch_related("observationupdated_set")
-            .order_by("-pub_date", "-pk")
         )
+        return self.apply_observation_filters(queryset)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -195,7 +255,7 @@ class ObservationMineListView(LoginRequiredMixin, ListView):
         return context
 
 
-class InsightsListView(LoginRequiredMixin, ListView):
+class InsightsListView(ObservationListFilterMixin, LoginRequiredMixin, ListView):
     model = InsightRefined
     template_name = "tree/insights_list.html"
     paginate_by = 100
@@ -206,11 +266,10 @@ class InsightsListView(LoginRequiredMixin, ListView):
             .order_by("-published")
             .values("pk")[:1]
         )
-        return (
-            InsightRefined.objects.filter(pk__in=Subquery(latest_ids))
-            .select_related("thread", "type")
-            .order_by("-published")
-        )
+        queryset = InsightRefined.objects.filter(
+            pk__in=Subquery(latest_ids)
+        ).select_related("thread", "type")
+        return self.apply_observation_filters(queryset)
 
 
 @login_required

--- a/tasks/assets/app.js
+++ b/tasks/assets/app.js
@@ -7,6 +7,7 @@ import "./scripts/shared.js";
 import "./app.scss";
 import "./observation_search.js";
 import "./observation_master_detail.js";
+import "./observation_menu.js";
 import "./observation_edit.js";
 import { autosizeAll, resizeTextarea } from "./autosize.js";
 

--- a/tasks/assets/observation_menu.js
+++ b/tasks/assets/observation_menu.js
@@ -1,0 +1,81 @@
+// Lower-pane controls for the Observations pages: Folder (navigates between the
+// Mine / All / Closed / Insights list URLs), Type (an ephemeral ?type= filter)
+// and Sort (a ?sort= ordering persisted to localStorage so the chosen order
+// carries across visits). The server does the actual filtering and ordering;
+// this only rewrites the URL on change and re-applies the saved sort on load.
+
+const SORT_KEY = "observations.sort";
+const DEFAULT_SORT = "added";
+
+const initObservationMenu = () => {
+    const menu = document.querySelector("[data-observation-menu]");
+    if (!menu) {
+        return;
+    }
+
+    const folderSelect = menu.querySelector(".folder-select");
+    const typeSelect = menu.querySelector(".type-select");
+    const sortSelect = menu.querySelector(".sort-select");
+
+    const url = new URL(window.location.href);
+    const urlSort = url.searchParams.get("sort");
+    const storedSort = localStorage.getItem(SORT_KEY);
+
+    // Persist an explicit ?sort= choice; otherwise re-apply a saved non-default
+    // one by redirecting once (no loop: after the replace, ?sort= is present).
+    if (urlSort) {
+        if (storedSort !== urlSort) {
+            localStorage.setItem(SORT_KEY, urlSort);
+        }
+    } else if (storedSort && storedSort !== DEFAULT_SORT) {
+        url.searchParams.set("sort", storedSort);
+        window.location.replace(url.toString());
+        return;
+    }
+
+    // Navigate to `target` after (optionally) syncing the current sort onto it.
+    const go = (target, { keepSort }) => {
+        if (keepSort) {
+            const sort = sortSelect ? sortSelect.value : urlSort || storedSort;
+            if (sort && sort !== DEFAULT_SORT) {
+                target.searchParams.set("sort", sort);
+            } else {
+                target.searchParams.delete("sort");
+            }
+        }
+        window.location.href = target.toString();
+    };
+
+    // Folder: jump to the selected list URL, carrying the current sort but
+    // dropping the ephemeral type filter (each folder opens at Type = All).
+    if (folderSelect) {
+        folderSelect.addEventListener("change", () => {
+            const target = new URL(folderSelect.value, window.location.origin);
+            go(target, { keepSort: true });
+        });
+    }
+
+    // Type: ephemeral — reflected only in the URL, never stored.
+    if (typeSelect) {
+        typeSelect.addEventListener("change", () => {
+            const target = new URL(window.location.href);
+            if (typeSelect.value) {
+                target.searchParams.set("type", typeSelect.value);
+            } else {
+                target.searchParams.delete("type");
+            }
+            window.location.href = target.toString();
+        });
+    }
+
+    // Sort: persisted to localStorage and reflected in the URL.
+    if (sortSelect) {
+        sortSelect.addEventListener("change", () => {
+            localStorage.setItem(SORT_KEY, sortSelect.value);
+            const target = new URL(window.location.href);
+            go(target, { keepSort: true });
+        });
+    }
+};
+
+initObservationMenu();

--- a/tasks/assets/styles/_observations.scss
+++ b/tasks/assets/styles/_observations.scss
@@ -1108,63 +1108,37 @@ body.page-observations {
     }
 }
 
-// --- Lower pane: the Mine / All / Closed / Insights tabs ---
+// --- Lower pane: Folder / Type / Sort filter controls (mirrors the Board) ---
 .page-observations .lower-pane {
-    align-items: stretch;
-    padding: 0 12px;
-    gap: 0;
+    padding: 0 20px;
+    gap: 1rem;
 }
 
-.observation-tabs {
-    display: flex;
-    align-items: stretch;
-    width: 100%;
-
-    a {
-        display: flex;
+.observation-controls {
+    .control {
+        display: inline-flex;
         align-items: center;
-        gap: 0.4rem;
+        gap: 0.35rem;
+        margin: 0;
+        cursor: pointer;
+    }
 
-        padding: 0 0.9rem;
+    .control-label {
+        color: #999;
+    }
 
-        color: #666;
-        text-decoration: none;
-        font-size: 0.95rem;
-
-        border-bottom: 2px solid transparent;
-
-        &:hover {
-            color: #205e7d;
-        }
-
-        &.active {
-            color: #205e7d;
-            font-weight: 600;
-            border-bottom-color: #205e7d;
-        }
-
-        .badge {
-            display: inline-flex;
-            align-items: center;
-            line-height: 1;
-
-            font-size: 0.72rem;
-            font-weight: 600;
-            color: #888;
-            background: #eef0f2;
-            border-radius: 9px;
-            padding: 0.2em 0.45em;
-        }
-
-        &.active .badge {
-            color: #205e7d;
-            background: #dbe9f1;
-        }
+    select {
+        background: transparent;
+        border: 1px solid #ddd;
+        border-radius: 3px;
+        color: #343434;
+        cursor: pointer;
     }
 
     .attach-exit {
         margin-left: auto;
         color: #c0392b;
+        text-decoration: none;
 
         &:hover {
             color: color.adjust(#c0392b, $lightness: -10%);

--- a/tasks/templates/tree/_observation_menu.html
+++ b/tasks/templates/tree/_observation_menu.html
@@ -14,15 +14,37 @@
 
         <a class="btn-new" href="{% url 'public-observation-add' %}">+ New</a>
     </div>
-    <div class="lower-pane">
-        <nav class="observation-tabs">
-            <a class="{% if active == 'public-observation-list' %}active{% endif %}" href="{% url 'public-observation-list' %}">Mine <span class="badge">{{ mine_count }}</span></a>
-            <a class="{% if active == 'public-observation-list-all' %}active{% endif %}" href="{% url 'public-observation-list-all' %}">All <span class="badge">{{ open_count }}</span></a>
-            <a class="{% if active == 'public-observation-list-closed' %}active{% endif %}" href="{% url 'public-observation-list-closed' %}">Closed <span class="badge">{{ closed_count }}</span></a>
-            <a class="{% if active == 'public-insights-list' %}active{% endif %}" href="{% url 'public-insights-list' %}">Insights <span class="badge">{{ insights_count }}</span></a>
-            {% if attach_mode %}
-                <a class="attach-exit" href="?">Exit Attach Mode</a>
-            {% endif %}
-        </nav>
+    <div class="lower-pane observation-controls" data-observation-menu>
+        <label class="control">
+            <span class="control-label">Folder</span>
+            <select class="folder-select">
+                <option value="{% url 'public-observation-list' %}" {% if active == 'public-observation-list' %}selected{% endif %}>Mine ({{ mine_count }})</option>
+                <option value="{% url 'public-observation-list-all' %}" {% if active == 'public-observation-list-all' %}selected{% endif %}>All ({{ open_count }})</option>
+                <option value="{% url 'public-observation-list-closed' %}" {% if active == 'public-observation-list-closed' %}selected{% endif %}>Closed ({{ closed_count }})</option>
+                <option value="{% url 'public-insights-list' %}" {% if active == 'public-insights-list' %}selected{% endif %}>Insights ({{ insights_count }})</option>
+            </select>
+        </label>
+
+        <label class="control">
+            <span class="control-label">Type</span>
+            <select class="type-select">
+                <option value="" {% if not current_type %}selected{% endif %}>All</option>
+                {% for observation_type in observation_types %}
+                    <option value="{{ observation_type.slug }}" {% if current_type == observation_type.slug %}selected{% endif %}>{{ observation_type.name }}</option>
+                {% endfor %}
+            </select>
+        </label>
+
+        <label class="control">
+            <span class="control-label">Sort</span>
+            <select class="sort-select">
+                <option value="added" {% if current_sort == 'added' %}selected{% endif %}>Last added</option>
+                <option value="modified" {% if current_sort == 'modified' %}selected{% endif %}>Last modified</option>
+            </select>
+        </label>
+
+        {% if attach_mode %}
+            <a class="attach-exit" href="?">Exit Attach Mode</a>
+        {% endif %}
     </div>
 </div>


### PR DESCRIPTION
## Summary

Reworks the Observations lower pane to mirror the Board's (Tasks) lower pane — three labelled `select` controls replace the `Mine / All / Closed / Insights` tab strip.

**Lower pane now reads:** `Folder: [ Mine (x) ]   Type: [ All ]   Sort: [ Last added ]`

- **Folder** — select over the four list URLs, with live counts; changing it navigates to that folder (carrying the current sort).
- **Type** — filters by `ObservationType` (`?type=<slug>`). **Ephemeral**: reflected only in the URL, never stored, reset to *All* when switching folders. Works across every folder model (`Observation` / `ObservationClosed` / `InsightRefined`, all of which expose a `type` FK).
- **Sort** — `Last added` (order by `-pk`) vs `Last modified` (last event time). **Persisted** to `localStorage` (`observations.sort`) and re-applied on load.

## Implementation

| File | Change |
|------|--------|
| `views_observation.py` | New `ObservationListFilterMixin` (type filter + sort ordering), wired into all four list views. Observation folders map `modified` → `with_last_event_published()`; Closed/Insights map it to their own `-published`. |
| `templatetags/observation_menu.py` | Adds `observation_types`, `current_type`, `current_sort` to the menu context. |
| `_observation_menu.html` | Tabs replaced with Folder/Type/Sort `.control` selects. |
| `observation_menu.js` (new) | Change handlers + load-time sort persistence; imported in `app.js`. |
| `_observations.scss` | Tab styling replaced with `.control` / `.control-label` / `select` styling matching the Board. |

## Design decisions
1. **Sort/Type show on all four folders** (not just Mine/All) for a consistent bar. On Closed/Insights, `Last modified` maps to the event's own timestamp.
2. **Switching folders resets Type to All** but keeps Sort — Type is ephemeral, Sort is persisted.

## Testing
- `manage.py check` clean; frontend `npm run build` clean.
- Queryset smoke test across all sort/type combinations for all 4 views — `modified` produces a distinct ordering (confirming the last-event annotation); `type` filters correctly across every folder model.
- Rendered all pages via the test client (200s) with correct selected-state on each control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)