### PR TITLE
feat(today): derive counted-task progress from the Reflection

### DIFF
--- a/tasks/apps/tree/services/journalling/journal_processing.py
+++ b/tasks/apps/tree/services/journalling/journal_processing.py
@@ -27,10 +27,10 @@ def process_journal_entry(journal_added, skip_habits=False, story=None, user=Non
         story: Optional Story instance. When provided, the JournalAdded itself
             and every HabitTracked extracted from hashtags get linked to the
             story via a StoryEvent row.
-        user: Optional user. When given, every ``[x]`` (good) line whose text
-            matches a task on the user's current board also ticks that task
-            via ``set_task_done`` — advancing progress markers just like the
-            Android tick. Passed only by the console/web journal callers.
+        user: Optional user. When given, any reflection line whose base matches
+            a task on the user's current board crosses that task once its
+            progress (derived from the Reflection) reaches the total. Passed
+            only by the console/web journal callers.
     """
     # Import here to avoid circular imports
     from ...models import HabitTracked, StoryEvent, Thread
@@ -63,28 +63,51 @@ def process_journal_entry(journal_added, skip_habits=False, story=None, user=Non
 
 
 def _check_matching_board_tasks(user, comment, published):
-    """Tick each board task whose text matches a ``[x]`` (good) reflection line.
-
-    ``set_task_done`` handles progress markers, so ``[x] Do tasks (2/3)``
-    advances the matching task the same way the Android tick does. Runs after
-    ``add_reflection_items`` so a completing progress transition self-corrects
-    the reflection line; matching is exact, so an unmatched line never creates
-    a phantom board task.
+    """Cross board tasks based on the Reflection ``add_reflection_items`` just
+    wrote. Runs after it, so counts are current. For each reflection line (any
+    of good/better/best), base-match against the board: a counted task is
+    crossed once its derived count reaches the total; a marker-less task is
+    crossed because the line was recorded. Writes only the board — the
+    Reflection is owned by ``add_reflection_items``.
 
     The ``services.today`` imports are function-local: importing them at module
     scope would run ``today/__init__`` -> ``operations`` -> ``trips`` -> back
     into ``journalling`` (a cycle).
     """
+    from ...models import Reflection, Thread
     from ..today import board_tree
-    from ..today.operations import NoBoardError, _current_board, set_task_done
+    from ..today.operations import (
+        NoBoardError,
+        _cross_if_complete,
+        _current_board,
+        _progress_count,
+    )
+    from ..today.progress import base_of, parse_progress
 
     try:
         board = _current_board(user)
     except NoBoardError:
         return
 
-    for field, line in extract_reflection_lines(comment):
-        if field != "good":
+    daily = Thread.objects.filter(name="Daily").first()
+    reflection = (
+        Reflection.objects.filter(pub_date=published.date(), thread=daily).first()
+        if daily is not None
+        else None
+    )
+
+    changed = False
+    for _field, line in extract_reflection_lines(comment):
+        base = base_of(line)
+        hit = board_tree.find_task_by_base(board.state, base)
+        if hit is None:
             continue
-        if board_tree.find_task_by_text(board.state, line) is not None:
-            set_task_done(user, line, done=True, published=published)
+        _, _, node = hit
+        if parse_progress(board_tree._node_text(node)) is None:
+            if board_tree.get_state(node) != "done":
+                board_tree.set_state(node, "done")
+                changed = True
+        elif _cross_if_complete(board, base, _progress_count(reflection, base)):
+            changed = True
+    if changed:
+        board.save()

--- a/tasks/apps/tree/services/journalling/reflection_extraction.py
+++ b/tasks/apps/tree/services/journalling/reflection_extraction.py
@@ -35,18 +35,31 @@ def extract_reflection_lines(note):
     whitespace are stripped first, so ``- [x] foo`` yields ``foo`` — matching
     the board task's text rather than ``- foo``.
 
+    CRLF / CR line endings are normalized to LF before splitting (the CLI's
+    ``sanitize_string`` stores ``\\r\\n``), so a stray ``\\r`` never trails the
+    extracted content — otherwise ``foo\\r`` would neither dedupe nor match the
+    board task ``foo``.
+
+    A progress marker is coerced to single-number ``(K)`` form (``coerce_to_count``),
+    so a client may send either ``New task (1)`` or the displayed ``New task (1/3)``
+    and both store/match as ``New task (1)``.
+
     Args:
         note: The journal note text to parse.
 
     Returns:
         List of (field_name, line_content) tuples.
     """
+    # Lazy: ``today`` at module scope would cycle back through journalling.
+    from ..today.progress import coerce_to_count
+
+    normalized = note.replace("\r\n", "\n").replace("\r", "\n")
     result = []
-    for raw_line in note.split("\n"):
+    for raw_line in normalized.split("\n"):
         line = _LEADING_LIST_MARKER_RE.sub("", raw_line, count=1)
         for prefix, field in REFLECTION_LINE_PREFIXES:
             if line.startswith(prefix):
-                result.append((field, line[len(prefix) :]))
+                result.append((field, coerce_to_count(line[len(prefix) :])))
                 break
     return result
 

--- a/tasks/apps/tree/services/today/board_tree.py
+++ b/tasks/apps/tree/services/today/board_tree.py
@@ -6,6 +6,7 @@ and ``data`` (which holds a ``state`` string and ``meaningfulMarkers``). See
 """
 
 from ...board_operations import create_task_item
+from .progress import base_of
 
 
 def _node_text(node):
@@ -30,6 +31,28 @@ def find_task_by_text(state, text):
             continue
         node = parent_list[i]
         if _node_text(node) == text:
+            return parent_list, i, node
+        stack.append((parent_list, i + 1))
+        children = node.get("children") or []
+        if children:
+            stack.append((children, 0))
+    return None
+
+
+def find_task_by_base(state, base):
+    """Depth-first search for a node whose marker-stripped text (``base_of``)
+    equals ``base`` — so `New task (3)` on the board is found by the base
+    `New task` regardless of the marker form journaled/ticked. First match wins.
+
+    Returns ``(parent_list, index, node)`` on a hit, ``None`` otherwise.
+    """
+    stack = [(state, 0)]
+    while stack:
+        parent_list, i = stack.pop()
+        if i >= len(parent_list):
+            continue
+        node = parent_list[i]
+        if base_of(_node_text(node)) == base:
             return parent_list, i, node
         stack.append((parent_list, i + 1))
         children = node.get("children") or []

--- a/tasks/apps/tree/services/today/operations.py
+++ b/tasks/apps/tree/services/today/operations.py
@@ -16,7 +16,13 @@ from ...board_operations import board_thread_for
 from ...models import Board, JournalAdded, Plan, Reflection, Story, StoryEvent, Thread
 from ..trips.operations import StoryNotFoundError, StoryStoppedError
 from . import board_tree, text_lines
-from .progress import parse_progress, render_progress
+from .progress import (
+    base_of,
+    marker_value,
+    parse_progress,
+    render_count,
+    render_progress,
+)
 
 
 class NoBoardError(Exception):
@@ -27,6 +33,7 @@ class NoBoardError(Exception):
 class TodayTask:
     text: str
     done: bool
+    mark: Optional[str] = None  # "~" (better) / "^" (best) for boolean tasks
 
 
 @dataclass(frozen=True)
@@ -105,14 +112,46 @@ def _current_board(user):
     return board
 
 
-def plan_tasks(pub_date, thread_name):
-    """Return the Plan.focus lines for ``pub_date`` / ``thread_name``, each
-    flagged done if it also appears verbatim in that day's Reflection.good.
+def _progress_count(reflection, base):
+    """The task's completed-step count ``N`` = the largest marker value among
+    Reflection good/better/best lines whose base matches ``base`` (0 if none)."""
+    if reflection is None:
+        return 0
+    values = []
+    for field in ("good", "better", "best"):
+        for line in text_lines.split_lines(getattr(reflection, field)):
+            if base_of(line) == base:
+                value = marker_value(line)
+                if value is not None:
+                    values.append(value)
+    return max(values, default=0)
 
-    This is the single source of truth for "is a task crossed off": a plan
-    line is done iff it's an exact-match line in the reflection's ``good``
-    field. Order follows the Plan; empty lines are dropped. Returns an empty
-    list when the thread doesn't exist or there's no plan for the date.
+
+def _boolean_mark(reflection, line):
+    """``(done, mark)`` for a marker-less task line: done if it appears in any
+    Reflection field; ``mark`` is ``~`` (better) / ``^`` (best), None for good."""
+    if reflection is None:
+        return (False, None)
+    if text_lines.has_line(reflection.good, line):
+        return (True, None)
+    if text_lines.has_line(reflection.better, line):
+        return (True, "~")
+    if text_lines.has_line(reflection.best, line):
+        return (True, "^")
+    return (False, None)
+
+
+def plan_tasks(pub_date, thread_name):
+    """Return the day's Plan.focus lines as display tasks, deriving state from
+    the Reflection (Plan/Board text is never rewritten by progress).
+
+    - Marker-less line: done if it appears in any Reflection field
+      (good/better/best), with a ``~``/`^`` mark for better/best.
+    - Counted line ``Base (M)``: ``N`` = the largest count logged for ``Base``
+      across the fields; display ``(min(N+1, M)/M)``; done when ``N >= M``.
+
+    Order follows the Plan; empty lines are dropped. Returns an empty list when
+    the thread doesn't exist or there's no plan for the date.
     """
     thread = Thread.objects.filter(name=thread_name).first()
     if thread is None:
@@ -122,9 +161,23 @@ def plan_tasks(pub_date, thread_name):
     reflection = Reflection.objects.filter(pub_date=pub_date, thread=thread).first()
 
     plan_lines = [l for l in text_lines.split_lines(plan.focus if plan else None) if l]
-    good = set(text_lines.split_lines(reflection.good if reflection else None))
 
-    return [TodayTask(text=line, done=line in good) for line in plan_lines]
+    tasks = []
+    for line in plan_lines:
+        progress = parse_progress(line)
+        if progress is None:
+            done, mark = _boolean_mark(reflection, line)
+            tasks.append(TodayTask(text=line, done=done, mark=mark))
+        else:
+            n = _progress_count(reflection, base_of(line))
+            step = min(n + 1, progress.total)
+            tasks.append(
+                TodayTask(
+                    text=render_progress(line, progress, step),
+                    done=n >= progress.total,
+                )
+            )
+    return tasks
 
 
 @transaction.atomic
@@ -256,80 +309,62 @@ def _set_task_done_boolean(user, text, done, today, published):
     return text
 
 
-def _next_progress_step(progress, done):
-    """Compute the next ``current`` value, or None if the request is a no-op.
-
-    Per the agreed semantics:
-    - ``done=True`` always advances by 1 — including past full completion
-      (e.g. ``(3/3) → (4/3)`` via the "Add another" action on the
-      completed-task dialog).
-    - ``done=False`` resets to pristine ``(N)`` if the task was at or
-      past full completion, otherwise it's a no-op (unticking a
-      partially-progressed task is not meaningful).
-    """
-    if done:
-        return progress.current + 1
-    if progress.current < progress.total:
-        return None
-    return 0
+def _cross_if_complete(board, base, n):
+    """Cross / un-cross the board node matching ``base`` based on whether its
+    completed count ``n`` reached the node's own total. No text edits. Returns
+    True if the node state changed (caller saves the board)."""
+    hit = board_tree.find_task_by_base(board.state, base)
+    if hit is None:
+        return False
+    _, _, node = hit
+    node_progress = parse_progress(board_tree._node_text(node))
+    total = node_progress.total if node_progress else 1
+    new_state = "done" if n >= total else "open"
+    if board_tree.get_state(node) != new_state:
+        board_tree.set_state(node, new_state)
+        return True
+    return False
 
 
 def _set_task_done_progress(user, text, done, progress, today, published):
-    next_current = _next_progress_step(progress, done)
-    if next_current is None:
-        return None
+    """Android-tick progression under the reflection-count model: read the
+    task's current count ``N`` from the Reflection, log the next count line
+    ``Base (N±1)`` (increment on tick, decrement on untick), and cross the
+    matching board node when the count reaches its total. Plan/Board text is
+    never rewritten.
 
+    Returns the display marker text for an optional journal entry, or None on a
+    no-op (untick at zero).
+    """
     pub_date = _today(today, published)
-    new_text = render_progress(text, progress, next_current)
-    # A task is "done" whenever its current step is at or past its total —
-    # this includes over-quota states like (4/3) reached via "Add another".
-    done_before = progress.current >= progress.total
-    done_after = next_current >= progress.total
-
-    board = _current_board(user)
-    hit = board_tree.find_task_by_text(board.state, text)
-    if hit is None:
-        node = board_tree.append_task_at_root(board.state, new_text)
-    else:
-        _, _, node = hit
-        board_tree.rename(node, new_text)
-    board_tree.set_state(node, "done" if done_after else "open")
-    board.save()
-
+    base = base_of(text)
     daily = _daily_thread()
-    plan, _created = Plan.objects.get_or_create(pub_date=pub_date, thread=daily)
-    if text_lines.has_line(plan.focus, text):
-        new_focus = text_lines.replace_line(plan.focus, text, new_text)
-    elif not text_lines.has_line(plan.focus, new_text):
-        new_focus = text_lines.add_unique_line(plan.focus, new_text)
-    else:
-        new_focus = plan.focus
-    if new_focus != (plan.focus or ""):
-        plan.focus = new_focus
-        plan.save()
-
     reflection, _created = Reflection.objects.get_or_create(
         pub_date=pub_date, thread=daily
     )
-    if not done_before and done_after:
-        # Transition into completion: drop any stale marker (defensive)
-        # and add the new fully-complete text.
-        cleaned = text_lines.remove_line(reflection.good, text)
-        new_good = text_lines.add_unique_line(cleaned, new_text)
-    elif done_before and not done_after:
-        # Transition out of completion (Reset): remove the old line.
-        new_good = text_lines.remove_line(reflection.good, text)
-    elif done_before and done_after:
-        # Rename in place — (3/3) → (4/3) via "Add another", or any
-        # other over-quota advance.
-        new_good = text_lines.replace_line(reflection.good, text, new_text)
+    n = _progress_count(reflection, base)
+
+    if done:
+        new_n = n + 1
+        new_good = text_lines.add_unique_line(
+            reflection.good, render_count(text, progress, new_n)
+        )
     else:
-        new_good = reflection.good or ""
+        if n <= 0:
+            return None
+        new_n = n - 1
+        new_good = text_lines.remove_line(
+            reflection.good, render_count(text, progress, n)
+        )
     if new_good != (reflection.good or ""):
         reflection.good = new_good
         reflection.save()
 
-    return new_text
+    board = _current_board(user)
+    if _cross_if_complete(board, base, new_n):
+        board.save()
+
+    return render_progress(text, progress, min(new_n + 1, progress.total))
 
 
 @transaction.atomic

--- a/tasks/apps/tree/services/today/progress.py
+++ b/tasks/apps/tree/services/today/progress.py
@@ -69,3 +69,46 @@ def render_progress(text, progress, new_current):
     else:
         marker = f"({new_current}/{progress.total})"
     return text[:start] + marker + text[end:]
+
+
+def render_count(text, progress, n):
+    """Replace the marker at ``progress.span`` with single-number ``(n)`` — the
+    internal storage form for a progress count (``New task (2/3)`` →
+    ``New task (2)``)."""
+    start, end = progress.span
+    return text[:start] + f"({n})" + text[end:]
+
+
+def marker_value(text):
+    """The first parenthesized number of the first marker in ``text`` (regex
+    group 1), or ``None``. This is ``current`` for the ``(K/M)`` form and the
+    count for the ``(K)`` form — i.e. the progress a stored count line records.
+    """
+    if not text:
+        return None
+    match = PROGRESS_RE.search(text)
+    return int(match.group(1)) if match else None
+
+
+def coerce_to_count(text):
+    """Rewrite the first progress marker to single-number ``(K)`` form (``K`` =
+    the marker's first number), so both ``New task (1/3)`` and ``New task (1)``
+    are stored as ``New task (1)``. Text without a valid marker is unchanged."""
+    progress = parse_progress(text)
+    if progress is None:
+        return text
+    return render_count(text, progress, marker_value(text))
+
+
+def base_of(text):
+    """Return ``text`` with its first progress marker removed, for
+    marker-insensitive matching: ``New task (3)`` / ``New task (2/3)`` /
+    ``New task (2)`` all yield ``New task``. Text without a valid marker is
+    returned stripped."""
+    if not text:
+        return ""
+    progress = parse_progress(text)
+    if progress is None:
+        return text.strip()
+    start, end = progress.span
+    return (text[:start].rstrip() + " " + text[end:].lstrip()).strip()

--- a/tasks/apps/tree/tests/test_android_task_api.py
+++ b/tasks/apps/tree/tests/test_android_task_api.py
@@ -141,8 +141,8 @@ class AndroidTaskAPITestCase(APITestCase):
             response.json(),
             {
                 "items": [
-                    {"text": "bravo", "done": False},
-                    {"text": "alpha", "done": True},
+                    {"text": "bravo", "done": False, "mark": None},
+                    {"text": "alpha", "done": True, "mark": None},
                 ]
             },
         )
@@ -163,7 +163,7 @@ class AndroidTaskAPITestCase(APITestCase):
         response = self._list(date=yesterday)
         self.assertEqual(
             response.json(),
-            {"items": [{"text": "buy bread", "done": False}]},
+            {"items": [{"text": "buy bread", "done": False, "mark": None}]},
         )
 
     def test_missing_token_returns_401(self):
@@ -283,44 +283,51 @@ class AndroidTaskAPITestCase(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_progress_task_advances_via_repeated_complete(self):
-        """Three POSTs to /complete on a (3) task should advance it to (3/3)
-        and flip the list's done flag."""
+        """A (3) task starts displaying (1/3); each /complete logs the next
+        count and advances the display, crossing the board node at the total.
+        Board/Plan text is never rewritten."""
         self._auth()
         self._add("Do tasks (3)")
 
-        self._complete("Do tasks (3)", True)
+        # Fresh counted task already displays (1/3) (N=0).
         self.assertEqual(
             self._list().json(),
-            {"items": [{"text": "Do tasks (1/3)", "done": False}]},
+            {"items": [{"text": "Do tasks (1/3)", "done": False, "mark": None}]},
         )
 
         self._complete("Do tasks (1/3)", True)
         self.assertEqual(
             self._list().json(),
-            {"items": [{"text": "Do tasks (2/3)", "done": False}]},
+            {"items": [{"text": "Do tasks (2/3)", "done": False, "mark": None}]},
         )
 
         self._complete("Do tasks (2/3)", True)
         self.assertEqual(
             self._list().json(),
-            {"items": [{"text": "Do tasks (3/3)", "done": True}]},
+            {"items": [{"text": "Do tasks (3/3)", "done": False, "mark": None}]},
         )
 
-        # Reflection.good and board state should both reflect completion.
+        self._complete("Do tasks (3/3)", True)
+        self.assertEqual(
+            self._list().json(),
+            {"items": [{"text": "Do tasks (3/3)", "done": True, "mark": None}]},
+        )
+
+        # Counts logged in the Reflection; board text unchanged; node crossed.
         reflection = Reflection.objects.get(thread=self.daily)
-        self.assertEqual(reflection.good, "Do tasks (3/3)")
+        self.assertEqual(reflection.good, "Do tasks (1)\nDo tasks (2)\nDo tasks (3)")
         self.board.refresh_from_db()
-        self.assertEqual(self.board.state[0]["text"], "Do tasks (3/3)")
+        self.assertEqual(self.board.state[0]["data"]["text"], "Do tasks (3)")
         self.assertEqual(self.board.state[0]["data"]["state"], "done")
 
-        # Untick resets to pristine.
+        # Untick decrements the count by one and un-crosses.
         self._complete("Do tasks (3/3)", False)
         self.assertEqual(
             self._list().json(),
-            {"items": [{"text": "Do tasks (3)", "done": False}]},
+            {"items": [{"text": "Do tasks (3/3)", "done": False, "mark": None}]},
         )
         reflection.refresh_from_db()
-        self.assertEqual(reflection.good, "")
+        self.assertEqual(reflection.good, "Do tasks (1)\nDo tasks (2)")
         self.board.refresh_from_db()
         self.assertEqual(self.board.state[0]["data"]["state"], "open")
 
@@ -389,41 +396,39 @@ class AndroidTaskAPITestCase(APITestCase):
         self._complete("Do tasks (3)", True, note="step one done")
 
         entry = JournalAdded.objects.get(thread=self.daily)
-        # Post-tick text in the [x] line, then the user's note.
-        self.assertEqual(entry.comment, "- [x] Do tasks (1/3)\nstep one done")
+        # Post-tick display (N=1 -> (2/3)) in the [x] line, then the note.
+        self.assertEqual(entry.comment, "- [x] Do tasks (2/3)\nstep one done")
 
     def test_add_another_advances_past_full(self):
-        """End-to-end Add another flow: a /complete on a fully-completed
-        progress task bumps it to (N+1/N), keeps the row checked, and
-        records a journal entry with the new over-quota text."""
+        """Ticking past completion keeps logging counts (over-quota) while the
+        display caps at (M/M) and the row stays checked."""
         self._auth()
         self._add("Do tasks (1)")
-        # First tick: (1) → (1/1), done.
+        # First tick completes it: N=1 >= 1 -> display (1/1), done.
         self._complete("Do tasks (1)", True, note="first")
         self.assertEqual(
             self._list().json(),
-            {"items": [{"text": "Do tasks (1/1)", "done": True}]},
+            {"items": [{"text": "Do tasks (1/1)", "done": True, "mark": None}]},
         )
-        # "Add another" tick on the already-done task → (2/1), still done.
+        # "Add another" tick on the already-done task keeps counting.
         self._complete("Do tasks (1/1)", True, note="another one")
 
         self.assertEqual(
             self._list().json(),
-            {"items": [{"text": "Do tasks (2/1)", "done": True}]},
+            {"items": [{"text": "Do tasks (1/1)", "done": True, "mark": None}]},
         )
-        # Reflection.good renamed in place — single line, new text.
+        # Counts accumulate (over-quota); board row stays checked.
         reflection = Reflection.objects.get(thread=self.daily)
-        self.assertEqual(reflection.good, "Do tasks (2/1)")
-        # Board row stays checked.
+        self.assertEqual(reflection.good, "Do tasks (1)\nDo tasks (2)")
         self.board.refresh_from_db()
         self.assertTrue(self.board.state[0]["state"]["checked"])
-        # Two journal entries, one per tick.
+        # Two journal entries, both showing the capped (1/1) display.
         self.assertEqual(
             sorted(JournalAdded.objects.values_list("comment", flat=True)),
             sorted(
                 [
                     "- [x] Do tasks (1/1)\nfirst",
-                    "- [x] Do tasks (2/1)\nanother one",
+                    "- [x] Do tasks (1/1)\nanother one",
                 ]
             ),
         )

--- a/tasks/apps/tree/tests/test_journal_processing.py
+++ b/tasks/apps/tree/tests/test_journal_processing.py
@@ -118,6 +118,15 @@ class JournalProcessingTestCase(TestCase):
         reflection = Reflection.objects.get()
         self.assertEqual(reflection.good, "did a thing")
 
+    def test_crlf_line_endings_do_not_leave_trailing_cr(self):
+        """CLI comments use CRLF; the stored line must not keep a stray \\r."""
+        process_journal_entry(
+            self._create_journal("- [x] New task (3)\r\n\r\nWill it work?")
+        )
+
+        reflection = Reflection.objects.get()
+        self.assertEqual(reflection.good, "New task (3)")
+
     def test_entry_with_valid_habit_creates_habit_tracked(self):
         """An entry with a valid #habit creates a HabitTracked entry."""
         journal = self._create_journal("#food pizza for lunch")
@@ -231,16 +240,53 @@ class JournalBoardCheckTestCase(TestCase):
         reflection = Reflection.objects.get(thread=self.daily)
         self.assertEqual(reflection.good, "buy bread")
 
-    def test_matching_progress_task_is_advanced(self):
-        self._add_board_task("Do tasks (2/3)")
+    def test_matching_progress_task_partial_logs_count_no_cross(self):
+        self._add_board_task("Do tasks (3)")
 
-        process_journal_entry(self._journal("[x] Do tasks (2/3)"), user=self.user)
+        process_journal_entry(self._journal("[x] Do tasks (1)"), user=self.user)
 
         self.board.refresh_from_db()
-        self.assertEqual(self.board.state[0]["data"]["text"], "Do tasks (3/3)")
-        self.assertEqual(self.board.state[0]["data"]["state"], "done")
+        # Board text is never rewritten; not crossed until the count reaches 3.
+        self.assertEqual(self.board.state[0]["data"]["text"], "Do tasks (3)")
+        self.assertEqual(self.board.state[0]["data"]["state"], "open")
         reflection = Reflection.objects.get(thread=self.daily)
-        self.assertEqual(reflection.good, "Do tasks (3/3)")
+        self.assertEqual(reflection.good, "Do tasks (1)")
+
+    def test_matching_progress_task_crosses_when_count_reaches_total(self):
+        self._add_board_task("Do tasks (3)")
+
+        process_journal_entry(self._journal("[x] Do tasks (3)"), user=self.user)
+
+        self.board.refresh_from_db()
+        self.assertEqual(self.board.state[0]["data"]["text"], "Do tasks (3)")
+        self.assertEqual(self.board.state[0]["data"]["state"], "done")  # 3 >= 3
+        reflection = Reflection.objects.get(thread=self.daily)
+        self.assertEqual(reflection.good, "Do tasks (3)")
+
+    def test_multiple_counts_in_one_entry_cross_at_total(self):
+        self._add_board_task("New task (3)")
+
+        process_journal_entry(
+            self._journal("[x] New task (2)\n[x] New task (3)"), user=self.user
+        )
+
+        self.board.refresh_from_db()
+        self.assertEqual(self.board.state[0]["data"]["state"], "done")  # max=3 >= 3
+        reflection = Reflection.objects.get(thread=self.daily)
+        self.assertEqual(reflection.good, "New task (2)\nNew task (3)")
+
+    def test_better_marker_progresses_via_its_field(self):
+        self._add_board_task("New task (3)")
+
+        process_journal_entry(self._journal("[~] New task (3)"), user=self.user)
+
+        self.board.refresh_from_db()
+        self.assertEqual(
+            self.board.state[0]["data"]["state"], "done"
+        )  # count in better
+        reflection = Reflection.objects.get(thread=self.daily)
+        self.assertEqual(reflection.better, "New task (3)")
+        self.assertFalse(reflection.good)
 
     def test_unmatched_line_creates_no_board_task(self):
         process_journal_entry(self._journal("[x] not on the board"), user=self.user)
@@ -257,15 +303,30 @@ class JournalBoardCheckTestCase(TestCase):
 
         self.assertEqual(self._board_node("buy bread")["data"]["state"], "open")
 
-    def test_bullet_prefixed_line_matches_and_advances_progress_task(self):
-        # ``- [x] <task>`` (markdown-checkbox style) must strip the leading
-        # bullet so it matches the board task text and progresses it.
+    def test_bullet_prefixed_progress_line_matches_by_base_and_coerces(self):
+        # ``- [x] <task>`` (markdown-checkbox style): strip the bullet, match by
+        # base, and coerce the displayed ``(1/3)`` form to the stored count (1).
         self._add_board_task("Pyszne posiłki (3)")
 
-        process_journal_entry(self._journal("- [x] Pyszne posiłki (3)"), user=self.user)
+        process_journal_entry(
+            self._journal("- [x] Pyszne posiłki (1/3)"), user=self.user
+        )
 
         self.board.refresh_from_db()
-        self.assertEqual(self.board.state[0]["data"]["text"], "Pyszne posiłki (1/3)")
-        self.assertEqual(self.board.state[0]["data"]["state"], "open")
+        self.assertEqual(self.board.state[0]["data"]["text"], "Pyszne posiłki (3)")
+        self.assertEqual(self.board.state[0]["data"]["state"], "open")  # 1 < 3
         reflection = Reflection.objects.get(thread=self.daily)
-        self.assertEqual(reflection.good, "Pyszne posiłki (3)")
+        self.assertEqual(reflection.good, "Pyszne posiłki (1)")
+
+    def test_crlf_bullet_line_matches_and_crosses(self):
+        # The real CLI scenario: a CRLF comment must still match the board.
+        self._add_board_task("New task (3)")
+
+        process_journal_entry(
+            self._journal("- [x] New task (3)\r\n\r\nWill it work?"), user=self.user
+        )
+
+        self.board.refresh_from_db()
+        self.assertEqual(self.board.state[0]["data"]["state"], "done")  # 3 >= 3
+        reflection = Reflection.objects.get(thread=self.daily)
+        self.assertEqual(reflection.good, "New task (3)")

--- a/tasks/apps/tree/tests/test_journal_story_api.py
+++ b/tasks/apps/tree/tests/test_journal_story_api.py
@@ -88,19 +88,20 @@ class JournalBoardCheckEndpointTestCase(APITestCase):
     def setUp(self):
         self.client.force_authenticate(user=self.user)
         self.board = Board.objects.create(
-            thread=self.daily, state=[create_task_item("Do tasks (2/3)")]
+            thread=self.daily, state=[create_task_item("Do tasks (3)")]
         )
 
-    def test_journal_post_advances_matching_progress_task(self):
+    def test_journal_post_crosses_matching_progress_task_at_total(self):
         resp = self.client.post(
             reverse("journaladded-list"),
-            {"comment": "[x] Do tasks (2/3)", "thread": "Daily", "tags": []},
+            {"comment": "[x] Do tasks (3)", "thread": "Daily", "tags": []},
             format="json",
         )
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
 
         self.board.refresh_from_db()
-        self.assertEqual(self.board.state[0]["data"]["text"], "Do tasks (3/3)")
+        # Board text is never rewritten; count 3 reaches the total -> crossed.
+        self.assertEqual(self.board.state[0]["data"]["text"], "Do tasks (3)")
         self.assertEqual(self.board.state[0]["data"]["state"], "done")
         reflection = Reflection.objects.get(thread=self.daily)
-        self.assertEqual(reflection.good, "Do tasks (3/3)")
+        self.assertEqual(reflection.good, "Do tasks (3)")

--- a/tasks/apps/tree/tests/test_today_plans_api.py
+++ b/tasks/apps/tree/tests/test_today_plans_api.py
@@ -53,9 +53,9 @@ class TodayPlansAPITestCase(APITestCase):
         self.assertEqual(
             daily["tasks"],
             [
-                {"text": "alpha", "done": False},
-                {"text": "bravo", "done": True},
-                {"text": "charlie", "done": False},
+                {"text": "alpha", "done": False, "mark": None},
+                {"text": "bravo", "done": True, "mark": None},
+                {"text": "charlie", "done": False, "mark": None},
             ],
         )
 
@@ -71,13 +71,15 @@ class TodayPlansAPITestCase(APITestCase):
         self.assertEqual(body["weekly"]["thread"], "Weekly")
         self.assertEqual(body["weekly"]["pub_date"], eow.isoformat())
         self.assertEqual(
-            body["weekly"]["tasks"], [{"text": "week task", "done": False}]
+            body["weekly"]["tasks"],
+            [{"text": "week task", "done": False, "mark": None}],
         )
 
         self.assertEqual(body["monthly"]["thread"], "Big-picture")
         self.assertEqual(body["monthly"]["pub_date"], eom.isoformat())
         self.assertEqual(
-            body["monthly"]["tasks"], [{"text": "month task", "done": True}]
+            body["monthly"]["tasks"],
+            [{"text": "month task", "done": True, "mark": None}],
         )
 
     def test_crlf_stored_focus_returns_clean_task_text(self):
@@ -90,8 +92,8 @@ class TodayPlansAPITestCase(APITestCase):
         self.assertEqual(
             tasks,
             [
-                {"text": "alpha", "done": False},
-                {"text": "bravo", "done": True},
+                {"text": "alpha", "done": False, "mark": None},
+                {"text": "bravo", "done": True, "mark": None},
             ],
         )
 

--- a/tasks/apps/tree/tests/test_today_progress.py
+++ b/tasks/apps/tree/tests/test_today_progress.py
@@ -6,7 +6,7 @@ from django.db import DatabaseError
 from django.test import TestCase
 
 from ..models import Board, Plan, Profile, Reflection, Thread
-from ..services.today import board_tree, set_task_done, text_lines
+from ..services.today import board_tree, plan_tasks, set_task_done, text_lines
 from ..services.today.progress import parse_progress, render_progress
 
 TODAY = date_cls(2026, 5, 21)
@@ -117,7 +117,8 @@ class ProgressLifecycleTestCase(TestCase):
         Reflection.objects.filter(thread=self.daily).delete()
 
     def _seed(self, text):
-        """Put text into Plan and on the board at root level."""
+        """Put the total-form task into Plan and on the board at root level.
+        Under the reflection-count model this text is never rewritten."""
         Plan.objects.create(pub_date=TODAY, thread=self.daily, focus=text)
         self.board.state = [board_tree.append_task_at_root([], text)]
         self.board.save()
@@ -130,61 +131,46 @@ class ProgressLifecycleTestCase(TestCase):
         ).first()
         return plan, reflection
 
-    # --- forward progression -----------------------------------------------
+    def _node(self):
+        self.board.refresh_from_db()
+        return self.board.state[0]
 
-    def test_first_tick_promotes_pristine_to_partial(self):
+    def _display(self):
+        return [(t.text, t.done) for t in plan_tasks(TODAY, "Daily")]
+
+    # --- forward progression: Plan/Board text fixed, count logged ----------
+
+    def test_first_tick_logs_count_and_derives_partial(self):
         self._seed("Do tasks (3)")
 
         set_task_done(self.user, "Do tasks (3)", True, today=TODAY)
 
         plan, reflection = self._reload()
-        self.assertEqual(plan.focus, "Do tasks (1/3)")
-        self.assertEqual(self.board.state[0]["text"], "Do tasks (1/3)")
-        self.assertEqual(self.board.state[0]["data"]["text"], "Do tasks (1/3)")
-        self.assertEqual(self.board.state[0]["data"]["state"], "open")
-        # Reflection.good must NOT contain the partial form.
-        self.assertTrue(reflection is None or "Do tasks" not in (reflection.good or ""))
+        # Plan and Board text are never rewritten.
+        self.assertEqual(plan.focus, "Do tasks (3)")
+        self.assertEqual(self._node()["data"]["text"], "Do tasks (3)")
+        self.assertEqual(self._node()["data"]["state"], "open")  # 1 < 3
+        # The count is logged in the Reflection.
+        self.assertEqual(reflection.good, "Do tasks (1)")
+        # Display derives (2/3) from N=1.
+        self.assertEqual(self._display(), [("Do tasks (2/3)", False)])
 
-    def test_tick_partial_to_partial(self):
-        self._seed("Do tasks (1/3)")
-
-        set_task_done(self.user, "Do tasks (1/3)", True, today=TODAY)
-
-        plan, reflection = self._reload()
-        self.assertEqual(plan.focus, "Do tasks (2/3)")
-        self.assertEqual(self.board.state[0]["data"]["state"], "open")
-        self.assertTrue(reflection is None or "Do tasks" not in (reflection.good or ""))
-
-    def test_final_tick_marks_complete_and_adds_to_reflection(self):
-        self._seed("Do tasks (2/3)")
-
-        set_task_done(self.user, "Do tasks (2/3)", True, today=TODAY)
-
-        plan, reflection = self._reload()
-        self.assertEqual(plan.focus, "Do tasks (3/3)")
-        self.assertEqual(self.board.state[0]["data"]["state"], "done")
-        # The Vue Board view shows the strikethrough only when this flag
-        # is set — regression for the bug where progressed tasks fully
-        # completed via Android stayed visually unchecked on the web board.
-        self.assertTrue(self.board.state[0]["state"]["checked"])
-        self.assertEqual(reflection.good, "Do tasks (3/3)")
-
-    def test_full_cycle_3_to_complete(self):
+    def test_full_cycle_accumulates_counts_and_crosses_at_total(self):
         self._seed("Do tasks (3)")
 
         set_task_done(self.user, "Do tasks (3)", True, today=TODAY)
-        plan, _ = self._reload()
-        self.assertEqual(plan.focus, "Do tasks (1/3)")
+        self.assertEqual(self._display(), [("Do tasks (2/3)", False)])
 
-        set_task_done(self.user, "Do tasks (1/3)", True, today=TODAY)
-        plan, _ = self._reload()
-        self.assertEqual(plan.focus, "Do tasks (2/3)")
+        set_task_done(self.user, "Do tasks (3)", True, today=TODAY)
+        self.assertEqual(self._display(), [("Do tasks (3/3)", False)])
 
-        set_task_done(self.user, "Do tasks (2/3)", True, today=TODAY)
+        set_task_done(self.user, "Do tasks (3)", True, today=TODAY)
         plan, reflection = self._reload()
-        self.assertEqual(plan.focus, "Do tasks (3/3)")
-        self.assertEqual(self.board.state[0]["data"]["state"], "done")
-        self.assertEqual(reflection.good, "Do tasks (3/3)")
+        self.assertEqual(reflection.good, "Do tasks (1)\nDo tasks (2)\nDo tasks (3)")
+        self.assertEqual(plan.focus, "Do tasks (3)")  # unchanged
+        self.assertEqual(self._node()["data"]["state"], "done")  # crossed at N>=3
+        self.assertTrue(self._node()["state"]["checked"])
+        self.assertEqual(self._display(), [("Do tasks (3/3)", True)])
 
     def test_single_step_task_completes_on_first_tick(self):
         self._seed("Quick (1)")
@@ -192,118 +178,79 @@ class ProgressLifecycleTestCase(TestCase):
         set_task_done(self.user, "Quick (1)", True, today=TODAY)
 
         plan, reflection = self._reload()
-        self.assertEqual(plan.focus, "Quick (1/1)")
-        self.assertEqual(self.board.state[0]["data"]["state"], "done")
-        self.assertEqual(reflection.good, "Quick (1/1)")
+        self.assertEqual(reflection.good, "Quick (1)")
+        self.assertEqual(self._node()["data"]["state"], "done")  # 1 >= 1
+        self.assertEqual(self._display(), [("Quick (1/1)", True)])
 
-    # --- "Add another" past full completion -------------------------------
+    # --- "Add another" past full: over-quota counts, stays crossed --------
 
-    def test_add_another_from_full_advances_overquota(self):
-        """Tick on a fully-completed (N/N) task is no longer a no-op —
-        it advances to (N+1/N) and keeps the task marked done. This is the
-        backend half of the Add another button on the completed-task
-        dialog."""
-        self._seed("Done (3/3)")
-        Reflection.objects.create(pub_date=TODAY, thread=self.daily, good="Done (3/3)")
-        self.board.state[0]["data"]["state"] = "done"
-        self.board.state[0]["state"] = {"checked": True}
-        self.board.save()
+    def test_add_another_past_full_keeps_advancing_and_crossed(self):
+        self._seed("Do tasks (3)")
+        for _ in range(3):
+            set_task_done(self.user, "Do tasks (3)", True, today=TODAY)
+        self.assertEqual(self._node()["data"]["state"], "done")
 
-        set_task_done(self.user, "Done (3/3)", True, today=TODAY)
+        set_task_done(self.user, "Do tasks (3)", True, today=TODAY)  # 4th
 
-        plan, reflection = self._reload()
-        self.assertEqual(plan.focus, "Done (4/3)")
-        # Still marked done — Add another bumps the count, doesn't reset.
-        self.assertEqual(self.board.state[0]["data"]["state"], "done")
-        self.assertTrue(self.board.state[0]["state"]["checked"])
-        # Reflection line renamed in place — no duplicate, no removal.
-        self.assertEqual(reflection.good, "Done (4/3)")
+        _plan, reflection = self._reload()
+        self.assertIn("Do tasks (4)", reflection.good)
+        self.assertEqual(self._node()["data"]["state"], "done")  # 4 >= 3
+        self.assertEqual(self._display(), [("Do tasks (3/3)", True)])  # step capped
 
-    def test_add_another_from_overquota_keeps_advancing(self):
-        self._seed("Done (4/3)")
-        Reflection.objects.create(pub_date=TODAY, thread=self.daily, good="Done (4/3)")
-        self.board.state[0]["data"]["state"] = "done"
-        self.board.state[0]["state"] = {"checked": True}
-        self.board.save()
+    # --- untick: decrement the count, un-cross ----------------------------
 
-        set_task_done(self.user, "Done (4/3)", True, today=TODAY)
+    def test_untick_from_complete_decrements_and_uncrosses(self):
+        self._seed("Do tasks (3)")
+        for _ in range(3):
+            set_task_done(self.user, "Do tasks (3)", True, today=TODAY)
+        self.assertEqual(self._node()["data"]["state"], "done")
 
-        plan, reflection = self._reload()
-        self.assertEqual(plan.focus, "Done (5/3)")
-        self.assertEqual(self.board.state[0]["data"]["state"], "done")
-        self.assertEqual(reflection.good, "Done (5/3)")
+        set_task_done(self.user, "Do tasks (3)", False, today=TODAY)
 
-    def test_reset_from_overquota_returns_to_pristine(self):
-        """Reset on (4/3) — or any over-quota state — goes straight back
-        to the pristine (N) form and clears Reflection.good."""
-        self._seed("Done (4/3)")
-        Reflection.objects.create(pub_date=TODAY, thread=self.daily, good="Done (4/3)")
-        self.board.state[0]["data"]["state"] = "done"
-        self.board.state[0]["state"] = {"checked": True}
-        self.board.save()
+        _plan, reflection = self._reload()
+        self.assertEqual(reflection.good, "Do tasks (1)\nDo tasks (2)")  # (3) removed
+        self.assertEqual(self._node()["data"]["state"], "open")  # 2 < 3
+        self.assertEqual(self._display(), [("Do tasks (3/3)", False)])  # N=2 -> step 3
 
-        set_task_done(self.user, "Done (4/3)", False, today=TODAY)
-
-        plan, reflection = self._reload()
-        self.assertEqual(plan.focus, "Done (3)")
-        self.assertEqual(self.board.state[0]["data"]["state"], "open")
-        self.assertFalse(self.board.state[0]["state"]["checked"])
-        self.assertEqual(reflection.good, "")
-
-    # --- no-ops ------------------------------------------------------------
-
-    def test_untick_on_pristine_is_noop(self):
+    def test_untick_at_zero_is_noop(self):
         self._seed("Fresh (3)")
 
-        set_task_done(self.user, "Fresh (3)", False, today=TODAY)
+        result = set_task_done(self.user, "Fresh (3)", False, today=TODAY)
 
-        plan, _reflection = self._reload()
-        self.assertEqual(plan.focus, "Fresh (3)")
-        self.assertEqual(self.board.state[0]["data"]["state"], "open")
+        self.assertIsNone(result)
+        _plan, reflection = self._reload()
+        self.assertEqual(self._node()["data"]["state"], "open")
+        self.assertTrue(reflection is None or not reflection.good)
 
-    def test_untick_on_partial_is_noop(self):
-        self._seed("Mid (2/3)")
+    def test_untick_on_partial_decrements(self):
+        self._seed("Mid (3)")
+        set_task_done(self.user, "Mid (3)", True, today=TODAY)  # N=1
 
-        set_task_done(self.user, "Mid (2/3)", False, today=TODAY)
+        set_task_done(self.user, "Mid (3)", False, today=TODAY)  # back to 0
 
-        plan, _reflection = self._reload()
-        self.assertEqual(plan.focus, "Mid (2/3)")
-        self.assertEqual(self.board.state[0]["data"]["state"], "open")
-
-    # --- backward (only from full) ----------------------------------------
-
-    def test_untick_from_complete_resets_to_pristine(self):
-        self._seed("Done (3/3)")
-        Reflection.objects.create(pub_date=TODAY, thread=self.daily, good="Done (3/3)")
-        self.board.state[0]["data"]["state"] = "done"
-        self.board.save()
-
-        set_task_done(self.user, "Done (3/3)", False, today=TODAY)
-
-        plan, reflection = self._reload()
-        self.assertEqual(plan.focus, "Done (3)")
-        self.assertEqual(self.board.state[0]["text"], "Done (3)")
-        self.assertEqual(self.board.state[0]["data"]["state"], "open")
+        _plan, reflection = self._reload()
         self.assertEqual(reflection.good, "")
+        self.assertEqual(self._node()["data"]["state"], "open")
 
     # --- marker placement variations --------------------------------------
 
-    def test_mid_text_marker(self):
+    def test_mid_text_marker_logs_count_base(self):
         self._seed("Buy (5) apples")
 
         set_task_done(self.user, "Buy (5) apples", True, today=TODAY)
 
-        plan, _ = self._reload()
-        self.assertEqual(plan.focus, "Buy (1/5) apples")
-        self.assertEqual(self.board.state[0]["text"], "Buy (1/5) apples")
+        _plan, reflection = self._reload()
+        self.assertEqual(reflection.good, "Buy (1) apples")
+        self.assertEqual(self._display(), [("Buy (2/5) apples", False)])
 
-    def test_leading_marker(self):
-        self._seed("(2/4) Walk 1km")
+    def test_leading_marker_logs_count_base(self):
+        self._seed("(4) Walk 1km")
 
-        set_task_done(self.user, "(2/4) Walk 1km", True, today=TODAY)
+        set_task_done(self.user, "(4) Walk 1km", True, today=TODAY)
 
-        plan, _ = self._reload()
-        self.assertEqual(plan.focus, "(3/4) Walk 1km")
+        _plan, reflection = self._reload()
+        self.assertEqual(reflection.good, "(1) Walk 1km")
+        self.assertEqual(self._display(), [("(2/4) Walk 1km", False)])
 
     # --- fallthrough to boolean -------------------------------------------
 
@@ -314,39 +261,40 @@ class ProgressLifecycleTestCase(TestCase):
 
         plan, reflection = self._reload()
         self.assertEqual(plan.focus, "pay bills")  # text unchanged
-        self.assertEqual(self.board.state[0]["data"]["state"], "done")
+        self.assertEqual(self._node()["data"]["state"], "done")
         self.assertEqual(reflection.good, "pay bills")
 
     # --- co-existence with other tasks ------------------------------------
 
-    def test_only_target_line_in_plan_renames(self):
+    def test_only_target_task_progresses(self):
         Plan.objects.create(
             pub_date=TODAY, thread=self.daily, focus="Do tasks (3)\nother task"
         )
-        self.board.state = [
-            board_tree.append_task_at_root([], "Do tasks (3)"),
-        ]
+        self.board.state = [board_tree.append_task_at_root([], "Do tasks (3)")]
         self.board.save()
 
         set_task_done(self.user, "Do tasks (3)", True, today=TODAY)
 
-        plan, _ = self._reload()
-        self.assertEqual(plan.focus, "Do tasks (1/3)\nother task")
+        plan, reflection = self._reload()
+        self.assertEqual(plan.focus, "Do tasks (3)\nother task")  # unchanged
+        self.assertEqual(reflection.good, "Do tasks (1)")
+        self.assertEqual(
+            self._display(),
+            [("Do tasks (2/3)", False), ("other task", False)],
+        )
 
     # --- atomicity --------------------------------------------------------
 
-    def test_reflection_failure_rolls_back_board_and_plan(self):
-        self._seed("Done (2/3)")
+    def test_reflection_failure_rolls_back_board(self):
+        self._seed("Do tasks (3)")
 
         with mock.patch(
             "tasks.apps.tree.services.today.operations.Reflection.save",
             side_effect=DatabaseError("boom"),
         ):
             with self.assertRaises(DatabaseError):
-                set_task_done(self.user, "Done (2/3)", True, today=TODAY)
+                set_task_done(self.user, "Do tasks (3)", True, today=TODAY)
 
-        plan, reflection = self._reload()
-        self.assertEqual(plan.focus, "Done (2/3)")
-        self.assertEqual(self.board.state[0]["text"], "Done (2/3)")
-        self.assertEqual(self.board.state[0]["data"]["state"], "open")
-        self.assertIsNone(reflection)
+        _plan, reflection = self._reload()
+        self.assertEqual(self._node()["data"]["state"], "open")
+        self.assertTrue(reflection is None or not reflection.good)

--- a/tasks/apps/tree/tests/test_today_tasks_service.py
+++ b/tasks/apps/tree/tests/test_today_tasks_service.py
@@ -308,17 +308,19 @@ class TodayServiceTestCase(TestCase):
             note="step one done",
         )
 
+        # Journal records the post-tick display (N=1 -> (2/3)); the count is
+        # stored separately in Reflection.good.
         entry = JournalAdded.objects.get(thread=self.daily)
-        self.assertEqual(entry.comment, "- [x] Do tasks (1/3)\nstep one done")
+        self.assertEqual(entry.comment, "- [x] Do tasks (2/3)\nstep one done")
 
     def test_progress_completion_journal_matches_reflection_line(self):
         add_task(self.user, "Do tasks (3)", today=TODAY)
-        # Advance to (2/3) without notes.
+        # Advance to N=2 without notes.
         complete_task(self.user, "Do tasks (3)", True, today=TODAY)
         complete_task(self.user, "Do tasks (1/3)", True, today=TODAY)
         self.assertFalse(JournalAdded.objects.exists())
 
-        # Final tick with a note.
+        # Final tick with a note completes the task (N=3).
         complete_task(
             self.user,
             "Do tasks (2/3)",
@@ -330,16 +332,16 @@ class TodayServiceTestCase(TestCase):
         entry = JournalAdded.objects.get(thread=self.daily)
         self.assertEqual(entry.comment, "- [x] Do tasks (3/3)\nfinished")
         reflection = Reflection.objects.get(thread=self.daily)
-        self.assertEqual(reflection.good, "Do tasks (3/3)")
+        self.assertEqual(reflection.good, "Do tasks (1)\nDo tasks (2)\nDo tasks (3)")
 
     def test_add_another_from_complete_journals_with_overquota_text(self):
-        """Tick on a fully-completed progress task is the Add another
-        action — it advances to (N+1/N) and records a new journal entry
-        with the over-quota text."""
+        """Ticking a fully-completed progress task keeps advancing the count
+        (over-quota) and records another journal entry; the display caps at
+        (M/M)."""
         add_task(self.user, "Do tasks (3)", today=TODAY)
         for old in ("Do tasks (3)", "Do tasks (1/3)", "Do tasks (2/3)"):
             complete_task(self.user, old, True, today=TODAY)
-        # Now at (3/3). The above ticks carried no note → no journal yet.
+        # Now at N=3 (crossed). The above ticks carried no note → no journal yet.
         self.assertFalse(JournalAdded.objects.exists())
 
         complete_task(
@@ -350,11 +352,14 @@ class TodayServiceTestCase(TestCase):
             note="one more",
         )
 
+        # Display caps at (3/3); the count 4 is logged in the Reflection.
         entry = JournalAdded.objects.get(thread=self.daily)
-        self.assertEqual(entry.comment, "- [x] Do tasks (4/3)\none more")
-        # Reflection line is renamed in place — not duplicated.
+        self.assertEqual(entry.comment, "- [x] Do tasks (3/3)\none more")
         reflection = Reflection.objects.get(thread=self.daily)
-        self.assertEqual(reflection.good, "Do tasks (4/3)")
+        self.assertEqual(
+            reflection.good,
+            "Do tasks (1)\nDo tasks (2)\nDo tasks (3)\nDo tasks (4)",
+        )
 
     def test_journal_failure_rolls_back_reflection_and_board(self):
         add_task(self.user, "buy bread", today=TODAY)

--- a/tasks/apps/tree/views.py
+++ b/tasks/apps/tree/views.py
@@ -175,7 +175,8 @@ def _serialize_plan(pub_date, thread_name):
         "thread": thread_name,
         "pub_date": pub_date.isoformat(),
         "tasks": [
-            {"text": t.text, "done": t.done} for t in plan_tasks(pub_date, thread_name)
+            {"text": t.text, "done": t.done, "mark": t.mark}
+            for t in plan_tasks(pub_date, thread_name)
         ],
     }
 

--- a/tasks/apps/tree/views_android_api.py
+++ b/tasks/apps/tree/views_android_api.py
@@ -97,7 +97,11 @@ class AndroidTaskListView(APIView):
         except NoBoardError:
             return _no_board_response()
         return Response(
-            {"items": [{"text": it.text, "done": it.done} for it in items]},
+            {
+                "items": [
+                    {"text": it.text, "done": it.done, "mark": it.mark} for it in items
+                ]
+            },
             status=status.HTTP_200_OK,
         )
 


### PR DESCRIPTION
## What

Counted tasks (`New task (3)`) no longer **rewrite** the Plan line and Board node to `(1/3)`, `(2/3)`, … On each tick/journal the **Reflection accumulates the count lines** (`New task (1)`, `(2)`, …) and the `(N/M)` display is **computed at GET time**. Plan and Board text stay fixed at the total `(M)` form; the board node is only **crossed** once the count reaches the total.

### Lifecycle (`New task (3)`, journaled with `[x]`)

| Action | Reflection.good | Console + Android display | Board node |
|--------|-----------------|---------------------------|------------|
| initial | *(empty)* | `New task (1/3)` | `New task (3)`, open |
| `[x] New task (1)` | `New task (1)` | `New task (2/3)` | open |
| `[x] New task (2)` | `New task (1)` / `(2)` | `New task (3/3)` | open |
| `[x] New task (3)` | `New task (1)` / `(2)` / `(3)` | `New task (3/3)`, done | **crossed** |

## Details

- **Derive, don't mutate.** `plan_tasks` computes each task's display + `done` from the Reflection: `N` = the largest first-number among matching lines (across good/better/best), display step = `min(N+1, M)`, done at `N ≥ M`. Powers both console (`today_plans`) and Android (`list_today_tasks`).
- **All three markers / all fields.** `[x]`→good, `[~]`→better, `[^]`→best. Done-detection and progress read every field; a boolean task completed via `[~]`/`[^]` returns a `~`/`^` **mark** (new field in both plan payloads).
- **Coercion + base-match.** A client may send `(K)` or the displayed `(K/M)`; it's coerced to `(K)` on write. Matching is by marker-stripped base, so ticking the displayed `(2/3)` still advances `New task (3)`. Multiple counts in one journal entry (`[x] New task (2)` + `[x] New task (3)`) are supported.
- **Full replacement.** The Android tick (`set_task_done`) and the console journal board-check both funnel through the same count/cross logic; the old `_set_task_done_progress` `(N/M)` mutation path is gone.

Builds on #278/#279 (merged); carries the small CRLF-normalization fix in `extract_reflection_lines` it depends on.

## Not migrated

Existing `(N/M)` text already stored on boards/plans is left as-is (base-matching still works; display is driven by the Plan line). Edit stray `(N/M)` back to `(M)` for the cleanest look.

## Testing

- Full `tree` suite: **340 passing** (rewrote the `(N/M)`-mutation tests to the count model; added coverage for multi-line entries, `[~]`/`[^]` fields, coercion, base-match round-trip, and the `mark` payloads).
- End-to-end (rolled back) against a live board: counts accumulate `(1)`→`(2)`→`(3)`, display derives `(1/3)`→`(2/3)`→`(3/3)`, the node crosses only at `N≥3`, Plan/Board text unchanged, and `[x] New task (1/3)` stores `New task (1)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)