### PR TITLE
fix(journal): strip leading list bullet before reflection marker

### DIFF
--- a/tasks/apps/tree/services/journalling/reflection_extraction.py
+++ b/tasks/apps/tree/services/journalling/reflection_extraction.py
@@ -5,6 +5,7 @@ This module contains logic for parsing journal entries and extracting
 reflection items (good/better/best) to add to the appropriate Reflection.
 """
 
+import re
 from calendar import monthrange
 from datetime import timedelta
 
@@ -13,6 +14,12 @@ REFLECTION_LINE_PREFIXES = (
     ("[~] ", "better"),
     ("[^] ", "best"),
 )
+
+# Optional leading whitespace and an optional markdown list bullet (``-``,
+# ``*`` or ``+``) before the marker, so both ``[x] foo`` and the
+# markdown-checkbox style ``- [x] foo`` are accepted and strip to ``foo``.
+# This mirrors the ``- [x] <text>`` format the Android tick itself records.
+_LEADING_LIST_MARKER_RE = re.compile(r"^\s*(?:[-*+]\s+)?")
 
 
 def extract_reflection_lines(note):
@@ -24,20 +31,24 @@ def extract_reflection_lines(note):
     - [~] for "better" items
     - [^] for "best" items
 
+    A leading markdown list bullet (``- ``, ``* `` or ``+ ``) and surrounding
+    whitespace are stripped first, so ``- [x] foo`` yields ``foo`` — matching
+    the board task's text rather than ``- foo``.
+
     Args:
         note: The journal note text to parse.
 
     Returns:
         List of (field_name, line_content) tuples.
     """
-    lines = note.split("\n")
-
-    return [
-        (field, line.replace(prefix, "", 1))
-        for line in lines
-        for prefix, field in REFLECTION_LINE_PREFIXES
-        if prefix in line[:12]
-    ]
+    result = []
+    for raw_line in note.split("\n"):
+        line = _LEADING_LIST_MARKER_RE.sub("", raw_line, count=1)
+        for prefix, field in REFLECTION_LINE_PREFIXES:
+            if line.startswith(prefix):
+                result.append((field, line[len(prefix) :]))
+                break
+    return result
 
 
 def add_reflection_items(journal_added, comment=None):

--- a/tasks/apps/tree/tests/test_journal_processing.py
+++ b/tasks/apps/tree/tests/test_journal_processing.py
@@ -110,6 +110,14 @@ class JournalProcessingTestCase(TestCase):
         reflection = Reflection.objects.get()
         self.assertEqual(reflection.good, "same good thing")
 
+    def test_leading_list_bullet_is_stripped(self):
+        """A markdown list bullet before the marker is stripped from the
+        stored line, so ``- [x] foo`` yields ``foo`` (not ``- foo``)."""
+        process_journal_entry(self._create_journal("- [x] did a thing"))
+
+        reflection = Reflection.objects.get()
+        self.assertEqual(reflection.good, "did a thing")
+
     def test_entry_with_valid_habit_creates_habit_tracked(self):
         """An entry with a valid #habit creates a HabitTracked entry."""
         journal = self._create_journal("#food pizza for lunch")
@@ -248,3 +256,16 @@ class JournalBoardCheckTestCase(TestCase):
         process_journal_entry(self._journal("[x] buy bread"))
 
         self.assertEqual(self._board_node("buy bread")["data"]["state"], "open")
+
+    def test_bullet_prefixed_line_matches_and_advances_progress_task(self):
+        # ``- [x] <task>`` (markdown-checkbox style) must strip the leading
+        # bullet so it matches the board task text and progresses it.
+        self._add_board_task("Pyszne posiłki (3)")
+
+        process_journal_entry(self._journal("- [x] Pyszne posiłki (3)"), user=self.user)
+
+        self.board.refresh_from_db()
+        self.assertEqual(self.board.state[0]["data"]["text"], "Pyszne posiłki (1/3)")
+        self.assertEqual(self.board.state[0]["data"]["state"], "open")
+        reflection = Reflection.objects.get(thread=self.daily)
+        self.assertEqual(reflection.good, "Pyszne posiłki (3)")


### PR DESCRIPTION
## Problem

Journaling `- [x] Pyszne posiłki (3)` (markdown-checkbox style) from the console tool appended a reflection line but did **not** progress the matching board task.

`extract_reflection_lines` only stripped the `[x] ` marker via `line.replace("[x] ", "", 1)`, leaving the leading `- ` intact. So the extracted content became `- Pyszne posiłki (3)`, which:

- got stored in `Reflection.good` with an ugly `- ` prefix, and
- failed the exact-text board lookup (`find_task_by_text`) against `Pyszne posiłki (3)` → no progression.

## Fix

`extract_reflection_lines` now strips an optional leading markdown list bullet (`- `, `* `, `+ `) plus surrounding whitespace before the marker. Both bullet and non-bullet styles yield clean text (`Pyszne posiłki (3)`) that matches the board task and advances it (`(3)` → `(1/3)`). This also aligns with the `- [x] <text>` format the Android tick itself records.

The parse also switched from the loose "marker within the first 12 chars" heuristic to anchoring the marker at the logical start of the line (after optional whitespace/bullet), which is stricter and more predictable.

## Testing

- Full `tree` suite: **339 passing**.
- Added `test_leading_list_bullet_is_stripped` (reflection stores `foo`, not `- foo`) and `test_bullet_prefixed_line_matches_and_advances_progress_task` (the exact reported scenario: `- [x] Pyszne posiłki (3)` → board advances to `Pyszne posiłki (1/3)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)