### PR TITLE
feat(today): canonicalize carried progress tasks on copy/move

### DIFF
--- a/tasks/apps/tree/services/today/operations.py
+++ b/tasks/apps/tree/services/today/operations.py
@@ -20,6 +20,8 @@ from .progress import (
     base_of,
     marker_value,
     parse_progress,
+    remaining_after,
+    render_carried,
     render_count,
     render_progress,
 )
@@ -221,8 +223,21 @@ def list_board_items(user):
 def add_task(user, text, today=None):
     """Ensure the task exists on the board (root-level append if missing)
     and that today's Plan.focus contains the line.
+
+    An in-progress display marker ``(N/K)`` — the form the Android list shows
+    for a partly-counted task, carried in verbatim by "Copy to today" / "Move
+    to tomorrow" — is canonically rewritten to the count of the work that still
+    *remains* (``New task (2/3)`` → ``New task (2)``); see
+    ``_add_carried_progress_task``. Plain and already-canonical ``(K)`` tasks
+    take the straight path below.
     """
     pub_date = _today(today)
+
+    remaining = remaining_after(text)
+    if remaining is not None:
+        _add_carried_progress_task(user, text, remaining, pub_date)
+        return
+
     board = _current_board(user)
 
     if board_tree.find_task_by_text(board.state, text) is None:
@@ -232,6 +247,48 @@ def add_task(user, text, today=None):
     daily = _daily_thread()
     plan, _created = Plan.objects.get_or_create(pub_date=pub_date, thread=daily)
     new_focus = text_lines.add_unique_line(plan.focus, text)
+    if new_focus != (plan.focus or ""):
+        plan.focus = new_focus
+        plan.save()
+
+
+def _add_carried_progress_task(user, text, remaining, pub_date):
+    """Carry an in-progress ``(N/K)`` task forward as a fresh ``(remaining)``
+    counter: rename the matching board node's marker to ``(remaining)`` and put
+    the canonical single-number line on the day's Plan.focus.
+
+    When only one step remains (``remaining == 1`` — the last item, or a
+    finished task whose display capped at ``(K/K)``) the marker is dropped
+    altogether and the task carries forward as a plain, counter-less one.
+
+    The board node is matched by base (marker-insensitive) so ``New task (K)`` is
+    found regardless of the display marker; its own text layout is preserved and
+    only the marker value is rewritten. When the task isn't on the board yet, the
+    canonical line is appended at the root.
+    """
+    board = _current_board(user)
+    canonical = render_carried(text, remaining)
+    base = base_of(text)
+
+    hit = board_tree.find_task_by_base(board.state, base)
+    if hit is None:
+        board_tree.append_task_at_root(board.state, canonical)
+        board.save()
+    else:
+        _, _, node = hit
+        node_text = board_tree._node_text(node)
+        new_node_text = (
+            render_carried(node_text, remaining)
+            if parse_progress(node_text) is not None
+            else canonical
+        )
+        if node_text != new_node_text:
+            board_tree.rename(node, new_node_text)
+            board.save()
+
+    daily = _daily_thread()
+    plan, _created = Plan.objects.get_or_create(pub_date=pub_date, thread=daily)
+    new_focus = text_lines.add_unique_line(plan.focus, canonical)
     if new_focus != (plan.focus or ""):
         plan.focus = new_focus
         plan.save()
@@ -371,6 +428,13 @@ def _set_task_done_progress(user, text, done, progress, today, published):
 def delete_task(user, text, today=None):
     """Remove the task from the board (only if leaf) and from today's
     Plan.focus. Reflection.good is intentionally left untouched.
+
+    Board removal matches the exact text, so a carried progress task whose node
+    was already renamed to its remaining count survives (that node is the work
+    moved forward, not deleted). The Plan.focus line is matched by base for
+    progress tasks, because the plan stores the canonical ``(K)`` form while the
+    caller passes the display ``(N/K)`` form — matching by base finds it either
+    way. This is what lets "Move to tomorrow" drop the task off today's plan.
     """
     pub_date = _today(today)
     board = _current_board(user)
@@ -385,7 +449,23 @@ def delete_task(user, text, today=None):
     daily = _daily_thread()
     plan = Plan.objects.filter(pub_date=pub_date, thread=daily).first()
     if plan and plan.focus:
-        new_focus = text_lines.remove_line(plan.focus, text)
+        new_focus = _remove_plan_line(plan.focus, text)
         if new_focus != plan.focus:
             plan.focus = new_focus
             plan.save()
+
+
+def _remove_plan_line(focus, text):
+    """Drop ``text`` from a Plan.focus. Plain lines are removed by exact match;
+    a progress-marked ``text`` removes the counted line whose base matches
+    (marker-insensitive), so the stored ``(K)`` form is found when the caller
+    passes the display ``(N/K)`` form."""
+    if parse_progress(text) is None:
+        return text_lines.remove_line(focus, text)
+    base = base_of(text)
+    kept = [
+        line
+        for line in text_lines.split_lines(focus)
+        if not (parse_progress(line) is not None and base_of(line) == base)
+    ]
+    return "\n".join(kept)

--- a/tasks/apps/tree/services/today/progress.py
+++ b/tasks/apps/tree/services/today/progress.py
@@ -100,6 +100,47 @@ def coerce_to_count(text):
     return render_count(text, progress, marker_value(text))
 
 
+def remaining_after(text):
+    """For an in-progress display marker ``(N/K)``, the count of steps that
+    still *remain* if the task is carried forward as a fresh counter:
+    ``K + 1 - N``.
+
+    The display form ``(N/K)`` means "on step N of K", so ``N - 1`` steps are
+    already done and ``K - (N - 1) = K + 1 - N`` remain. Carrying ``New task
+    (1/3)`` (nothing done) forward yields ``3``; ``(2/3)`` (one done) yields
+    ``2``; ``(3/3)`` (two done) yields ``1``.
+
+    Returns ``None`` when ``text`` has no two-number in-progress marker (a bare
+    ``(K)`` is already canonical, marker-less text has nothing to carry) or when
+    the remaining count would drop below 1 (nothing left to carry forward).
+    """
+    match = PROGRESS_RE.search(text or "")
+    if match is None or match.group(2) is None:
+        return None
+    n, k = int(match.group(1)), int(match.group(2))
+    remaining = k + 1 - n
+    return remaining if remaining >= 1 else None
+
+
+def render_carried(text, remaining):
+    """Render ``text``'s first marker for a task carried forward with
+    ``remaining`` steps left.
+
+    - ``remaining > 1`` → ``(remaining)`` (a fresh counter for the rest).
+    - ``remaining <= 1`` → the bare base with the marker dropped, so a task
+      down to its last step — or a finished one, whose display caps at
+      ``(K/K)`` → ``remaining == 1`` — becomes a plain, counter-less task.
+
+    Text without a valid marker is returned unchanged.
+    """
+    progress = parse_progress(text)
+    if progress is None:
+        return text
+    if remaining <= 1:
+        return base_of(text)
+    return render_count(text, progress, remaining)
+
+
 def base_of(text):
     """Return ``text`` with its first progress marker removed, for
     marker-insensitive matching: ``New task (3)`` / ``New task (2/3)`` /

--- a/tasks/apps/tree/tests/test_today_progress.py
+++ b/tasks/apps/tree/tests/test_today_progress.py
@@ -7,7 +7,12 @@ from django.test import TestCase
 
 from ..models import Board, Plan, Profile, Reflection, Thread
 from ..services.today import board_tree, plan_tasks, set_task_done, text_lines
-from ..services.today.progress import parse_progress, render_progress
+from ..services.today.progress import (
+    parse_progress,
+    remaining_after,
+    render_carried,
+    render_progress,
+)
 
 TODAY = date_cls(2026, 5, 21)
 
@@ -77,6 +82,52 @@ class ProgressRenderTestCase(TestCase):
             render_progress("(2/4) Walk 1km", p, 3),
             "(3/4) Walk 1km",
         )
+
+
+class RemainingAfterTestCase(TestCase):
+    def test_nothing_done_carries_full_total(self):
+        # (1/3) means nothing done yet -> all 3 remain.
+        self.assertEqual(remaining_after("New task (1/3)"), 3)
+
+    def test_partway_carries_remaining(self):
+        # (2/3) means one done -> two remain.
+        self.assertEqual(remaining_after("New task (2/3)"), 2)
+
+    def test_last_step_carries_one(self):
+        # (3/3) means two done -> one remains.
+        self.assertEqual(remaining_after("New task (3/3)"), 1)
+
+    def test_bare_count_is_already_canonical(self):
+        # A single-number (K) form is the stored/canonical shape already.
+        self.assertIsNone(remaining_after("New task (3)"))
+
+    def test_no_marker(self):
+        self.assertIsNone(remaining_after("pay bills"))
+        self.assertIsNone(remaining_after(""))
+        self.assertIsNone(remaining_after(None))
+
+    def test_overshoot_leaves_nothing_to_carry(self):
+        # Over-quota display never reaches the client (it caps at (K/K)), but
+        # a hand-typed (4/3) has -1 remaining -> nothing to carry.
+        self.assertIsNone(remaining_after("New task (4/3)"))
+
+    def test_uses_first_marker(self):
+        self.assertEqual(remaining_after("Do (2/3) the (5) thing"), 2)
+
+
+class RenderCarriedTestCase(TestCase):
+    def test_multiple_remaining_keeps_counter(self):
+        self.assertEqual(render_carried("New task (2/3)", 2), "New task (2)")
+
+    def test_one_remaining_drops_marker(self):
+        # Last item / finished task -> plain, counter-less task.
+        self.assertEqual(render_carried("New task (3/3)", 1), "New task")
+
+    def test_one_remaining_drops_mid_text_marker(self):
+        self.assertEqual(render_carried("Buy (2/2) apples", 1), "Buy apples")
+
+    def test_no_marker_unchanged(self):
+        self.assertEqual(render_carried("pay bills", 1), "pay bills")
 
 
 class ReplaceLineTestCase(TestCase):

--- a/tasks/apps/tree/tests/test_today_tasks_service.py
+++ b/tasks/apps/tree/tests/test_today_tasks_service.py
@@ -117,6 +117,143 @@ class TodayServiceTestCase(TestCase):
         plan = Plan.objects.get(pub_date=TODAY, thread=self.daily)
         self.assertEqual(plan.focus, "nested")
 
+    # --- add_task: carried progress tasks (Copy to today / Move to tomorrow) -
+
+    def test_add_progress_display_form_canonicalises_to_remaining(self):
+        # "Copy to today" hands the display form (1/3) back to /add; nothing is
+        # done yet, so the whole task (3) is carried onto the new plan.
+        add_task(self.user, "New task (1/3)", today=TODAY)
+
+        plan = Plan.objects.get(pub_date=TODAY, thread=self.daily)
+        self.assertEqual(plan.focus, "New task (3)")
+
+        self.board.refresh_from_db()
+        self.assertEqual(len(self.board.state), 1)
+        self.assertEqual(self.board.state[0]["text"], "New task (3)")
+
+    def test_add_progress_partway_carries_only_remaining(self):
+        add_task(self.user, "New task (2/3)", today=TODAY)
+
+        plan = Plan.objects.get(pub_date=TODAY, thread=self.daily)
+        self.assertEqual(plan.focus, "New task (2)")
+        self.board.refresh_from_db()
+        self.assertEqual(self.board.state[0]["text"], "New task (2)")
+
+    def test_add_progress_renames_existing_board_node_in_place(self):
+        # A board node already carries the original total; carrying (2/3)
+        # forward rewrites that node's marker to the remaining count, keeping
+        # its identity/children rather than appending a duplicate.
+        node = create_task_item("New task (3)")
+        node["children"] = [create_task_item("subtask")]
+        self.board.state = [node]
+        self.board.save()
+
+        add_task(self.user, "New task (2/3)", today=TODAY)
+
+        self.board.refresh_from_db()
+        self.assertEqual(len(self.board.state), 1)
+        self.assertEqual(self.board.state[0]["text"], "New task (2)")
+        self.assertEqual(self.board.state[0]["data"]["text"], "New task (2)")
+        # The node kept its subtree — it was renamed, not replaced.
+        self.assertEqual(self.board.state[0]["children"][0]["text"], "subtask")
+
+    def test_add_progress_preserves_mid_text_marker_on_board(self):
+        self.board.state = [create_task_item("Buy (5) apples")]
+        self.board.save()
+
+        add_task(self.user, "Buy (2/5) apples", today=TODAY)
+
+        plan = Plan.objects.get(pub_date=TODAY, thread=self.daily)
+        self.assertEqual(plan.focus, "Buy (4) apples")
+        self.board.refresh_from_db()
+        self.assertEqual(self.board.state[0]["text"], "Buy (4) apples")
+
+    def test_add_progress_carry_is_idempotent(self):
+        add_task(self.user, "New task (2/3)", today=TODAY)
+        add_task(self.user, "New task (2/3)", today=TODAY)
+
+        plan = Plan.objects.get(pub_date=TODAY, thread=self.daily)
+        self.assertEqual(plan.focus, "New task (2)")
+        self.board.refresh_from_db()
+        self.assertEqual(len(self.board.state), 1)
+
+    def test_add_last_step_carries_as_plain_task(self):
+        # (3/3) means two of three done -> one remains; the last item drops the
+        # counter and carries forward as a plain task.
+        self.board.state = [create_task_item("New task (3)")]
+        self.board.save()
+
+        add_task(self.user, "New task (3/3)", today=TODAY)
+
+        plan = Plan.objects.get(pub_date=TODAY, thread=self.daily)
+        self.assertEqual(plan.focus, "New task")
+        self.board.refresh_from_db()
+        self.assertEqual(len(self.board.state), 1)
+        self.assertEqual(self.board.state[0]["text"], "New task")
+        self.assertEqual(self.board.state[0]["data"]["text"], "New task")
+
+    def test_copy_finished_task_carries_as_plain_task(self):
+        # A finished counted task on another day (display capped at (K/K));
+        # "Copy to today" drops the counter entirely rather than leaving a "(1)".
+        YESTERDAY = date_cls(2026, 5, 20)
+        add_task(self.user, "New task (2)", today=YESTERDAY)
+        set_task_done(self.user, "New task (2)", True, today=YESTERDAY)
+        set_task_done(self.user, "New task (1/2)", True, today=YESTERDAY)  # (2/2)
+
+        add_task(self.user, "New task (2/2)", today=TODAY)
+
+        today_plan = Plan.objects.get(pub_date=TODAY, thread=self.daily)
+        self.assertEqual(today_plan.focus, "New task")
+        # Yesterday's counted line is untouched; the shared board node is stripped.
+        yesterday_plan = Plan.objects.get(pub_date=YESTERDAY, thread=self.daily)
+        self.assertEqual(yesterday_plan.focus, "New task (2)")
+        self.board.refresh_from_db()
+        self.assertEqual(len(self.board.state), 1)
+        self.assertEqual(self.board.state[0]["text"], "New task")
+
+    def test_move_last_step_to_tomorrow_as_plain_task(self):
+        TOMORROW = date_cls(2026, 5, 22)
+        add_task(self.user, "New task (2)", today=TODAY)
+        set_task_done(self.user, "New task (2)", True, today=TODAY)  # display (2/2)
+
+        add_task(self.user, "New task (2/2)", today=TOMORROW)
+        delete_task(self.user, "New task (2/2)", today=TODAY)
+
+        tomorrow_plan = Plan.objects.get(pub_date=TOMORROW, thread=self.daily)
+        self.assertEqual(tomorrow_plan.focus, "New task")
+        today_plan = Plan.objects.get(pub_date=TODAY, thread=self.daily)
+        self.assertEqual(today_plan.focus, "")
+        self.board.refresh_from_db()
+        self.assertEqual(len(self.board.state), 1)
+        self.assertEqual(self.board.state[0]["text"], "New task")
+
+    def test_move_progress_task_to_tomorrow(self):
+        # Full "Move to tomorrow": the task was added and one step ticked, so
+        # today's list shows it as (2/3). Moving hands that display form to
+        # /add (for tomorrow) then /delete (for today).
+        TOMORROW = date_cls(2026, 5, 22)
+        add_task(self.user, "New task (3)", today=TODAY)
+        set_task_done(self.user, "New task (3)", True, today=TODAY)
+
+        add_task(self.user, "New task (2/3)", today=TOMORROW)
+        delete_task(self.user, "New task (2/3)", today=TODAY)
+
+        # Tomorrow carries the two remaining steps; today's plan line is gone.
+        tomorrow_plan = Plan.objects.get(pub_date=TOMORROW, thread=self.daily)
+        self.assertEqual(tomorrow_plan.focus, "New task (2)")
+        today_plan = Plan.objects.get(pub_date=TODAY, thread=self.daily)
+        self.assertEqual(today_plan.focus, "")
+
+        # The single shared board node now reflects the remaining count and is
+        # still present (it's the carried work, not a deletion).
+        self.board.refresh_from_db()
+        self.assertEqual(len(self.board.state), 1)
+        self.assertEqual(self.board.state[0]["text"], "New task (2)")
+
+        # Today keeps its record of the step done that day.
+        reflection = Reflection.objects.get(pub_date=TODAY, thread=self.daily)
+        self.assertEqual(reflection.good, "New task (1)")
+
     # --- set_task_done ------------------------------------------------------
 
     def test_set_task_done_true_marks_board_and_appends_reflection(self):


### PR DESCRIPTION
## What & why

Android's **Copy to today** and **Move to tomorrow** hand the *display* form of a counted task (e.g. `New task (2/3)`) back to the `/add` (and `/delete`) endpoints. Previously that display form was stored verbatim. This PR rewrites the in-progress marker to the work that still **remains** when the task is carried onto the next Plan.

For any `(N/K)`, the remaining count is `K + 1 − N`:

| Copied / moved | Steps done | → Result |
|---|---|---|
| `New task (1/3)` | 0 | `New task (3)` |
| `New task (2/3)` | 1 | `New task (2)` |
| `New task (3/3)` (last item) | 2 | `New task` |
| `New task (2/2)` (finished) | — | `New task` |

When carrying forward would leave exactly one step — the last remaining item, or a finished task whose display caps at `(K/K)` — the marker is dropped entirely and the task carries forward as a plain, counter-less task.

## Changes

- **`services/today/progress.py`**
  - `remaining_after(text)` — `K + 1 − N` for an in-progress `(N/K)`; `None` for a bare `(K)`, marker-less text, or over-quota input.
  - `render_carried(text, remaining)` — renders the carried marker, collapsing a lone remaining step to the bare base (handles end and mid-text markers).
- **`services/today/operations.py`**
  - `add_task` routes an in-progress `(N/K)` through `_add_carried_progress_task`, which renames the matching board node's marker **in place** (preserving children and mid-text position; appends canonically if not yet on the board) and writes the canonical line to the target day's `Plan.focus`.
  - `delete_task` matches the `Plan.focus` line by **base** for progress tasks (the plan stores the canonical `(K)` while the caller sends the display `(N/K)`), so **Move to tomorrow** actually drops the task off today's plan. Board removal stays exact-match, so the just-renamed carried node survives the move.

No Android changes needed — `add_task`/`delete_task` are used only by these endpoints.

## Testing

- `python manage.py test tasks.apps.tree` — **353 tests pass** (full app suite).
- 14 new tests: `remaining_after` + `render_carried` unit coverage, and integration tests for copy-to-today, move-to-tomorrow, cross-day board-node rename, mid-text markers, idempotency, and the "1 remaining → plain task" cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)